### PR TITLE
refactor(world): persist presentation sessions and recovery

### DIFF
--- a/desktop/renderer/src/world/bridgeClient.test.ts
+++ b/desktop/renderer/src/world/bridgeClient.test.ts
@@ -21,4 +21,37 @@ describe("createWorldBridgeClient", () => {
     const invoke = async (request: { method: string; payload: Record<string, unknown> }): Promise<BridgeResponse> => ({ id: "response", type: "response", method: request.method, payload: {}, error: { code: "world_conflict", message: "既定事实发生冲突" } });
     await assert.rejects(() => createWorldBridgeClient(invoke).advance("world-1"), (error: unknown) => error instanceof WorldBridgeError && error.code === "world_conflict");
   });
+
+  it("maps presentation checkpoints to the durable session bridge", async () => {
+    const requests: Array<{ method: string; payload: Record<string, unknown> }> = [];
+    const invoke = async (request: { method: string; payload: Record<string, unknown> }): Promise<BridgeResponse> => {
+      requests.push(request);
+      return {
+        id: "response",
+        type: "response",
+        method: request.method,
+        payload: {
+          presentation: {
+            session: {
+              worldId: "world-1",
+              lastPresentedEventSequence: 1,
+              activePlanId: null,
+              activeCueIndex: 0,
+              status: "awaiting_action",
+              updatedAt: "2026-07-29T00:00:00+00:00",
+            },
+            plans: [],
+          },
+        },
+        error: null,
+      };
+    };
+
+    const state = await createWorldBridgeClient(invoke).checkpointPresentation("world-1", "plan-1", 0);
+    assert.equal(state.session.lastPresentedEventSequence, 1);
+    assert.deepEqual(requests, [{
+      method: "worlds.presentation.checkpoint",
+      payload: { world_id: "world-1", plan_id: "plan-1", cue_index: 0 },
+    }]);
+  });
 });

--- a/desktop/renderer/src/world/bridgeClient.ts
+++ b/desktop/renderer/src/world/bridgeClient.ts
@@ -10,7 +10,12 @@ import type {
   WorldSummary,
   WorldTimelineEntry,
 } from "./types";
-import { parseWorldCatchUpPerformance, parseWorldDetailsPerformance } from "./presentationProtocol";
+import {
+  parsePresentationState,
+  parseWorldCatchUpPerformance,
+  parseWorldDetailsPerformance,
+  type WorldPresentationState,
+} from "./presentationProtocol";
 import { WorldBridgeError } from "./types";
 
 type DesktopInvoke = typeof window.miraDesktop.invoke;
@@ -40,6 +45,9 @@ export interface WorldBridgeClient {
   commitBackfill(worldId: string, preview: BackfillPreview): Promise<WorldDetails>;
   cancelRun(worldId: string): Promise<WorldDetails>;
   catchUp(worldId: string, cursor?: string): Promise<WorldCatchUp>;
+  pausePresentation(worldId: string): Promise<WorldPresentationState>;
+  resumePresentation(worldId: string): Promise<WorldPresentationState>;
+  checkpointPresentation(worldId: string, planId: string, cueIndex: number): Promise<WorldPresentationState>;
   redrawShot(worldId: string, shotId: string): Promise<SceneShot>;
 }
 
