### PR TITLE
fix(desktop): expand pet bubbles without scrollbars

### DIFF
--- a/desktop/renderer/src/pet/CodexSpritePetRenderer.test.tsx
+++ b/desktop/renderer/src/pet/CodexSpritePetRenderer.test.tsx
@@ -76,3 +76,18 @@ test("above observation bubbles render ahead of the sprite", () => {
   assert.match(styles, /\.pet-bubble-above\s*\{[^}]*flex-direction:\s*column;/s);
   assert.doesNotMatch(styles, /\.pet-bubble-above\s*\{[^}]*column-reverse/s);
 });
+
+test("full reply bubbles expand without an internal scrollbar", () => {
+  const markup = renderToStaticMarkup(
+    <CodexSpritePetRenderer
+      spritesheetUrl="mira-asset://pet"
+      state="idle"
+      observation={{ status: "observing", enabled: true, bubble: "很长的完整回复", persistent: false }}
+      bubbleLayout={{ placement: "above", height: 80 }}
+    />,
+  );
+  const styles = readFileSync(new URL("./styles.css", import.meta.url), "utf8");
+
+  assert.doesNotMatch(markup, /max-height/);
+  assert.doesNotMatch(styles, /\.pet-bubble\s*\{[^}]*overflow-y:\s*auto;/s);
+});

--- a/desktop/renderer/src/pet/CodexSpritePetRenderer.tsx
+++ b/desktop/renderer/src/pet/CodexSpritePetRenderer.tsx
@@ -61,7 +61,7 @@ export function CodexSpritePetRenderer({ spritesheetUrl, state, transientState =
 
   return (
     <div className={surfaceClass}>
-      {observation.bubble ? <PetBubble text={observation.bubble} persistent={observation.persistent} maxHeight={bubbleLayout.height} /> : null}
+      {observation.bubble ? <PetBubble text={observation.bubble} persistent={observation.persistent} /> : null}
       <div
         aria-label="桌宠"
         className={isDragging ? "pet-drag-region pet-dragging" : "pet-drag-region"}
@@ -86,7 +86,7 @@ export function CodexSpritePetRenderer({ spritesheetUrl, state, transientState =
 
 function noop(): void {}
 
-function PetBubble({ text, persistent, maxHeight }: { text: string; persistent: boolean; maxHeight: number }) {
+function PetBubble({ text, persistent }: { text: string; persistent: boolean }) {
   const ref = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => {
@@ -97,14 +97,13 @@ function PetBubble({ text, persistent, maxHeight }: { text: string; persistent: 
     const observer = typeof ResizeObserver === "undefined" ? null : new ResizeObserver(reportHeight);
     observer?.observe(element);
     return () => observer?.disconnect();
-  }, [maxHeight, persistent, text]);
+  }, [persistent, text]);
 
   return (
     <div
       ref={ref}
       className="pet-bubble"
       role="status"
-      style={maxHeight ? { maxHeight } : undefined}
     >
       <span>{text}</span>
       {persistent ? (

--- a/desktop/renderer/src/pet/styles.css
+++ b/desktop/renderer/src/pet/styles.css
@@ -64,7 +64,6 @@ body {
   font-size: 11px;
   line-height: 1.35;
   overflow-wrap: anywhere;
-  overflow-y: auto;
   white-space: pre-wrap;
   display: flex;
   gap: 5px;

--- a/desktop/src/pet/geometry.test.ts
+++ b/desktop/src/pet/geometry.test.ts
@@ -18,9 +18,9 @@ test("desktop pet flips the full bubble above near the display bottom", () => {
   );
 });
 
-test("desktop pet keeps overflowing full replies scrollable within the larger available side", () => {
+test("desktop pet preserves the full reply height beyond the larger available side", () => {
   assert.deepEqual(
     resolveDesktopPetBubbleLayout({ x: 1200, y: 500 }, workArea, 2_000),
-    { placement: "above", height: 494 },
+    { placement: "above", height: 2_000 },
   );
 });

--- a/desktop/src/pet/geometry.ts
+++ b/desktop/src/pet/geometry.ts
@@ -15,7 +15,7 @@ export function clampDesktopPetPosition(
   };
 }
 
-/** Resolves the largest on-screen bubble area, preferring the space below the pet. */
+/** Resolves the full-height bubble direction, preferring below when the available space is equal. */
 export function resolveDesktopPetBubbleLayout(
   position: DesktopPetPosition,
   workArea: { x: number; y: number; width: number; height: number },
@@ -30,7 +30,7 @@ export function resolveDesktopPetBubbleLayout(
   );
   const above = Math.max(0, position.y - workArea.y - desktopPetBubbleGap);
   if (height <= below || below >= above) {
-    return { placement: "below", height: Math.min(height, below) };
+    return { placement: "below", height };
   }
-  return { placement: "above", height: Math.min(height, above) };
+  return { placement: "above", height };
 }


### PR DESCRIPTION
## Summary

- preserve the renderer-measured full reply height instead of clamping it to one side of the display
- remove the bubble max-height and internal vertical scrollbar
- keep placement direction and the persisted sprite anchor behavior unchanged
- add regression coverage for oversized layout measurements and scrollbar-free rendering

## Verification

- `node node_modules/tsx/dist/cli.mjs --tsconfig desktop/renderer/tsconfig.json --test desktop/src/pet/geometry.test.ts desktop/src/pet/bubbleLayout.test.ts desktop/renderer/src/pet/CodexSpritePetRenderer.test.tsx` (11 passed)
- `npm --prefix desktop run typecheck`
- `npx eslint desktop/src/pet/geometry.ts desktop/src/pet/geometry.test.ts desktop/renderer/src/pet/CodexSpritePetRenderer.tsx desktop/renderer/src/pet/CodexSpritePetRenderer.test.tsx`
- `npm --prefix desktop run build`
- `graphify update .` (7173 nodes, 19112 edges)

## Known Blockers

- Real Electron desktop-window visual verification has not been run from the isolated worktree.

Closes #19


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expand desktop pet reply bubbles to render full replies without internal scrollbars. Preserves renderer-measured height and keeps placement/anchor behavior unchanged; addresses #19.

- **Bug Fixes**
  - Removed bubble max-height and `overflow-y: auto`; dropped `maxHeight` prop from `PetBubble`.
  - Geometry returns the full requested height and still prefers below when space is equal.
  - Added tests for oversized replies and scrollbar-free rendering.

<sup>Written for commit 8db2ceab0a83f9e6b9ed33e3385871ca0c4e639f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/20?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

