### PR TITLE
Fix Akasha role-scope and deletion lifecycle boundaries

### DIFF
--- a/agent/tools/recall_memory.py
+++ b/agent/tools/recall_memory.py
@@ -26,8 +26,10 @@ _RECENT_PRESETS = {
     "recent_30d": 30,
 }
 
+
 class RecallMemoryTool(Tool):
     name = "recall_memory"
+    context_precedence = frozenset({"role_id", "session_key", "channel", "chat_id"})
     description = "由当前 memory engine 的 tool_profile 注入工具描述。"
     parameters = {
         "type": "object",
@@ -56,6 +58,7 @@ class RecallMemoryTool(Tool):
         role_id: str | None = None,
         channel: str | None = None,
         chat_id: str | None = None,
+        session_key: str | None = None,
         **extra: Any,
     ) -> str:
         text = (query or "").strip()
@@ -63,14 +66,20 @@ class RecallMemoryTool(Tool):
             return _render_records([], trace={})
         time_window = _parse_time_filter(time_filter)
         if time_filter and time_window is None:
-            return json.dumps({"count": 0, "items": [], "error": "invalid_time_filter"}, ensure_ascii=False)
+            return json.dumps(
+                {"count": 0, "items": [], "error": "invalid_time_filter"},
+                ensure_ascii=False,
+            )
+        resolved_session_key = str(session_key or "").strip()
+        if not resolved_session_key and channel and chat_id:
+            resolved_session_key = f"{channel}:{chat_id}"
         result = await self._memory.query(
             MemoryQuery(
                 text=text,
                 intent=_normalize_intent(intent),
                 scope=MemoryScope(
                     role_id=str(role_id or "").strip(),
-                    session_key=f"{channel}:{chat_id}" if channel and chat_id else "",
+                    session_key=resolved_session_key,
                     channel=channel or "",
                     chat_id=chat_id or "",
                 ),
@@ -104,7 +113,9 @@ def _render_records(records: list[MemoryRecord], *, trace: dict[str, object]) ->
         if source_ref:
             item["source_ref"] = source_ref
         items.append(item)
-    cited_item_ids = [str(item["id"]) for item in items if str(item.get("id", "")).strip()]
+    cited_item_ids = [
+        str(item["id"]) for item in items if str(item.get("id", "")).strip()
+    ]
     return json.dumps(
         {
             "count": len(items),

--- a/agent/tools/registry.py
+++ b/agent/tools/registry.py
@@ -250,15 +250,16 @@ class ToolRegistry:
         if tool is None:
             return f"工具 '{name}' 不存在"
         try:
+            execution_context = context if context is not None else self.get_context()
             # 将会话上下文（channel、chat_id）作为低优先级默认值合并进 kwargs，
             # 工具可按需读取，不感知此机制的工具会直接忽略多余的 key。
             merged: dict[str, Any] = {
-                **(context or self.get_context()),
+                **execution_context,
                 **arguments,
             }
             for key in getattr(tool, "context_precedence", frozenset()):
-                if context is not None and key in context:
-                    merged[key] = context[key]
+                if key in execution_context:
+                    merged[key] = execution_context[key]
             if not _tool_defines_parameter(tool, _PROGRESS_DESCRIPTION_FIELD):
                 merged.pop(_PROGRESS_DESCRIPTION_FIELD, None)
             return await tool.execute(**merged)

--- a/core/roles/services.py
+++ b/core/roles/services.py
@@ -568,7 +568,23 @@ class RoleAggregateService:
         self.sessions = sessions
         self.memory = memory
         self.bindings = bindings
-        self._on_role_deleted = on_role_deleted
+        self._role_deleted_listeners: list[Callable[[str], None]] = []
+        if on_role_deleted is not None:
+            self.add_role_deleted_listener(on_role_deleted)
+
+    def add_role_deleted_listener(self, listener: Callable[[str], None]) -> None:
+        """Registers a runtime listener for successful role deletion."""
+
+        if listener not in self._role_deleted_listeners:
+            self._role_deleted_listeners.append(listener)
+
+    def remove_role_deleted_listener(self, listener: Callable[[str], None]) -> None:
+        """Removes a previously registered role-deletion listener."""
+
+        try:
+            self._role_deleted_listeners.remove(listener)
+        except ValueError:
+            return
 
     @classmethod
     def from_runtime(
@@ -675,10 +691,13 @@ class RoleAggregateService:
 
     def delete_role(self, role_id: str) -> tuple[bool, bool]:
         clean_role_id = _clean_role_id(role_id)
+        if not self._role_deleted_listeners:
+            raise RuntimeError("角色删除生命周期监听器未注册")
         deleted = self.repository.delete_role(clean_role_id)
         session_deleted = self.sessions.delete(clean_role_id) if deleted else False
-        if deleted and self._on_role_deleted is not None:
-            self._on_role_deleted(clean_role_id)
+        if deleted:
+            for listener in tuple(self._role_deleted_listeners):
+                listener(clean_role_id)
         return deleted, session_deleted
 
     def open_role(self, role_id: str) -> RoleAggregate:

--- a/desktop_bridge/service.py
+++ b/desktop_bridge/service.py
@@ -107,13 +107,16 @@ class DesktopBridgeService:
             Callable[[dict[str, Any]], Awaitable[None] | None]
         ] = set()
         self._self_seed_generator = self._build_self_seed_generator()
+        self._role_deleted_listener = lambda role_id: event_bus.enqueue(
+            RoleDeleted(role_id)
+        )
         self.role_service = role_service or RoleAggregateService.from_runtime(
             workspace=workspace,
             role_store=role_store,
             session_manager=session_manager,
             self_seed_generator=self._self_seed_generator,
-            on_role_deleted=lambda role_id: event_bus.enqueue(RoleDeleted(role_id)),
         )
+        self.role_service.add_role_deleted_listener(self._role_deleted_listener)
         self.conversation_service = ConversationService(
             session_manager,
             binding_resolver=self.role_service.bindings.resolve_role_id,
@@ -248,6 +251,7 @@ class DesktopBridgeService:
             ProactiveMessageCommitted,
             self._proactive_message_listener,
         )
+        self.role_service.remove_role_deleted_listener(self._role_deleted_listener)
         self._event_listeners.clear()
         await self.chat_service.aclose()
         await self.voice_handler.aclose()

--- a/tests/agent/tools/test_recall_memory.py
+++ b/tests/agent/tools/test_recall_memory.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.tools.recall_memory import RecallMemoryTool
+from agent.tools.registry import ToolRegistry
+from core.memory.engine import MemoryQueryResult, MemoryToolSpec
+
+
+@pytest.mark.asyncio
+async def test_registry_context_owns_recall_role_and_session_scope() -> None:
+    memory = AsyncMock()
+    memory.query.return_value = MemoryQueryResult()
+    tool = RecallMemoryTool(
+        memory,
+        MemoryToolSpec(
+            description="test recall",
+            parameters={
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        ),
+    )
+    registry = ToolRegistry()
+    registry.register(tool)
+    registry.set_context(
+        role_id="mira",
+        session_key="role:mira",
+        channel="desktop",
+        chat_id="role:mira",
+    )
+
+    await registry.execute(
+        "recall_memory",
+        {
+            "query": "secret",
+            "role_id": "luna",
+            "session_key": "role:luna",
+            "channel": "qq",
+            "chat_id": "luna-chat",
+        },
+    )
+
+    request = memory.query.await_args.args[0]
+    assert request.scope.role_id == "mira"
+    assert request.scope.session_key == "role:mira"
+    assert request.scope.channel == "desktop"
+    assert request.scope.chat_id == "role:mira"

--- a/tests/conversation/test_migrator.py
+++ b/tests/conversation/test_migrator.py
@@ -273,6 +273,7 @@ def test_conversation_migrator_does_not_restore_messages_after_role_deletion(
         workspace=tmp_path,
         role_store=RoleStore(tmp_path),
         session_manager=manager,
+        on_role_deleted=lambda _role_id: None,
     )
     roles.create_role(role_id="mira", name="Mira", system_prompt="test")
     roles.bindings.bind("telegram", "123", "mira", contact_id="owner")

--- a/tests/core/roles/test_services.py
+++ b/tests/core/roles/test_services.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import pytest
+
+from core.roles import RoleAggregateService, RoleStore
+from session.manager import SessionManager
+
+
+def test_role_deletion_requires_a_lifecycle_listener(tmp_path) -> None:
+    store = RoleStore(tmp_path)
+    service = RoleAggregateService.from_runtime(
+        workspace=tmp_path,
+        role_store=store,
+        session_manager=SessionManager(tmp_path),
+    )
+    service.create_role(
+        role_id="mira",
+        name="Mira",
+        system_prompt="You are Mira.",
+    )
+
+    with pytest.raises(RuntimeError, match="角色删除生命周期监听器"):
+        service.delete_role("mira")
+
+    assert store.get_role("mira") is not None
+
+
+def test_role_deletion_listener_can_be_removed(tmp_path) -> None:
+    service = RoleAggregateService.from_runtime(
+        workspace=tmp_path,
+        role_store=RoleStore(tmp_path),
+        session_manager=SessionManager(tmp_path),
+    )
+    deleted_role_ids: list[str] = []
+    service.add_role_deleted_listener(deleted_role_ids.append)
+    service.remove_role_deleted_listener(deleted_role_ids.append)
+    service.create_role(
+        role_id="mira",
+        name="Mira",
+        system_prompt="You are Mira.",
+    )
+
+    with pytest.raises(RuntimeError, match="角色删除生命周期监听器"):
+        service.delete_role("mira")
+
+    assert deleted_role_ids == []

--- a/tests/desktop_bridge/test_service.py
+++ b/tests/desktop_bridge/test_service.py
@@ -9,9 +9,10 @@ import pytest
 
 from agent.tools.message_push import MessagePushTool
 from bus.event_bus import EventBus
-from bus.events_lifecycle import ProactiveMessageCommitted, TurnCommitted
+from bus.events_lifecycle import ProactiveMessageCommitted, RoleDeleted, TurnCommitted
 from conversation.push_sync import ExternalImageSyncService
 from core.roles import RoleStore
+from core.roles.services import RoleAggregateService
 from desktop_bridge.service import DesktopBridgeService
 from desktop_bridge.voice_service import (
     VoiceOperationMetrics,
@@ -19,6 +20,47 @@ from desktop_bridge.voice_service import (
     VoiceTranscriptionResult,
 )
 from session.manager import SessionManager
+
+
+@pytest.mark.asyncio
+async def test_injected_role_service_publishes_role_deleted(tmp_path) -> None:
+    role_store = RoleStore(tmp_path)
+    session_manager = SessionManager(tmp_path)
+    role_service = RoleAggregateService.from_runtime(
+        workspace=tmp_path,
+        role_store=role_store,
+        session_manager=session_manager,
+    )
+    role_service.create_role(
+        role_id="mira",
+        name="Mira",
+        system_prompt="You are Mira.",
+    )
+    event_bus = EventBus()
+    deleted_role_ids: list[str] = []
+    event_bus.on(RoleDeleted, lambda event: deleted_role_ids.append(event.role_id))
+    service = DesktopBridgeService(
+        workspace=tmp_path,
+        role_store=role_store,
+        session_manager=session_manager,
+        agent_loop=SimpleNamespace(),
+        event_bus=event_bus,
+        role_service=role_service,
+    )
+
+    response = await service.handle(
+        {
+            "id": "delete-role-1",
+            "method": "roles.delete",
+            "payload": {"role_id": "mira"},
+        },
+        emit_event=Mock(),
+    )
+    await event_bus.drain()
+
+    assert response.error is None
+    assert deleted_role_ids == ["mira"]
+    await service.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/test_role_store.py
+++ b/tests/test_role_store.py
@@ -522,6 +522,7 @@ def test_role_store_delete_role_removes_role_runtime_directory(tmp_path: Path):
         workspace=tmp_path,
         role_store=RoleStore(tmp_path),
         session_manager=SessionManager(tmp_path),
+        on_role_deleted=lambda _role_id: None,
     )
     aggregate = service.create_role(
         role_id="mira",
@@ -564,6 +565,7 @@ def test_role_store_delete_role_keeps_other_role_runtime_directories(tmp_path: P
         workspace=tmp_path,
         role_store=RoleStore(tmp_path),
         session_manager=SessionManager(tmp_path),
+        on_role_deleted=lambda _role_id: None,
     )
     first = service.create_role(
         role_id="mira",


### PR DESCRIPTION
Closes #34

## Summary

- make trusted runtime role, session, channel, and chat context override model-provided recall arguments
- pass the canonical runtime session key into memory queries and preserve legacy channel/chat fallback
- require role-deletion lifecycle listeners before mutating role state
- wire and unwind `RoleDeleted` publication for both owned and injected role services

## Validation

- 171 focused registry, memory-contract, role-service, desktop-bridge, RoleStore, and conversation-migration tests passed
- 29 Akasha plugin tests passed
- Ruff passed on all changed Python files
- Black passed on all changed Python files
- `git diff --check` passed
- `graphify update .` passed (7,746 nodes, 20,289 edges, 315 communities; HTML skipped above 5,000 nodes)

## Blockers

- None


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces trusted runtime context for memory recall and tightens role deletion lifecycle to prevent cross-role leaks. Also ensures RoleDeleted is emitted for both internal and injected role services in the desktop bridge.

- **Bug Fixes**
  - Tool registry now treats `role_id`, `session_key`, `channel`, and `chat_id` from registry context as authoritative and overrides tool arguments.
  - `recall_memory` accepts `session_key` and uses it in memory queries; falls back to `channel:chat_id` for legacy paths.
  - Role deletion requires at least one lifecycle listener; added listener add/remove APIs and notify all listeners on delete.
  - Desktop bridge registers/unregisters a deletion listener and publishes RoleDeleted for both owned and injected role services.

- **Migration**
  - If you call role deletion outside the desktop bridge, register a deletion listener before deleting (e.g., add a listener or pass `on_role_deleted` to the service factory).
  - No action needed for DesktopBridge consumers; injected services are now wired to publish RoleDeleted automatically.

<sup>Written for commit 1e9b4b9c77ce768049a6d665dd68dceb472aa4d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/35?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