@@ -120,6 +128,19 @@ export function createWorldBridgeClient(invoke: DesktopInvoke = window.miraDeskt
     },
     async catchUp(worldId, cursor) {
       return parseWorldCatchUpPerformance(await invokePayload<WorldCatchUp>(invoke, "worlds.events.catch_up", { world_id: worldId, cursor }));
+    },
+    async pausePresentation(worldId) {
+      return parsePresentationState((await invokePayload<{ presentation: WorldPresentationState }>(invoke, "worlds.presentation.pause", { world_id: worldId })).presentation);
+    },
+    async resumePresentation(worldId) {
+      return parsePresentationState((await invokePayload<{ presentation: WorldPresentationState }>(invoke, "worlds.presentation.resume", { world_id: worldId })).presentation);
+    },
+    async checkpointPresentation(worldId, planId, cueIndex) {
+      return parsePresentationState((await invokePayload<{ presentation: WorldPresentationState }>(invoke, "worlds.presentation.checkpoint", {
+        world_id: worldId,
+        plan_id: planId,
+        cue_index: cueIndex,
+      })).presentation);
     },
     async redrawShot(worldId, shotId) {
       return (await invokePayload<{ shot: SceneShot }>(invoke, "worlds.shots.redraw", {

--- a/desktop/renderer/src/world/index.ts
+++ b/desktop/renderer/src/world/index.ts
@@ -9,6 +9,7 @@ export { WorldTimelineView } from "./WorldTimelineView";
 export { WorldWorkspace } from "./WorldWorkspace";
 export {
   parsePerformancePlan,
+  parsePresentationState,
   parseWorldCatchUpPerformance,
   parseWorldDetailsPerformance,
 } from "./presentationProtocol";
@@ -16,5 +17,7 @@ export type {
   PerformancePlan,
   PresentationCue,
   PresentationCueKind,
+  WorldPresentationSession,
+  WorldPresentationState,
 } from "./presentationProtocol";
 export * from "./types";

--- a/desktop/renderer/src/world/presentationProtocol.test.ts
+++ b/desktop/renderer/src/world/presentationProtocol.test.ts
@@ -1,6 +1,6 @@
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { parsePerformancePlan } from "./presentationProtocol";
+import { parsePerformancePlan, parsePresentationState } from "./presentationProtocol";
 
 const plan = {
   schemaVersion: 1,
@@ -40,5 +40,37 @@ describe("parsePerformancePlan", () => {
       ...plan,
       cues: [{ ...plan.cues[0], sequence: 1 }],
     }), /contiguous/);
+  });
+});
+
+describe("parsePresentationState", () => {
+  it("accepts a persisted cursor and keeps the stable plan identity", () => {
+    const state = parsePresentationState({
+      session: {
+        worldId: "world-1",
+        lastPresentedEventSequence: 0,
+        activePlanId: "plan-1",
+        activeCueIndex: 0,
+        status: "playing",
+        updatedAt: "2026-07-29T00:00:00+00:00",
+      },
+      plans: [plan],
+    });
+    assert.equal(state.session.activePlanId, "plan-1");
+    assert.equal(state.plans[0].planId, "plan-1");
+  });
+
+  it("rejects an unsupported session status", () => {
+    assert.throws(() => parsePresentationState({
+      session: {
+        worldId: "world-1",
+        lastPresentedEventSequence: 0,
+        activePlanId: null,
+        activeCueIndex: 0,
+        status: "stopped",
+        updatedAt: "2026-07-29T00:00:00+00:00",
+      },
+      plans: [],
+    }), /session status/);
   });
 });

--- a/desktop/renderer/src/world/presentationProtocol.ts
+++ b/desktop/renderer/src/world/presentationProtocol.ts
@@ -1,4 +1,9 @@
-import type { SceneBeat, WorldDetails, WorldCatchUp } from "./types";
+import type {
+  SceneBeat,
+  WorldCatchUp,
+  WorldDetails,
+  WorldPresentationSessionStatus,
+} from "./types";
 
 export const presentationProtocolVersion = 1 as const;
 
@@ -27,6 +32,22 @@ export type PerformancePlan = {
   eventId: string;
   sourceSequence: number;
   cues: PresentationCue[];
+};
+
+/** Renderer-side validated persisted presentation session. */
+export type WorldPresentationSession = {
+  worldId: string;
+  lastPresentedEventSequence: number;
+  activePlanId: string | null;
+  activeCueIndex: number;
+  status: WorldPresentationSessionStatus;
+  updatedAt: string;
+};
+
+/** Queue snapshot used by reconnect, pause/resume, and checkpoint calls. */
+export type WorldPresentationState = {
+  session: WorldPresentationSession;
+  plans: PerformancePlan[];
 };
 
 function record(value: unknown, label: string): Record<string, unknown> {
@@ -87,10 +108,38 @@ export function parsePerformancePlan(value: unknown): PerformancePlan {
   };
 }
 
