### PR TITLE
feat(world): freeze role visual and voice snapshots

### DIFF
--- a/desktop_bridge/world_simulation_handler.py
+++ b/desktop_bridge/world_simulation_handler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+import shutil
 from typing import Any
 from uuid import uuid4
 
@@ -30,6 +31,7 @@ class WorldSimulationHandler:
         self._roles = role_store
         self._repository = WorldRepository(workspace / "worlds.db")
         self._service = WorldSimulationService(self._repository)
+        self._world_assets_dir = workspace / "world_assets"
         self._shots: dict[tuple[str, str], dict[str, Any]] = {}
 
     def close(self) -> None:
@@ -590,7 +592,94 @@ class WorldSimulationHandler:
         return oc
 
     def _snapshot_for(self, role: Any) -> RoleTemplateSnapshot:
-        return RoleTemplateSnapshot(id=f"snapshot-{uuid4().hex}", source_role_id=role.id, source_version=role.updated_at, persona={"name": role.name, "description": role.description}, system_constraints=(role.system_prompt,), visual_profile={"avatar_path": self._asset_path(role.avatar)}, assets=tuple({"path": path} for path in [role.avatar, *role.illustrations] if path))
+        snapshot_id = f"snapshot-{uuid4().hex}"
+        asset_ids: dict[str, str] = {}
+        assets = []
+        for source in [role.avatar, *role.illustrations]:
+            if not source or source in asset_ids:
+                continue
+            copied = self._copy_snapshot_asset(snapshot_id, source)
+            if copied is None:
+                continue
+            asset_id = f"asset-{uuid4().hex}"
+            asset_ids[source] = asset_id
+            assets.append({"id": asset_id, "path": copied})
+        runtime = role.runtime_config if isinstance(role.runtime_config, dict) else {}
+        raw_bindings = runtime.get("mood_illustration_bindings", {})
+        bindings = raw_bindings if isinstance(raw_bindings, dict) else {}
+        mood_bindings = {
+            str(mood).strip(): asset_ids[str(path).strip()]
+            for mood, path in bindings.items()
+            if str(mood).strip() and str(path).strip() in asset_ids
+        }
+        raw_catalog = runtime.get("mood_catalog", [])
+        catalog = raw_catalog if isinstance(raw_catalog, list) else []
+        mood_catalog = [
+            str(mood).strip()
+            for mood in catalog
+            if str(mood).strip() in mood_bindings
+        ]
+        default_mood = str(runtime.get("default_mood") or "").strip()
+        if default_mood not in mood_bindings:
+            default_mood = mood_catalog[0] if mood_catalog else next(iter(mood_bindings), "")
+        return RoleTemplateSnapshot(
+            id=snapshot_id,
+            source_role_id=role.id,
+            source_version=role.updated_at,
+            persona={"name": role.name, "description": role.description},
+            system_constraints=(role.system_prompt,),
+            visual_profile={
+                "default_mood": default_mood,
+                "mood_catalog": mood_catalog,
+                "mood_illustration_bindings": mood_bindings,
+                "avatar_asset_id": asset_ids.get(role.avatar),
+            },
+            voice_profile=self._voice_profile(runtime),
+            assets=tuple(assets),
+        )
+
+    def _copy_snapshot_asset(self, snapshot_id: str, relative_path: str) -> str | None:
+        """Copy a role-owned asset before the source role can change or disappear."""
+
+        source = (self._roles.roles_dir / relative_path).resolve()
+        try:
+            source.relative_to(self._roles.assets_dir.resolve())
+        except ValueError:
+            return None
+        if not source.is_file():
+            return None
+        destination = self._world_assets_dir / snapshot_id / f"{uuid4().hex}{source.suffix}"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(source, destination)
+        return str(destination.resolve())
+
+    @staticmethod
+    def _voice_profile(runtime: dict[str, Any]) -> dict[str, Any]:
+        """Freeze only non-secret voice fields required by later presentation work."""
+
+        raw_tts = runtime.get("tts", {})
+        tts = raw_tts if isinstance(raw_tts, dict) else {}
+        voice_id = str(tts.get("voice_id") or "").strip()
+        if not voice_id:
+            return {}
+        speed = tts.get("speed", 1.0)
+        normalized_speed = float(speed) if isinstance(speed, (int, float)) else 1.0
+        if not 0.5 <= normalized_speed <= 2.0:
+            normalized_speed = 1.0
+        raw_emotions = tts.get("mood_tts_emotions", {})
+        emotions = raw_emotions if isinstance(raw_emotions, dict) else {}
+        return {
+            "config_version": 1,
+            "enabled": tts.get("enabled", True) is not False,
+            "provider": str(tts.get("provider") or "minimax").strip() or "minimax",
+            "voice_id": voice_id,
+            "speed": normalized_speed,
+            "mood_tts_emotions": {
+                str(mood).strip(): str(emotion).strip()
+                for mood, emotion in emotions.items()
+                if str(mood).strip() and str(emotion).strip()
+            },
+        }
 
     def _asset_path(self, relative_path: str | None) -> str | None:
         return str((self._roles.roles_dir / relative_path).resolve()) if relative_path else None

