### PR TITLE
refactor(world): define PerformancePlan and PresentationCue protocol

### DIFF
--- a/desktop/renderer/src/world/bridgeClient.ts
+++ b/desktop/renderer/src/world/bridgeClient.ts
@@ -10,6 +10,7 @@ import type {
   WorldSummary,
   WorldTimelineEntry,
 } from "./types";
+import { parseWorldCatchUpPerformance, parseWorldDetailsPerformance } from "./presentationProtocol";
 import { WorldBridgeError } from "./types";
 
 type DesktopInvoke = typeof window.miraDesktop.invoke;
@@ -50,29 +51,29 @@ export function createWorldBridgeClient(invoke: DesktopInvoke = window.miraDeskt
       return payload.worlds;
     },
     async getWorld(worldId) {
-      return (await invokePayload<{ world: WorldDetails }>(invoke, "worlds.get", { world_id: worldId })).world;
+      return parseWorldDetailsPerformance((await invokePayload<{ world: WorldDetails }>(invoke, "worlds.get", { world_id: worldId })).world);
     },
     async previewDraft(input) {
       return (await invokePayload<{ draft: WorldCreationDraft }>(invoke, "worlds.drafts.preview", input)).draft;
     },
     async confirmDraft(draftId, identities) {
-      return (await invokePayload<{ world: WorldDetails }>(invoke, "worlds.drafts.confirm", {
+      return parseWorldDetailsPerformance((await invokePayload<{ world: WorldDetails }>(invoke, "worlds.drafts.confirm", {
         draft_id: draftId,
         native_identities: identities,
-      })).world;
+      })).world);
     },
     async addOc(worldId, oc, anchorId) {
-      return (await invokePayload<{ world: WorldDetails }>(invoke, "worlds.ocs.add", {
+      return parseWorldDetailsPerformance((await invokePayload<{ world: WorldDetails }>(invoke, "worlds.ocs.add", {
         world_id: worldId,
         oc,
         anchor_id: anchorId,
-      })).world;
+      })).world);
     },
     async switchOc(worldId, ocId) {
-      return (await invokePayload<{ world: WorldDetails }>(invoke, "worlds.ocs.switch", {
+      return parseWorldDetailsPerformance((await invokePayload<{ world: WorldDetails }>(invoke, "worlds.ocs.switch", {
         world_id: worldId,
         oc_id: ocId,
-      })).world;
+      })).world);
     },
     async submitAction(worldId, content) {
       await invokePayload(invoke, "worlds.actions.submit", { world_id: worldId, content });
@@ -81,11 +82,11 @@ export function createWorldBridgeClient(invoke: DesktopInvoke = window.miraDeskt
       await invokePayload(invoke, "worlds.advance", { world_id: worldId });
     },
     async resolveBarrier(worldId, barrier, choiceId) {
-      return (await invokePayload<{ world: WorldDetails }>(invoke, "worlds.barriers.resolve", {
+      return parseWorldDetailsPerformance((await invokePayload<{ world: WorldDetails }>(invoke, "worlds.barriers.resolve", {
         world_id: worldId,
         barrier_id: barrier.id,
         choice_id: choiceId,
-      })).world;
+      })).world);
     },
     async getTimeline(worldId, perspective, ocId) {
       const payload = await invokePayload<{ entries: WorldTimelineEntry[] }>(invoke, "worlds.timeline", {
@@ -96,10 +97,10 @@ export function createWorldBridgeClient(invoke: DesktopInvoke = window.miraDeskt
       return payload.entries;
     },
     async copyWorld(worldId, anchorId) {
-      return (await invokePayload<{ world: WorldDetails }>(invoke, "worlds.copy", {
+      return parseWorldDetailsPerformance((await invokePayload<{ world: WorldDetails }>(invoke, "worlds.copy", {
         world_id: worldId,
         anchor_id: anchorId,
-      })).world;
+      })).world);
     },
     async previewBackfill(worldId, anchorId, oc) {
       return (await invokePayload<{ preview: BackfillPreview }>(invoke, "worlds.backfill.preview", {
@@ -109,16 +110,16 @@ export function createWorldBridgeClient(invoke: DesktopInvoke = window.miraDeskt
       })).preview;
     },
     async commitBackfill(worldId, preview) {
-      return (await invokePayload<{ world: WorldDetails }>(invoke, "worlds.backfill.commit", {
+      return parseWorldDetailsPerformance((await invokePayload<{ world: WorldDetails }>(invoke, "worlds.backfill.commit", {
         world_id: worldId,
         preview,
-      })).world;
+      })).world);
     },
     async cancelRun(worldId) {
-      return (await invokePayload<{ world: WorldDetails }>(invoke, "worlds.runs.cancel", { world_id: worldId })).world;
+      return parseWorldDetailsPerformance((await invokePayload<{ world: WorldDetails }>(invoke, "worlds.runs.cancel", { world_id: worldId })).world);
     },
     async catchUp(worldId, cursor) {
-      return invokePayload<WorldCatchUp>(invoke, "worlds.events.catch_up", { world_id: worldId, cursor });
+      return parseWorldCatchUpPerformance(await invokePayload<WorldCatchUp>(invoke, "worlds.events.catch_up", { world_id: worldId, cursor }));
     },
     async redrawShot(worldId, shotId) {
       return (await invokePayload<{ shot: SceneShot }>(invoke, "worlds.shots.redraw", {

--- a/desktop/renderer/src/world/index.ts
+++ b/desktop/renderer/src/world/index.ts
@@ -7,4 +7,14 @@ export { useWorldWorkspaceController } from "./useWorldWorkspaceController";
 export { WorldCreateFlow } from "./WorldCreateFlow";
 export { WorldTimelineView } from "./WorldTimelineView";
 export { WorldWorkspace } from "./WorldWorkspace";
+export {
+  parsePerformancePlan,
+  parseWorldCatchUpPerformance,
+  parseWorldDetailsPerformance,
+} from "./presentationProtocol";
+export type {
+  PerformancePlan,
+  PresentationCue,
+  PresentationCueKind,
+} from "./presentationProtocol";
 export * from "./types";

--- a/desktop/renderer/src/world/presentationProtocol.test.ts
+++ b/desktop/renderer/src/world/presentationProtocol.test.ts
@@ -1,0 +1,44 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parsePerformancePlan } from "./presentationProtocol";
+
+const plan = {
+  schemaVersion: 1,
+  planId: "plan-1",
+  worldId: "world-1",
+  eventId: "event-1",
+  sourceSequence: 2,
+  cues: [{
+    schemaVersion: 1,
+    cueId: "cue-1",
+    planId: "plan-1",
+    sequence: 0,
+    kind: "dialogue",
+    payload: { content: "你好" },
+    parallelGroup: null,
+    blocking: true,
+    completionState: "completed",
+    skipState: "skipped",
+    checkpoint: true,
+  }],
+};
+
+describe("parsePerformancePlan", () => {
+  it("accepts a versioned cue envelope", () => {
+    assert.deepEqual(parsePerformancePlan(plan), plan);
+  });
+
+  it("rejects a cue that belongs to another plan", () => {
+    assert.throws(() => parsePerformancePlan({
+      ...plan,
+      cues: [{ ...plan.cues[0], planId: "plan-2" }],
+    }), /cue planId/);
+  });
+
+  it("rejects non-contiguous cue sequences", () => {
+    assert.throws(() => parsePerformancePlan({
+      ...plan,
+      cues: [{ ...plan.cues[0], sequence: 1 }],
+    }), /contiguous/);
+  });
+});

--- a/desktop/renderer/src/world/presentationProtocol.ts
+++ b/desktop/renderer/src/world/presentationProtocol.ts
@@ -1,0 +1,108 @@
+import type { SceneBeat, WorldDetails, WorldCatchUp } from "./types";
+
+export const presentationProtocolVersion = 1 as const;
+
+export type PresentationCueKind = "dialogue" | "sprites" | "background" | "camera" | "audio" | "cg" | "text";
+
+/** Renderer-side validated presentation cue envelope. */
+export type PresentationCue = {
+  schemaVersion: typeof presentationProtocolVersion;
+  cueId: string;
+  planId: string;
+  sequence: number;
+  kind: PresentationCueKind;
+  payload: Record<string, unknown>;
+  parallelGroup: string | null;
+  blocking: boolean;
+  completionState: string;
+  skipState: string;
+  checkpoint: boolean;
+};
+
+/** Renderer-side validated presentation plan envelope. */
+export type PerformancePlan = {
+  schemaVersion: typeof presentationProtocolVersion;
+  planId: string;
+  worldId: string;
+  eventId: string;
+  sourceSequence: number;
+  cues: PresentationCue[];
+};
+
+function record(value: unknown, label: string): Record<string, unknown> {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error(`${label} must be an object`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function text(value: unknown, label: string): string {
+  if (typeof value !== "string" || !value.trim()) throw new Error(`${label} must be a non-empty string`);
+  return value;
+}
+
+function integer(value: unknown, label: string): number {
+  if (!Number.isInteger(value) || Number(value) < 0) throw new Error(`${label} must be a non-negative integer`);
+  return Number(value);
+}
+
+/** Validate an untrusted bridge payload before presentation code consumes it. */
+export function parsePerformancePlan(value: unknown): PerformancePlan {
+  const plan = record(value, "performance plan");
+  if (plan.schemaVersion !== presentationProtocolVersion) throw new Error("unsupported presentation schema");
+  const planId = text(plan.planId, "planId");
+  const cuesValue = plan.cues;
+  if (!Array.isArray(cuesValue)) throw new Error("cues must be an array");
+  const cues = cuesValue.map((item, index) => {
+    const cue = record(item, "cue");
+    if (cue.schemaVersion !== presentationProtocolVersion) throw new Error("unsupported cue schema");
+    if (integer(cue.sequence, "cue sequence") !== index) throw new Error("cue sequences must be contiguous");
+    if (cue.planId !== planId) throw new Error("cue planId does not match its plan");
+    const kind = cue.kind;
+    if (!["dialogue", "sprites", "background", "camera", "audio", "cg", "text"].includes(String(kind))) throw new Error("unsupported cue kind");
+    if (typeof cue.payload !== "object" || cue.payload === null || Array.isArray(cue.payload)) throw new Error("cue payload must be an object");
+    if (cue.parallelGroup !== null && typeof cue.parallelGroup !== "string") throw new Error("parallelGroup must be a string or null");
+    if (typeof cue.blocking !== "boolean" || typeof cue.checkpoint !== "boolean") throw new Error("cue flags are invalid");
+    return {
+      schemaVersion: presentationProtocolVersion,
+      cueId: text(cue.cueId, "cueId"),
+      planId,
+      sequence: index,
+      kind: kind as PresentationCueKind,
+      payload: cue.payload as Record<string, unknown>,
+      parallelGroup: cue.parallelGroup as string | null,
+      blocking: cue.blocking,
+      completionState: text(cue.completionState, "completionState"),
+      skipState: text(cue.skipState, "skipState"),
+      checkpoint: cue.checkpoint,
+    };
+  });
+  return {
+    schemaVersion: presentationProtocolVersion,
+    planId,
+    worldId: text(plan.worldId, "worldId"),
+    eventId: text(plan.eventId, "eventId"),
+    sourceSequence: integer(plan.sourceSequence, "sourceSequence"),
+    cues,
+  };
+}
+
+/** Validate presentation plans embedded in a world detail response. */
+export function parseWorldDetailsPerformance(world: WorldDetails): WorldDetails {
+  return {
+    ...world,
+    scene: {
+      ...world.scene,
+      beats: world.scene.beats.map((beat: SceneBeat) => beat.performancePlan ? { ...beat, performancePlan: parsePerformancePlan(beat.performancePlan) } : beat),
+    },
+  };
+}
+
+/** Validate presentation plans in a catch-up response before merging beats. */
+export function parseWorldCatchUpPerformance(update: WorldCatchUp): WorldCatchUp {
+  return {
+    ...update,
+    beats: update.beats.map((beat: SceneBeat) => beat.performancePlan ? { ...beat, performancePlan: parsePerformancePlan(beat.performancePlan) } : beat),
+    world: update.world ? parseWorldDetailsPerformance(update.world) : undefined,
+  };
+}

--- a/desktop/renderer/src/world/types.ts
+++ b/desktop/renderer/src/world/types.ts
@@ -41,6 +41,7 @@ export type SceneBeat = {
   kind: "dialogue" | "action" | "environment";
   content: string;
   shot?: SceneShot;
+  performancePlan?: import("./presentationProtocol").PerformancePlan;
   isCritical?: boolean;
 };
 

--- a/desktop_bridge/world_simulation_handler.py
+++ b/desktop_bridge/world_simulation_handler.py
@@ -12,6 +12,7 @@ from core.roles import RoleStore
 from world_simulation.actors import AutonomyPolicy, PlayerOC
 from world_simulation.dependencies import DependencySet
 from world_simulation.errors import HistoricalConflictError
+from world_simulation.performance import compile_performance_plan
 from world_simulation.proposals import BeatProposal, ProposedEvent
 from world_simulation.repository import WorldRepository
 from world_simulation.scenes import DecisionBarrier
@@ -375,7 +376,7 @@ class WorldSimulationHandler:
         changes = event.get("changes", {}) if isinstance(event.get("changes"), dict) else {}
         presentation = changes.get("presentation", {}) if isinstance(changes.get("presentation"), dict) else {}
         event_type = str(event.get("event_type") or "world.event")
-        return {"id": str(event.get("id") or f"beat-{order}"), "order": order, "timeLabel": str(event.get("effective_at") or ""), "speakerName": presentation.get("speaker_name"), "kind": presentation.get("kind", "environment"), "content": presentation.get("content", self._event_summary(event_type)), "isCritical": event_type.startswith("decision.")}
+        return {"id": str(event.get("id") or f"beat-{order}"), "order": order, "timeLabel": str(event.get("effective_at") or ""), "speakerName": presentation.get("speaker_name"), "kind": presentation.get("kind", "environment"), "content": presentation.get("content", self._event_summary(event_type)), "isCritical": event_type.startswith("decision."), "performancePlan": compile_performance_plan(event).to_bridge_dict()}
 
     def _timeline_entry(self, event: TimelineEvent, *, visibility: str) -> dict[str, Any]:
         return {"id": event.id, "timeLabel": event.effective_at, "title": self._event_title(event.event_type), "summary": self._beat(event.to_dict(), event.sequence)["content"], "visibility": visibility, "involvedNames": self._participant_names(event.world_id, event.participants), "canCopy": True, "canEnter": True}

--- a/tests/desktop_bridge/test_world_simulation_handler.py
+++ b/tests/desktop_bridge/test_world_simulation_handler.py
@@ -95,4 +95,7 @@ def test_action_catch_up_only_returns_committed_beats(tmp_path):
     assert replay is not None
     assert [beat["content"] for beat in replay["beats"]][-1] == "推开灯塔的门。"
     assert replay["world"]["scene"]["beats"][-1]["content"] == "推开灯塔的门。"
+    performance_plan = replay["beats"][-1]["performancePlan"]
+    assert performance_plan["schemaVersion"] == 1
+    assert performance_plan["cues"][0]["kind"] == "dialogue"
     handler.close()

--- a/tests/world_simulation/test_performance.py
+++ b/tests/world_simulation/test_performance.py
@@ -1,0 +1,86 @@
+from world_simulation.performance import (
+    PRESENTATION_PROTOCOL_VERSION,
+    PerformancePlan,
+    PresentationCue,
+    compile_performance_plan,
+    cue_id_for_plan,
+    plan_id_for_event,
+)
+from world_simulation.timeline import TimelineEvent
+
+
+def event(**changes):
+    return TimelineEvent(
+        id="event-1",
+        world_id="world-1",
+        event_type="scene.action.committed",
+        effective_at="2026-04-01T09:00:00+00:00",
+        sequence=3,
+        changes=changes,
+    )
+
+
+def test_plan_ids_are_stable_and_protocol_versioned():
+    plan_id = plan_id_for_event("world-1", "event-1")
+    assert plan_id == plan_id_for_event("world-1", "event-1")
+    assert plan_id != plan_id_for_event("world-1", "event-2")
+    assert cue_id_for_plan(plan_id, 0, "dialogue") != cue_id_for_plan(
+        plan_id, 1, "dialogue"
+    )
+
+
+def test_compiler_emits_deterministic_cues_and_parallel_stage_group():
+    plan = compile_performance_plan(
+        event(
+            presentation={
+                "content": "推开灯塔的门。",
+                "speaker_name": "岚",
+                "background": {"asset": "harbor"},
+                "sprites": [{"actor_id": "oc-1", "mood": "alert"}],
+                "camera": [{"kind": "pan", "duration_ms": 240}],
+                "audio": [{"kind": "ambience", "asset": "rain"}],
+            }
+        )
+    )
+
+    assert plan.schema_version == PRESENTATION_PROTOCOL_VERSION
+    assert [cue.kind for cue in plan.cues] == [
+        "background",
+        "sprites",
+        "camera",
+        "dialogue",
+        "audio",
+    ]
+    assert plan.cues[0].parallel_group == plan.cues[1].parallel_group
+    assert plan.cues[3].blocking is True
+    assert plan.cues[3].checkpoint is True
+    assert plan.to_bridge_dict()["cues"][3]["completionState"] == "completed"
+
+
+def test_compiler_falls_back_to_text_for_events_without_presentation():
+    plan = compile_performance_plan(event())
+
+    assert len(plan.cues) == 1
+    assert plan.cues[0].kind == "text"
+    assert plan.cues[0].payload == {"text": "scene.action.committed"}
+
+
+def test_plan_rejects_cues_from_another_plan():
+    cue = PresentationCue(
+        schema_version=1,
+        cue_id="cue-1",
+        plan_id="other-plan",
+        sequence=0,
+        kind="text",
+        payload={"text": "hello"},
+    )
+    plan = PerformancePlan(
+        id="plan-1", world_id="world-1", event_id="event-1", cues=(cue,)
+    )
+
+    try:
+        plan.validate()
+    except ValueError as exc:
+        assert "plan_id" in str(exc)
+    else:
+        raise AssertionError("plan validation should reject a foreign cue")

--- a/world_simulation/__init__.py
+++ b/world_simulation/__init__.py
@@ -2,7 +2,14 @@
 
 from world_simulation.actors import AutonomyPolicy, PlayerOC
 from world_simulation.dependencies import DependencySet
-from world_simulation.performance import PerformancePlan
+from world_simulation.performance import (
+    PRESENTATION_PROTOCOL_VERSION,
+    PerformancePlan,
+    PresentationCue,
+    compile_performance_plan,
+    cue_id_for_plan,
+    plan_id_for_event,
+)
 from world_simulation.proposals import BeatProposal, ProposedEvent
 from world_simulation.repository import WorldRepository
 from world_simulation.runs import WorldRun
@@ -24,7 +31,9 @@ __all__ = [
     "DecisionBarrier",
     "DependencySet",
     "NativeResident",
+    "PRESENTATION_PROTOCOL_VERSION",
     "PerformancePlan",
+    "PresentationCue",
     "PlayerOC",
     "ProposedEvent",
     "RoleTemplateSnapshot",
@@ -38,4 +47,7 @@ __all__ = [
     "WorldSimulationService",
     "WorldStateProjection",
     "WorldTemplate",
+    "compile_performance_plan",
+    "cue_id_for_plan",
+    "plan_id_for_event",
 ]

--- a/world_simulation/performance.py
+++ b/world_simulation/performance.py
@@ -1,9 +1,102 @@
-"""Replaceable presentation plans derived from committed world facts."""
+"""Versioned presentation plans derived from committed world facts."""
 
 from __future__ import annotations
 
+import hashlib
 from dataclasses import asdict, dataclass
-from typing import Any
+from collections.abc import Mapping
+from typing import Any, Literal
+
+from world_simulation.timeline import TimelineEvent
+
+PRESENTATION_PROTOCOL_VERSION = 1
+CueKind = Literal["dialogue", "sprites", "background", "camera", "audio", "cg", "text"]
+_CUE_KINDS = frozenset(
+    ("dialogue", "sprites", "background", "camera", "audio", "cg", "text")
+)
+
+
+def _stable_id(prefix: str, value: str) -> str:
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}-{digest}"
+
+
+def plan_id_for_event(
+    world_id: str,
+    event_id: str,
+    *,
+    protocol_version: int = PRESENTATION_PROTOCOL_VERSION,
+) -> str:
+    """Return the stable presentation-plan id for one committed event."""
+
+    if not world_id.strip() or not event_id.strip():
+        raise ValueError("world_id and event_id are required")
+    return _stable_id("plan", f"{protocol_version}:{world_id}:{event_id}")
+
+
+def cue_id_for_plan(plan_id: str, sequence: int, kind: CueKind) -> str:
+    """Return the stable cue id within one presentation plan."""
+
+    if sequence < 0:
+        raise ValueError("cue sequence must be non-negative")
+    return _stable_id("cue", f"{plan_id}:{sequence}:{kind}")
+
+
+@dataclass(frozen=True)
+class PresentationCue:
+    """One versioned, renderer-facing presentation instruction."""
+
+    schema_version: int
+    cue_id: str
+    plan_id: str
+    sequence: int
+    kind: CueKind
+    payload: dict[str, Any]
+    parallel_group: str | None = None
+    blocking: bool = True
+    completion_state: str = "completed"
+    skip_state: str = "skipped"
+    checkpoint: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject malformed cues before they cross the bridge boundary."""
+
+        if self.schema_version != PRESENTATION_PROTOCOL_VERSION:
+            raise ValueError(f"unsupported presentation schema: {self.schema_version}")
+        if not self.cue_id.strip() or not self.plan_id.strip():
+            raise ValueError("cue_id and plan_id are required")
+        if self.sequence < 0:
+            raise ValueError("cue sequence must be non-negative")
+        if self.kind not in _CUE_KINDS:
+            raise ValueError(f"unsupported cue kind: {self.kind}")
+        if self.parallel_group is not None and not self.parallel_group.strip():
+            raise ValueError("parallel_group cannot be empty")
+        if not self.completion_state.strip() or not self.skip_state.strip():
+            raise ValueError("cue terminal states are required")
+        if self.completion_state == self.skip_state:
+            raise ValueError("cue terminal states must differ")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the internal snake_case protocol envelope."""
+
+        return asdict(self)
+
+    def to_bridge_dict(self) -> dict[str, Any]:
+        """Serialize the camelCase envelope exposed to the renderer."""
+
+        return {
+            "schemaVersion": self.schema_version,
+            "cueId": self.cue_id,
+            "planId": self.plan_id,
+            "sequence": self.sequence,
+            "kind": self.kind,
+            "payload": dict(self.payload),
+            "parallelGroup": self.parallel_group,
+            "blocking": self.blocking,
+            "completionState": self.completion_state,
+            "skipState": self.skip_state,
+            "checkpoint": self.checkpoint,
+        }
 
 
 @dataclass(frozen=True)
@@ -13,6 +106,9 @@ class PerformancePlan:
     id: str
     world_id: str
     event_id: str
+    source_sequence: int = 0
+    schema_version: int = PRESENTATION_PROTOCOL_VERSION
+    cues: tuple[PresentationCue, ...] = ()
     dialogue: dict[str, Any] | None = None
     sprites: tuple[dict[str, Any], ...] = ()
     background: dict[str, Any] | None = None
@@ -21,7 +117,147 @@ class PerformancePlan:
     cg_tasks: tuple[dict[str, Any], ...] = ()
     fallback_text: str = ""
 
-    def to_dict(self) -> dict[str, Any]:
-        """Serialize the replaceable performance plan."""
+    def validate(self) -> None:
+        """Validate plan identity and contiguous cue ordering."""
 
-        return asdict(self)
+        if self.schema_version != PRESENTATION_PROTOCOL_VERSION:
+            raise ValueError(f"unsupported presentation schema: {self.schema_version}")
+        if (
+            not self.id.strip()
+            or not self.world_id.strip()
+            or not self.event_id.strip()
+        ):
+            raise ValueError("plan identity fields are required")
+        if self.source_sequence < 0:
+            raise ValueError("source_sequence must be non-negative")
+        sequences = [cue.sequence for cue in self.cues]
+        if sequences != list(range(len(self.cues))):
+            raise ValueError("cue sequences must be contiguous and zero-based")
+        if any(cue.plan_id != self.id for cue in self.cues):
+            raise ValueError("cue plan_id does not match its parent plan")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the internal snake_case protocol envelope."""
+
+        value = asdict(self)
+        value["cues"] = [cue.to_dict() for cue in self.cues]
+        return value
+
+    def to_bridge_dict(self) -> dict[str, Any]:
+        """Serialize the plan and cues for the renderer bridge."""
+
+        self.validate()
+        return {
+            "schemaVersion": self.schema_version,
+            "planId": self.id,
+            "worldId": self.world_id,
+            "eventId": self.event_id,
+            "sourceSequence": self.source_sequence,
+            "cues": [cue.to_bridge_dict() for cue in self.cues],
+        }
+
+
+def _as_mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def _as_mapping_tuple(value: Any) -> tuple[dict[str, Any], ...]:
+    if not isinstance(value, (list, tuple)):
+        return ()
+    return tuple(dict(item) for item in value if isinstance(item, Mapping))
+
+
+def _cue(
+    *,
+    plan_id: str,
+    sequence: int,
+    kind: CueKind,
+    payload: dict[str, Any],
+    blocking: bool,
+    parallel_group: str | None,
+) -> PresentationCue:
+    return PresentationCue(
+        schema_version=PRESENTATION_PROTOCOL_VERSION,
+        cue_id=cue_id_for_plan(plan_id, sequence, kind),
+        plan_id=plan_id,
+        sequence=sequence,
+        kind=kind,
+        payload=payload,
+        parallel_group=parallel_group,
+        blocking=blocking,
+        checkpoint=blocking,
+    )
+
+
+def compile_performance_plan(
+    event: TimelineEvent | Mapping[str, Any],
+) -> PerformancePlan:
+    """Compile one committed event into a deterministic presentation plan."""
+
+    value = event.to_dict() if isinstance(event, TimelineEvent) else dict(event)
+    world_id = str(value.get("world_id") or "")
+    event_id = str(value.get("id") or "")
+    if not world_id or not event_id:
+        raise ValueError("committed event requires world_id and id")
+    plan_id = plan_id_for_event(world_id, event_id)
+    changes = _as_mapping(value.get("changes"))
+    presentation = _as_mapping(changes.get("presentation"))
+    event_type = str(value.get("event_type") or "world.event")
+    fallback_text = str(
+        presentation.get("fallback_text") or presentation.get("content") or event_type
+    )
+    dialogue_value = _as_mapping(presentation.get("dialogue"))
+    if not dialogue_value and presentation.get("content"):
+        dialogue_value = {
+            "content": str(presentation["content"]),
+            "speaker_name": str(presentation.get("speaker_name") or ""),
+        }
+    sprites = _as_mapping_tuple(presentation.get("sprites"))
+    camera = _as_mapping_tuple(presentation.get("camera"))
+    audio = _as_mapping_tuple(presentation.get("audio"))
+    cg_tasks = _as_mapping_tuple(presentation.get("cg_tasks"))
+    background = _as_mapping(presentation.get("background"))
+    stage_group = f"stage-{event_id}"
+    specs: list[tuple[CueKind, dict[str, Any], bool, str | None]] = []
+    if background:
+        specs.append(("background", dict(background), False, stage_group))
+    if sprites:
+        specs.append(("sprites", {"items": list(sprites)}, False, stage_group))
+    if camera:
+        specs.append(("camera", {"items": list(camera)}, False, stage_group))
+    if cg_tasks:
+        specs.append(("cg", {"tasks": list(cg_tasks)}, False, stage_group))
+    if dialogue_value:
+        specs.append(("dialogue", dict(dialogue_value), True, None))
+    if audio:
+        specs.append(("audio", {"items": list(audio)}, False, stage_group))
+    if not specs:
+        specs.append(("text", {"text": fallback_text}, True, None))
+    cues = tuple(
+        _cue(
+            plan_id=plan_id,
+            sequence=sequence,
+            kind=kind,
+            payload=payload,
+            blocking=blocking,
+            parallel_group=parallel_group,
+        )
+        for sequence, (kind, payload, blocking, parallel_group) in enumerate(specs)
+    )
+    plan = PerformancePlan(
+        id=plan_id,
+        world_id=world_id,
+        event_id=event_id,
+        source_sequence=int(value.get("sequence") or 0),
+        schema_version=PRESENTATION_PROTOCOL_VERSION,
+        cues=cues,
+        dialogue=dict(dialogue_value) if dialogue_value else None,
+        sprites=sprites,
+        background=dict(background) if background else None,
+        camera=camera,
+        audio=audio,
+        cg_tasks=cg_tasks,
+        fallback_text=fallback_text,
+    )
+    plan.validate()
+    return plan


### PR DESCRIPTION
Part of #39

## 变更摘要

- 建立版本化 `PerformancePlan -> PresentationCue` 协议，协议版本为 1。
- 为 plan/cue 提供基于世界、事件、序号和 cue kind 的稳定 ID。
- 将背景、角色差分、镜头、CG、音频作为并行 stage cues；对白和文本作为阻塞 checkpoint。
- Python 保持 snake_case 内部序列化，bridge 输出 camelCase envelope。
- renderer 在消费世界详情和 catch-up 响应前运行 runtime schema 校验。
- 保留现有世界事实、timeline、run 和 copy 语义；未实现后续 PixiJS、session persistence 或 voice。

## 验证

- `uv run pytest tests/world_simulation/test_performance.py tests/desktop_bridge/test_world_simulation_handler.py`：6 passed
- `npm run desktop:test`：394 tests，393 passed，1 skipped
- `npm run desktop:typecheck`：通过
- `uvx ruff check`：通过
- `uvx black --check`（4 个变更 Python 文件）：通过
- `git diff --check`：通过
- `graphify update .`：通过

Closes #40