+/** Validate a persisted presentation cursor and its derived plan queue. */
+export function parsePresentationState(value: unknown): WorldPresentationState {
+  const state = record(value, "presentation state");
+  const sessionValue = record(state.session, "presentation session");
+  const status = sessionValue.status;
+  if (!["playing", "paused", "awaiting_action", "awaiting_barrier"].includes(String(status))) {
+    throw new Error("unsupported presentation session status");
+  }
+  const activePlanId = sessionValue.activePlanId;
+  if (activePlanId !== null && typeof activePlanId !== "string") {
+    throw new Error("activePlanId must be a string or null");
+  }
+  const session = {
+    worldId: text(sessionValue.worldId, "session worldId"),
+    lastPresentedEventSequence: integer(sessionValue.lastPresentedEventSequence, "lastPresentedEventSequence"),
+    activePlanId: activePlanId as string | null,
+    activeCueIndex: integer(sessionValue.activeCueIndex, "activeCueIndex"),
+    status: status as WorldPresentationSessionStatus,
+    updatedAt: text(sessionValue.updatedAt, "session updatedAt"),
+  };
+  if (!Array.isArray(state.plans)) throw new Error("presentation plans must be an array");
+  return {
+    session,
+    plans: state.plans.map(parsePerformancePlan),
+  };
+}
+
 /** Validate presentation plans embedded in a world detail response. */
 export function parseWorldDetailsPerformance(world: WorldDetails): WorldDetails {
   return {
     ...world,
+    presentation: world.presentation ? parsePresentationState(world.presentation) : undefined,
     scene: {
       ...world.scene,
       beats: world.scene.beats.map((beat: SceneBeat) => beat.performancePlan ? { ...beat, performancePlan: parsePerformancePlan(beat.performancePlan) } : beat),
@@ -102,6 +151,7 @@ export function parseWorldDetailsPerformance(world: WorldDetails): WorldDetails 
 export function parseWorldCatchUpPerformance(update: WorldCatchUp): WorldCatchUp {
   return {
     ...update,
+    presentation: update.presentation ? parsePresentationState(update.presentation) : undefined,
     beats: update.beats.map((beat: SceneBeat) => beat.performancePlan ? { ...beat, performancePlan: parsePerformancePlan(beat.performancePlan) } : beat),
     world: update.world ? parseWorldDetailsPerformance(update.world) : undefined,
   };

--- a/desktop/renderer/src/world/types.ts
+++ b/desktop/renderer/src/world/types.ts
@@ -11,6 +11,9 @@ export type WorldSummary = {
 /** Player-facing lifecycle state for a world run. */
 export type WorldRunStatus = "idle" | "running" | "action_required" | "barrier" | "stopped" | "resumable";
 
+/** Persisted playback lifecycle for one world's derived presentation queue. */
+export type WorldPresentationSessionStatus = "playing" | "paused" | "awaiting_action" | "awaiting_barrier";
+
 /** A player-created character living on the shared world timeline. */
 export type WorldOc = {
   id: string;
@@ -88,6 +91,7 @@ export type WorldDetails = WorldSummary & {
   scene: WorldScene;
   relatedCharacters: Array<{ id: string; name: string; relationship: string; avatarUrl?: string }>;
   performance: { active: boolean; label: string; canCancel: boolean };
+  presentation?: import("./presentationProtocol").WorldPresentationState;
 };
 
 /** A role template that can be adapted as a native identity. */
@@ -159,6 +163,7 @@ export type WorldCatchUp = {
   cursor: string;
   beats: SceneBeat[];
   world?: WorldDetails;
+  presentation?: import("./presentationProtocol").WorldPresentationState;
 };
 
 /** Stable error exposed by the renderer bridge client. */

--- a/desktop_bridge/request_dispatcher.py
+++ b/desktop_bridge/request_dispatcher.py
@@ -36,6 +36,9 @@ _BACKGROUND_WORLD_METHODS = frozenset(
         "worlds.advance",
         "worlds.barriers.resolve",
         "worlds.runs.cancel",
+        "worlds.presentation.pause",
+        "worlds.presentation.resume",
+        "worlds.presentation.checkpoint",
     }
 )
 

--- a/desktop_bridge/world_simulation_handler.py
+++ b/desktop_bridge/world_simulation_handler.py
@@ -13,12 +13,14 @@ from world_simulation.actors import AutonomyPolicy, PlayerOC
 from world_simulation.dependencies import DependencySet
 from world_simulation.errors import HistoricalConflictError
 from world_simulation.performance import compile_performance_plan
+from world_simulation.presentation_session import WorldPresentationSession
 from world_simulation.proposals import BeatProposal, ProposedEvent
 from world_simulation.repository import WorldRepository
 from world_simulation.scenes import DecisionBarrier
 from world_simulation.service import WorldSimulationService
 from world_simulation.timeline import TimelineEvent
 from world_simulation.world import NativeResident, RoleTemplateSnapshot, WorldDraft, WorldTemplate
+from world_simulation.world import utc_now
 
 
 class WorldSimulationHandler:
@@ -70,6 +72,12 @@ class WorldSimulationHandler:
             return {"world": self._cancel_run(payload)}
         if method == "worlds.events.catch_up":
             return self._catch_up(payload)
+        if method == "worlds.presentation.pause":
+            return {"presentation": self._pause_presentation(payload)}
+        if method == "worlds.presentation.resume":
+            return {"presentation": self._resume_presentation(payload)}
+        if method == "worlds.presentation.checkpoint":
+            return {"presentation": self._checkpoint_presentation(payload)}
         if method == "worlds.shots.redraw":
             return {"shot": self._redraw_shot(payload)}
         raise ValueError(f"unknown world method: {method}")
@@ -308,7 +316,155 @@ class WorldSimulationHandler:
         messages = self._repository.list_outbox(world_id, after_sequence=cursor)
         beats = [self._beat(message["payload"].get("event", {}), int(message["sequence"])) for message in messages]
         next_cursor = str(messages[-1]["sequence"] if messages else cursor)
-        return {"cursor": next_cursor, "beats": beats, "world": self._world_details(world_id)}
+        world = self._world_details(world_id)
+        return {
+            "cursor": next_cursor,
+            "beats": beats,
+            "world": world,
+            "presentation": world["presentation"],
+        }
+
+    def _pause_presentation(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Pause queue consumption while retaining the current cue cursor."""
+
+        world_id = self._world_id(payload)
+        session = self._presentation_session(world_id)
+        if session.status != "paused":
+            session = replace(session, status="paused", updated_at=utc_now())
+            self._repository.save_presentation_session(session)
+        return self._presentation_state(world_id)
+
+    def _resume_presentation(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Resume queue consumption without replaying completed plans."""
+
+        world_id = self._world_id(payload)
+        state = self._presentation_state(world_id)
+        session = state["session"]
+        if session["status"] == "paused":
+            status = "playing" if state["plans"] else self._waiting_status(world_id)
+            session = replace(
+                self._presentation_session(world_id),
+                status=status,
+                updated_at=utc_now(),
+            )
+            self._repository.save_presentation_session(session)
+        return self._presentation_state(world_id)
+
+    def _checkpoint_presentation(self, payload: dict[str, Any]) -> dict[str, Any]:
+        """Persist one completed cue and advance only the derived playback cursor."""
+
+        world_id = self._world_id(payload)
+        plan_id = self._required(payload, "plan_id")
+        raw_cue_index = payload.get("cue_index")
+        try:
+            cue_index = int(str(raw_cue_index).strip()) if raw_cue_index is not None else -1
+        except ValueError as exc:
+            raise ValueError("cue_index 必须是非负整数") from exc
+        if cue_index < 0:
+            raise ValueError("cue_index 必须是非负整数")
+        events = self._repository.list_events(world_id)
+        target = next(
+            (
+                event
+                for event in events
+                if compile_performance_plan(event).id == plan_id
+            ),
+            None,
+        )
+        if target is None:
+            raise ValueError("找不到对应的演出计划")
+        plan = compile_performance_plan(target)
+        if cue_index >= len(plan.cues):
+            raise ValueError("cue_index 超出演出计划范围")
+        session = self._presentation_session(world_id)
+        if target.sequence <= session.last_presented_event_sequence:
+            return self._presentation_state(world_id)
+        if session.status == "paused":
+            raise ValueError("演出已暂停")
+        if target.sequence != session.last_presented_event_sequence + 1:
+            raise ValueError("演出计划必须按世界事件顺序完成")
+        if session.active_plan_id not in (None, plan.id):
+            raise ValueError("另一演出计划正在等待完成")
+        cue = plan.cues[cue_index]
+        if not cue.checkpoint and cue_index != len(plan.cues) - 1:
+            raise ValueError("只能提交阻塞 cue 或计划末尾 checkpoint")
+        if session.active_plan_id == plan.id and cue_index < session.active_cue_index:
+            return self._presentation_state(world_id)
+        if session.active_plan_id == plan.id and cue_index > session.active_cue_index:
+            raise ValueError("不能跳过当前演出 cue")
+        next_index = cue_index + 1
+        if next_index < len(plan.cues):
+            next_session = replace(
+                session,
+                active_plan_id=plan.id,
+                active_cue_index=next_index,
+                status="playing",
+                updated_at=utc_now(),
+            )
+        else:
+            next_session = replace(
+                session,
+                last_presented_event_sequence=target.sequence,
+                active_plan_id=None,
+                active_cue_index=0,
+                status="playing",
+                updated_at=utc_now(),
+            )
+        self._repository.save_presentation_session(next_session)
+        return self._presentation_state(world_id)
+
+    def _presentation_session(self, world_id: str) -> WorldPresentationSession:
+        """Load a session, rebuilding an empty cursor when its derived row is gone."""
+
+        session = self._repository.get_presentation_session(world_id)
+        if session is not None:
+            return session
+        events = self._repository.list_events(world_id)
+        session = WorldPresentationSession(
+            world_id=world_id,
+            status="playing" if events else self._waiting_status(world_id),
+        )
+        self._repository.save_presentation_session(session)
+        return session
+
+    def _presentation_state(self, world_id: str) -> dict[str, Any]:
+        """Derive idempotent plans from facts and expose the persisted cursor."""
+
+        events = self._repository.list_events(world_id)
+        barriers = self._repository.list_pending_barriers(world_id)
+        session = self._presentation_session(world_id)
+        plans = [
+            compile_performance_plan(event)
+            for event in events
+            if event.sequence > session.last_presented_event_sequence
+        ]
+        if session.active_plan_id and all(plan.id != session.active_plan_id for plan in plans):
+            session = replace(
+                session,
+                active_plan_id=None,
+                active_cue_index=0,
+                status="playing" if plans and session.status != "paused" else session.status,
+                updated_at=utc_now(),
+            )
+            self._repository.save_presentation_session(session)
+        elif session.status != "paused":
+            desired = "playing" if plans else self._waiting_status(world_id, barriers=barriers)
+            if session.status != desired:
+                session = replace(session, status=desired, updated_at=utc_now())
+                self._repository.save_presentation_session(session)
+        return {
+            "session": session.to_bridge_dict(),
+            "plans": [plan.to_bridge_dict() for plan in plans],
+        }
+
+    def _waiting_status(
+        self, world_id: str, *, barriers: list[DecisionBarrier] | None = None
+    ) -> str:
+        return "awaiting_barrier" if barriers is not None and barriers else (
+            "awaiting_barrier"
+            if self._repository.list_pending_barriers(world_id)
+            else "awaiting_action"
+        )
 
     def _redraw_shot(self, payload: dict[str, Any]) -> dict[str, Any]:
         world_id = self._world_id(payload)
@@ -341,6 +497,7 @@ class WorldSimulationHandler:
             },
             "relatedCharacters": [{"id": resident.id, "name": resident.name, "relationship": resident.occupation or "世界原住民", "avatarUrl": resident.visual_identity.get("avatar_path")} for resident in residents],
             "performance": {"active": bool(beats), "label": "观看现场演出", "canCancel": False},
+            "presentation": self._presentation_state(world_id),
         }
 
     def _summary(self, world: Any) -> dict[str, Any]:

--- a/tests/desktop_bridge/test_world_simulation_handler.py
+++ b/tests/desktop_bridge/test_world_simulation_handler.py
@@ -89,13 +89,89 @@ def test_action_catch_up_only_returns_committed_beats(tmp_path):
         {"world_id": world_id, "cursor": "0"},
         request_id="catch-up",
     )
+    repeated = handler.handle(
+        "worlds.events.catch_up",
+        {"world_id": world_id, "cursor": "0"},
+        request_id="catch-up-repeat",
+    )
 
     assert accepted is not None
     assert accepted["run_id"]
     assert replay is not None
+    assert repeated is not None
     assert [beat["content"] for beat in replay["beats"]][-1] == "推开灯塔的门。"
     assert replay["world"]["scene"]["beats"][-1]["content"] == "推开灯塔的门。"
+    assert [plan["planId"] for plan in replay["presentation"]["plans"]] == [
+        plan["planId"] for plan in repeated["presentation"]["plans"]
+    ]
     performance_plan = replay["beats"][-1]["performancePlan"]
     assert performance_plan["schemaVersion"] == 1
     assert performance_plan["cues"][0]["kind"] == "dialogue"
     handler.close()
+
+
+def test_presentation_session_checkpoints_pause_and_rebuilds_from_facts(tmp_path):
+    role_store = RoleStore(tmp_path)
+    role = role_store.create_role(name="凛", system_prompt="保持冷静")
+    handler = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    draft = handler.handle(
+        "worlds.drafts.preview",
+        _creation_input(role.id),
+        request_id="preview-world",
+    )
+    assert draft is not None
+    confirmed = handler.handle(
+        "worlds.drafts.confirm",
+        {
+            "draft_id": draft["draft"]["id"],
+            "native_identities": draft["draft"]["nativeIdentities"],
+        },
+        request_id="confirm-world",
+    )
+    assert confirmed is not None
+    world = confirmed["world"]
+    initial = world["presentation"]
+    assert initial["session"]["status"] == "playing"
+    assert len(initial["plans"]) == 1
+    plan_id = initial["plans"][0]["planId"]
+
+    paused = handler.handle(
+        "worlds.presentation.pause",
+        {"world_id": world["id"]},
+        request_id="pause-presentation",
+    )
+    assert paused is not None
+    assert paused["presentation"]["session"]["status"] == "paused"
+    resumed = handler.handle(
+        "worlds.presentation.resume",
+        {"world_id": world["id"]},
+        request_id="resume-presentation",
+    )
+    assert resumed is not None
+    assert resumed["presentation"]["session"]["status"] == "playing"
+
+    checkpoint = handler.handle(
+        "worlds.presentation.checkpoint",
+        {"world_id": world["id"], "plan_id": plan_id, "cue_index": 0},
+        request_id="checkpoint-presentation",
+    )
+    assert checkpoint is not None
+    assert checkpoint["presentation"]["session"]["lastPresentedEventSequence"] == 1
+    assert checkpoint["presentation"]["plans"] == []
+    duplicate = handler.handle(
+        "worlds.presentation.checkpoint",
+        {"world_id": world["id"], "plan_id": plan_id, "cue_index": 0},
+        request_id="duplicate-checkpoint",
+    )
+    assert duplicate == checkpoint
+
+    handler._repository.delete_presentation_session(world["id"])
+    handler.close()
+    restarted = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    rebuilt = restarted.handle(
+        "worlds.get", {"world_id": world["id"]}, request_id="rebuild-session"
+    )
+    assert rebuilt is not None
+    assert rebuilt["world"]["presentation"]["session"]["lastPresentedEventSequence"] == 0
+    assert rebuilt["world"]["presentation"]["plans"]
+    restarted.close()

--- a/tests/world_simulation/test_repository.py
+++ b/tests/world_simulation/test_repository.py
@@ -1,4 +1,5 @@
 from world_simulation.repository import WorldRepository
+from world_simulation.presentation_session import WorldPresentationSession
 
 
 def test_confirmed_world_persists_fact_projection_idempotency_and_outbox(
@@ -27,3 +28,32 @@ def test_outbox_cursor_replays_without_duplicates(repository: WorldRepository, w
     assert repository.list_outbox(
         world.id, after_sequence=repository.consumer_cursor("desktop", world.id)
     ) == []
+
+
+def test_presentation_session_survives_restart_and_can_be_rebuilt(
+    repository: WorldRepository, world, tmp_path
+):
+    repository.save_presentation_session(
+        WorldPresentationSession(
+            world_id=world.id,
+            last_presented_event_sequence=1,
+            active_plan_id="plan-1",
+            active_cue_index=2,
+            status="paused",
+            updated_at="2026-04-01T09:00:00+00:00",
+        )
+    )
+    repository.close()
+
+    restarted = WorldRepository(tmp_path / "worlds.db")
+    assert restarted.get_presentation_session(world.id) == WorldPresentationSession(
+        world_id=world.id,
+        last_presented_event_sequence=1,
+        active_plan_id="plan-1",
+        active_cue_index=2,
+        status="paused",
+        updated_at="2026-04-01T09:00:00+00:00",
+    )
+    restarted.delete_presentation_session(world.id)
+    assert restarted.get_presentation_session(world.id) is None
+    restarted.close()

--- a/tests/world_simulation/test_service.py
+++ b/tests/world_simulation/test_service.py
@@ -166,6 +166,11 @@ def test_copy_uses_committed_node_and_evolves_independently(
     }
     assert repository.require_world(world.id).revision == 2
     assert repository.require_world(copy.id).revision == 3
+    copied_session = repository.get_presentation_session(copy.id)
+    assert copied_session is not None
+    joined_event = repository.get_event(world.id, joined["event_id"])
+    assert joined_event is not None
+    assert copied_session.last_presented_event_sequence == joined_event.sequence
 
 
 def test_cancel_queued_run_is_persistent_and_idempotent(

--- a/world_simulation/__init__.py
+++ b/world_simulation/__init__.py
@@ -10,6 +10,10 @@ from world_simulation.performance import (
     cue_id_for_plan,
     plan_id_for_event,
 )
+from world_simulation.presentation_session import (
+    PresentationSessionStatus,
+    WorldPresentationSession,
+)
 from world_simulation.proposals import BeatProposal, ProposedEvent
 from world_simulation.repository import WorldRepository
 from world_simulation.runs import WorldRun
@@ -33,6 +37,7 @@ __all__ = [
     "NativeResident",
     "PRESENTATION_PROTOCOL_VERSION",
     "PerformancePlan",
+    "PresentationSessionStatus",
     "PresentationCue",
     "PlayerOC",
     "ProposedEvent",
@@ -47,6 +52,7 @@ __all__ = [
     "WorldSimulationService",
     "WorldStateProjection",
     "WorldTemplate",
+    "WorldPresentationSession",
     "compile_performance_plan",
     "cue_id_for_plan",
     "plan_id_for_event",

--- a/world_simulation/_schema.py
+++ b/world_simulation/_schema.py
@@ -138,4 +138,13 @@ CREATE TABLE IF NOT EXISTS outbox_consumers (
     acknowledged_sequence INTEGER NOT NULL,
     PRIMARY KEY (consumer_id, world_id)
 );
+
+CREATE TABLE IF NOT EXISTS world_presentation_sessions (
+    world_id TEXT PRIMARY KEY REFERENCES worlds(id) ON DELETE CASCADE,
+    last_presented_event_sequence INTEGER NOT NULL,
+    active_plan_id TEXT,
+    active_cue_index INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    updated_at TEXT NOT NULL
+);
 """

--- a/world_simulation/presentation_session.py
+++ b/world_simulation/presentation_session.py
@@ -1,0 +1,65 @@
+"""Durable playback cursor for one world's derived presentation queue."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+from typing import Any, Literal
+
+from world_simulation.world import utc_now
+
+PresentationSessionStatus = Literal[
+    "playing", "paused", "awaiting_action", "awaiting_barrier"
+]
+_SESSION_STATUSES = frozenset(
+    ("playing", "paused", "awaiting_action", "awaiting_barrier")
+)
+
+
+@dataclass(frozen=True)
+class WorldPresentationSession:
+    """Persisted playback progress kept separate from authoritative world facts."""
+
+    world_id: str
+    last_presented_event_sequence: int = 0
+    active_plan_id: str | None = None
+    active_cue_index: int = 0
+    status: PresentationSessionStatus = "awaiting_action"
+    updated_at: str = field(default_factory=utc_now)
+
+    def __post_init__(self) -> None:
+        """Reject invalid cursors before they are written to SQLite."""
+
+        self.validate()
+
+    def validate(self) -> None:
+        """Validate session identity, cursor bounds, and lifecycle status."""
+
+        if not self.world_id.strip():
+            raise ValueError("world_id is required")
+        if self.last_presented_event_sequence < 0:
+            raise ValueError("last_presented_event_sequence must be non-negative")
+        if self.active_cue_index < 0:
+            raise ValueError("active_cue_index must be non-negative")
+        if self.active_plan_id is not None and not self.active_plan_id.strip():
+            raise ValueError("active_plan_id cannot be empty")
+        if self.status not in _SESSION_STATUSES:
+            raise ValueError(f"unsupported presentation session status: {self.status}")
+        if not self.updated_at.strip():
+            raise ValueError("updated_at is required")
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serialize the internal snake_case session record."""
+
+        return asdict(self)
+
+    def to_bridge_dict(self) -> dict[str, Any]:
+        """Serialize the session envelope exposed to the renderer."""
+
+        return {
+            "worldId": self.world_id,
+            "lastPresentedEventSequence": self.last_presented_event_sequence,
+            "activePlanId": self.active_plan_id,
+            "activeCueIndex": self.active_cue_index,
+            "status": self.status,
+            "updatedAt": self.updated_at,
+        }

--- a/world_simulation/repository.py
+++ b/world_simulation/repository.py
@@ -15,6 +15,7 @@ from world_simulation.repository_records import RepositoryRecords, _dump, _load
 from world_simulation.runs import WorldRun
 from world_simulation.scenes import DecisionBarrier, SceneThread
 from world_simulation.timeline import TimelineEvent, WorldStateProjection
+from world_simulation.presentation_session import WorldPresentationSession
 from world_simulation.world import (
     NativeResident,
     RoleTemplateSnapshot,
@@ -171,6 +172,11 @@ class WorldRepository(RepositoryRecords):
             self._insert_event(connection, initial_event)
             self._upsert_projection(connection, projection)
             connection.execute(
+                """INSERT INTO world_presentation_sessions
+                VALUES (?, ?, ?, ?, ?, ?)""",
+                (world.id, 0, None, 0, "playing", world.created_at),
+            )
+            connection.execute(
                 "UPDATE world_drafts SET status = 'confirmed' WHERE id = ?",
                 (draft.id,),
             )
@@ -191,6 +197,65 @@ class WorldRepository(RepositoryRecords):
                 "SELECT * FROM worlds WHERE id = ?", (world_id,)
             ).fetchone()
         return self._row_to_world(row) if row is not None else None
+
+    def get_presentation_session(
+        self, world_id: str
+    ) -> WorldPresentationSession | None:
+        """Load the derived playback cursor for one world."""
+
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT * FROM world_presentation_sessions WHERE world_id = ?",
+                (world_id,),
+            ).fetchone()
+        if row is None:
+            return None
+        return WorldPresentationSession(
+            world_id=row["world_id"],
+            last_presented_event_sequence=int(row["last_presented_event_sequence"]),
+            active_plan_id=row["active_plan_id"],
+            active_cue_index=int(row["active_cue_index"]),
+            status=row["status"],
+            updated_at=row["updated_at"],
+        )
+
+    def save_presentation_session(self, session: WorldPresentationSession) -> None:
+        """Upsert playback progress without touching timeline facts."""
+
+        session.validate()
+        with self.transaction() as connection:
+            world = connection.execute(
+                "SELECT 1 FROM worlds WHERE id = ?", (session.world_id,)
+            ).fetchone()
+            if world is None:
+                raise WorldNotFoundError(f"world not found: {session.world_id}")
+            connection.execute(
+                """INSERT INTO world_presentation_sessions
+                VALUES (?, ?, ?, ?, ?, ?)
+                ON CONFLICT(world_id) DO UPDATE SET
+                last_presented_event_sequence = excluded.last_presented_event_sequence,
+                active_plan_id = excluded.active_plan_id,
+                active_cue_index = excluded.active_cue_index,
+                status = excluded.status,
+                updated_at = excluded.updated_at""",
+                (
+                    session.world_id,
+                    session.last_presented_event_sequence,
+                    session.active_plan_id,
+                    session.active_cue_index,
+                    session.status,
+                    session.updated_at,
+                ),
+            )
+
+    def delete_presentation_session(self, world_id: str) -> None:
+        """Delete only derived playback progress so it can be rebuilt."""
+
+        with self.transaction() as connection:
+            connection.execute(
+                "DELETE FROM world_presentation_sessions WHERE world_id = ?",
+                (world_id,),
+            )
 
     def list_worlds(self) -> list[WorldInstance]:
         """Return worlds in creation order without exposing repository internals."""

--- a/world_simulation/repository_records.py
+++ b/world_simulation/repository_records.py
@@ -87,6 +87,18 @@ class RepositoryRecords:
                 )
                 self._insert_event(connection, copied)
             self._upsert_projection(connection, projection)
+            connection.execute(
+                """INSERT INTO world_presentation_sessions
+                VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    target.id,
+                    through_event.sequence,
+                    None,
+                    0,
+                    "awaiting_action",
+                    target.created_at,
+                ),
+            )
             self._save_idempotency(connection, request_id, target.id, result)
             self._insert_outbox(
                 connection,


### PR DESCRIPTION
Part of #39
Blocked by #40 (Draft PR #47)

## 变更摘要

- 在 `worlds.db` 增加独立的 `world_presentation_sessions` 表，不修改世界事实或 timeline。
- 持久化 `last_presented_event_sequence`、`active_plan_id`、`active_cue_index`、`status` 与更新时间。
- 从已提交世界事件和稳定 plan ID 派生待播放队列；session 缺失时可安全重建。
- 新增 pause、resume、checkpoint bridge RPC，checkpoint 幂等且严格按世界事件顺序推进。
- world copy 从复制节点的演出 cursor 开始，不重播此前历史。
- renderer 对 session/queue envelope 做 runtime 校验，并公开 typed bridge client 方法。

## 验证

- `uv run pytest tests/world_simulation tests/desktop_bridge/test_world_simulation_handler.py`：20 passed
- `npm run desktop:test`：397 tests，396 passed，1 skipped
- `npm run desktop:typecheck`：通过
- `uvx ruff check`：通过
- `uvx black --check --fast world_simulation/presentation_session.py`：通过
- `git diff --check`：通过
- `graphify update .`：通过

## 已知阻塞

- 此 PR 以 `codex/issue-40-presentation-protocol` 为 base，等待 #47 合并后再进入 main。
- PixiJS 舞台与实际 Galgame UI 消费属于后续 #43/#44。

Closes #41

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persisted world presentation session state with pause/resume/checkpoint RPCs and renderer-side validation, so playback can recover across restarts and advance safely in strict event order. This enables durable, idempotent progression of the derived presentation queue based on committed world events.

- **New Features**
  - Added `world_presentation_sessions` table in `worlds.db` to store `last_presented_event_sequence`, `active_plan_id`, `active_cue_index`, `status`, `updated_at`.
  - New bridge methods: `worlds.presentation.pause`, `worlds.presentation.resume`, `worlds.presentation.checkpoint` (idempotent; enforces event sequence and cue rules).
  - Derived plan queue from committed events; session safely rebuilt if missing.
  - Renderer: added `parsePresentationState`, `WorldPresentationState`, `WorldPresentationSessionStatus`, and client methods `pausePresentation`, `resumePresentation`, `checkpointPresentation`.
  - `catch_up` and world details responses now include `presentation` state.
  - World copy initializes the session at the copier’s cursor to avoid replaying history.

<sup>Written for commit e280dc8dc466c67b6fc568e908deabc1cacb0b28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/48?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

