### PR TITLE
Update channel fixtures for single-contact bindings

### DIFF
--- a/tests/bootstrap/test_tools.py
+++ b/tests/bootstrap/test_tools.py
@@ -19,7 +19,7 @@ def test_role_target_validation_uses_canonical_chat_id_comparison(
     store.update_role(
         role.id,
         channel_bindings=[
-            {"channel": "qq", "chat_id": "gqq:42", "allow_from": []}
+            {"channel": "qq", "chat_id": "gqq:42", "allow_from": ["user-1"]}
         ],
     )
 
@@ -44,7 +44,11 @@ def test_role_target_validation_explains_wrong_channel_for_bound_chat(
     store.update_role(
         role.id,
         channel_bindings=[
-            {"channel": "qqbot", "chat_id": "c2c:user-1", "allow_from": []}
+            {
+                "channel": "qqbot",
+                "chat_id": "c2c:user-1",
+                "allow_from": ["user-1"],
+            }
         ],
     )
 

--- a/tests/test_channel_clients.py
+++ b/tests/test_channel_clients.py
@@ -393,7 +393,7 @@ async def test_telegram_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path:
     role_store.update_role(
         "mira",
         channel_bindings=[
-            {"channel": "telegram", "chat_id": "123", "allow_from": []}
+            {"channel": "telegram", "chat_id": "123", "allow_from": ["1"]}
         ],
     )
     interrupt_controller = MagicMock()
@@ -810,8 +810,8 @@ async def test_qq_channel_paths(monkeypatch: pytest.MonkeyPatch, tmp_path: Path)
     role_store.update_role(
         "mira",
         channel_bindings=[
-            {"channel": "qq", "chat_id": "1", "allow_from": []},
-            {"channel": "qq", "chat_id": "gqq:100", "allow_from": []},
+            {"channel": "qq", "chat_id": "1", "allow_from": ["1"]},
+            {"channel": "qq", "chat_id": "gqq:100", "allow_from": ["1"]},
         ],
     )
     async def _request_get(url, **kwargs):
@@ -965,7 +965,7 @@ async def test_telegram_channel_routes_bound_inbound_to_role_session(
     role_store.update_role(
         "mira",
         channel_bindings=[
-            {"channel": "telegram", "chat_id": "123", "allow_from": []}
+            {"channel": "telegram", "chat_id": "123", "allow_from": ["1"]}
         ],
     )
 


### PR DESCRIPTION
Closes #32

## Summary

- give each external channel fixture exactly one contact as required by #24
- use the actual inbound sender IDs for Telegram and QQ path tests
- preserve empty `allow_from` only for desktop bindings
- change tests only; production behavior is unchanged

## Validation

- 5 previously failing tests passed
- `tests/bootstrap/test_tools.py` and `tests/test_channel_clients.py`: 9 passed
- all direct `RoleStore` consumer tests: 319 passed
- Ruff passed on both changed files
- Black check passed for `tests/bootstrap/test_tools.py`; `tests/test_channel_clients.py` has pre-existing formatting drift outside these fixture changes and was left untouched to avoid unrelated churn
- `git diff --check` passed
- `graphify update .` passed (7,681 nodes, 20,167 edges, 325 communities; HTML skipped above 5,000 nodes)

## Blockers

- None


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated channel test fixtures to enforce single-contact bindings and use correct sender IDs, fixing failing Telegram/QQ path tests with no production changes.

- **Bug Fixes**
  - Set exactly one contact in `allow_from` for external channel bindings.
  - Use real inbound sender IDs in Telegram and QQ tests.
  - Keep empty `allow_from` only for desktop bindings.

<sup>Written for commit 2eb7b6c7ee1d021eaafd103147b47da9f6554113. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/33?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