--- a/tests/desktop_bridge/test_world_simulation_handler.py
+++ b/tests/desktop_bridge/test_world_simulation_handler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from pathlib import Path
+
 from core.roles import RoleStore
 from desktop_bridge.world_simulation_handler import WorldSimulationHandler
 
@@ -175,3 +177,49 @@ def test_presentation_session_checkpoints_pause_and_rebuilds_from_facts(tmp_path
     assert rebuilt["world"]["presentation"]["session"]["lastPresentedEventSequence"] == 0
     assert rebuilt["world"]["presentation"]["plans"]
     restarted.close()
+
+
+def test_world_draft_freezes_role_visual_and_voice_snapshots(tmp_path):
+    source = tmp_path / "portrait.png"
+    source.write_bytes(b"world-owned-image")
+    role_store = RoleStore(tmp_path)
+    role = role_store.create_role(
+        name="凛",
+        system_prompt="保持冷静",
+        avatar_source=source,
+        illustration_sources=[source],
+    )
+    role = role_store.update_role(
+        role.id,
+        runtime_config={
+            "default_mood": "平静",
+            "mood_catalog": ["平静"],
+            "mood_illustration_bindings": {"平静": role.illustrations[0]},
+            "tts": {
+                "provider": "minimax",
+                "voice_id": "rin-voice",
+                "speed": 1.2,
+                "secret_key": "must-not-be-copied",
+            },
+        },
+    )
+    handler = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    draft = handler.handle(
+        "worlds.drafts.preview",
+        _creation_input(role.id),
+        request_id="preview-world",
+    )
+    assert draft is not None
+    stored = handler._repository.get_draft(draft["draft"]["id"])
+    assert stored is not None
+    snapshot = stored.role_snapshots[0]
+    copied_paths = [item["path"] for item in snapshot.assets]
+    assert copied_paths and all(
+        (tmp_path / "world_assets") in Path(path).parents for path in copied_paths
+    )
+    assert all(Path(path).is_file() for path in copied_paths)
+    assert snapshot.voice_profile["voice_id"] == "rin-voice"
+    assert "secret_key" not in snapshot.voice_profile
+    role_store.delete_role(role.id)
+    assert all(Path(path).is_file() for path in copied_paths)
+    handler.close()

--- a/tests/world_simulation/test_visuals.py
+++ b/tests/world_simulation/test_visuals.py
@@ -1,0 +1,50 @@
+from world_simulation.visuals import WorldVisualResolver
+from world_simulation.world import RoleTemplateSnapshot
+
+
+def test_visual_resolver_uses_mood_default_avatar_then_silhouette():
+    snapshot = RoleTemplateSnapshot(
+        id="snapshot-1",
+        source_role_id="role-1",
+        source_version="v1",
+        persona={},
+        visual_profile={
+            "default_mood": "平静",
+            "mood_illustration_bindings": {"平静": "asset-mood"},
+            "avatar_asset_id": "asset-avatar",
+        },
+        assets=(
+            {"id": "asset-mood", "path": "C:/world-assets/mood.png"},
+            {"id": "asset-avatar", "path": "C:/world-assets/avatar.png"},
+        ),
+    )
+    resolver = WorldVisualResolver()
+
+    assert resolver.resolve(snapshot, "平静").source == "mood"
+    assert resolver.resolve(snapshot, "悲伤").source == "default_mood"
+    assert (
+        resolver.resolve(
+            RoleTemplateSnapshot(
+                id="snapshot-2",
+                source_role_id="role-1",
+                source_version="v1",
+                persona={},
+                visual_profile={"avatar_asset_id": "asset-avatar"},
+                assets=({"id": "asset-avatar", "path": "C:/world-assets/avatar.png"},),
+            ),
+            "悲伤",
+        ).source
+        == "avatar"
+    )
+    assert (
+        resolver.resolve(
+            RoleTemplateSnapshot(
+                id="snapshot-3",
+                source_role_id="role-1",
+                source_version="v1",
+                persona={},
+            ),
+            "悲伤",
+        ).source
+        == "silhouette"
+    )

--- a/world_simulation/__init__.py
+++ b/world_simulation/__init__.py
@@ -14,6 +14,7 @@ from world_simulation.presentation_session import (
     PresentationSessionStatus,
     WorldPresentationSession,
 )
+from world_simulation.visuals import ResolvedWorldVisual, WorldVisualResolver
 from world_simulation.proposals import BeatProposal, ProposedEvent
 from world_simulation.repository import WorldRepository
 from world_simulation.runs import WorldRun
@@ -53,7 +54,9 @@ __all__ = [
     "WorldStateProjection",
     "WorldTemplate",
     "WorldPresentationSession",
+    "WorldVisualResolver",
     "compile_performance_plan",
     "cue_id_for_plan",
     "plan_id_for_event",
+    "ResolvedWorldVisual",
 ]

--- a/world_simulation/repository.py
+++ b/world_simulation/repository.py
@@ -276,6 +276,16 @@ class WorldRepository(RepositoryRecords):
             ).fetchall()
         return [NativeResident(**_load(row["payload"], {})) for row in rows]
 
+    def list_role_snapshots(self, world_id: str) -> list[RoleTemplateSnapshot]:
+        """Return immutable role snapshots captured when the world was created."""
+
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT payload FROM role_snapshots WHERE world_id = ? ORDER BY id",
+                (world_id,),
+            ).fetchall()
+        return [RoleTemplateSnapshot(**_load(row["payload"], {})) for row in rows]
+
     def require_world(self, world_id: str) -> WorldInstance:
         """Load a world or fail with a stable domain error."""
 

--- a/world_simulation/visuals.py
+++ b/world_simulation/visuals.py
@@ -1,0 +1,47 @@
+"""Resolve world-owned role visuals without reading mutable role configuration."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from world_simulation.world import RoleTemplateSnapshot
+
+
+@dataclass(frozen=True)
+class ResolvedWorldVisual:
+    """One resolved world-owned visual or the stable silhouette fallback."""
+
+    asset_id: str | None
+    path: str | None
+    source: str
+
+
+class WorldVisualResolver:
+    """Resolve a mood from one frozen role snapshot with deterministic fallbacks."""
+
+    def resolve(self, snapshot: RoleTemplateSnapshot, mood: str) -> ResolvedWorldVisual:
+        """Resolve current mood, default mood, avatar, then a fixed silhouette."""
+
+        profile = snapshot.visual_profile
+        bindings = profile.get("mood_illustration_bindings", {})
+        assets = {
+            str(asset.get("id") or ""): str(asset.get("path") or "")
+            for asset in snapshot.assets
+            if isinstance(asset, dict)
+        }
+        requested = str(mood or "").strip()
+        default_mood = str(profile.get("default_mood") or "").strip()
+        for candidate, source in ((requested, "mood"), (default_mood, "default_mood")):
+            asset_id = (
+                str(bindings.get(candidate) or "") if isinstance(bindings, dict) else ""
+            )
+            path = assets.get(asset_id, "")
+            if asset_id and path:
+                return ResolvedWorldVisual(asset_id=asset_id, path=path, source=source)
+        avatar_id = str(profile.get("avatar_asset_id") or "")
+        avatar_path = assets.get(avatar_id, "")
+        if avatar_id and avatar_path:
+            return ResolvedWorldVisual(
+                asset_id=avatar_id, path=avatar_path, source="avatar"
+            )
+        return ResolvedWorldVisual(asset_id=None, path=None, source="silhouette")

--- a/world_simulation/world.py
+++ b/world_simulation/world.py
@@ -45,6 +45,7 @@ class RoleTemplateSnapshot:
     persona: dict[str, Any]
     system_constraints: tuple[str, ...] = ()
     visual_profile: dict[str, Any] = field(default_factory=dict)
+    voice_profile: dict[str, Any] = field(default_factory=dict)
     assets: tuple[dict[str, Any], ...] = ()
     schema_version: int = 1
     created_at: str = field(default_factory=utc_now)


### PR DESCRIPTION
Part of #39
Blocked by #41 (Draft PR #48)

## 变更摘要

- 草案创建时把角色 avatar 与 mood 差分复制至 `world_assets/<snapshot>`，不再依赖可变角色目录。
- `RoleTemplateSnapshot` 冻结 mood catalog、default mood、mood-to-asset ID binding 和仅包含非敏感字段的 voice profile。
- 新增 `WorldVisualResolver`，固定按当前 mood、default mood、avatar、silhouette 解析。
- world copy 复用已冻结 snapshot；角色更新或删除不会影响既有世界。
- 路径仍经 Electron 私有 workspace 的受控 asset transport 暴露。

## 验证

- `uv run pytest tests/world_simulation tests/desktop_bridge/test_world_simulation_handler.py`：22 passed
- `npm run desktop:typecheck`：通过
- `uvx ruff check`：通过
- `uvx black --check --fast`（新增模块与测试）：通过
- `git diff --check`：通过
- `graphify update .`：通过

## 已知阻塞

- 此 PR 以 `codex/issue-41-presentation-session` 为 base，等待 #48 合并。
- PixiJS 资产加载与实际舞台渲染属于后续 #43。

Closes #42

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Freezes role visuals and voice settings at world draft time by copying assets into `world_assets/<snapshot>`. Existing worlds now render consistently even if the source role changes or is deleted.

- **New Features**
  - Capture `RoleTemplateSnapshot` with frozen mood catalog, default mood, mood→asset bindings, avatar asset ID, and a non-secret `voice_profile` (provider, `voice_id`, speed, per-mood emotions).
  - Copy avatar and illustration files into a world-owned snapshot folder and bind them to generated asset IDs; reuse snapshots for world copies.
  - Add `WorldVisualResolver` to pick visuals by current mood, then default mood, then avatar, else a silhouette fallback; export `ResolvedWorldVisual` and the resolver from `world_simulation`.
  - Add `WorldRepository.list_role_snapshots(world_id)` to load immutable snapshots.

<sup>Written for commit f17e0d425608e4610f0bfad3f70864cf0daac70f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/49?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

