### PR TITLE
feat(world): 构建 PixiJS 舞台与 WorldAssetManager

### DIFF
--- a/desktop/package-lock.json
+++ b/desktop/package-lock.json
@@ -9,6 +9,7 @@
         "@phosphor-icons/react": "^2.1.10",
         "gsap": "^3.15.0",
         "motion": "^12.42.2",
+        "pixi.js": "^8.19.0",
         "react": "^19.2.5",
         "react-dom": "^19.2.5",
         "uiohook-napi": "^1.5.5"
@@ -908,6 +909,12 @@
         "react-dom": ">= 16.8"
       }
     },
+    "node_modules/@pixi/colord": {
+      "version": "2.9.6",
+      "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "license": "MIT"
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
@@ -1310,6 +1317,12 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/earcut": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-3.0.0.tgz",
+      "integrity": "sha512-k/9fOUGO39yd2sCjrbAJvGDEQvRwRnQIZlBz43roGwUZo5SHAmyVvSFyaVVZkicRVCaDXPKlbxrUcBuJoSWunQ==",
+      "license": "MIT"
+    },
     "node_modules/@types/estree": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
@@ -1366,6 +1379,21 @@
       },
       "peerDependencies": {
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.71",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.71.tgz",
+      "integrity": "sha512-mMy8/ODcKhab808co15eW+yN+HgXoQxRQHTiBV9Mrvl1r0ufnid7YOcI+gi4eUWSWl9ezD6TW2KXccrL8HCh2A==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
       }
     },
     "node_modules/any-promise": {
@@ -1657,6 +1685,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/earcut": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.2.3.tgz",
+      "integrity": "sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==",
+      "license": "ISC"
+    },
     "node_modules/electron": {
       "version": "43.1.1",
       "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.1.tgz",
@@ -1757,6 +1791,12 @@
       "engines": {
         "node": ">=6"
       }
+    },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "license": "MIT"
     },
     "node_modules/fast-glob": {
       "version": "3.3.3",
@@ -1905,6 +1945,15 @@
         "node": ">=6.9.0"
       }
     },
+    "node_modules/gifuct-js": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/gifuct-js/-/gifuct-js-2.1.2.tgz",
+      "integrity": "sha512-rI2asw77u0mGgwhV3qA+OEgYqaDn5UNqgs+Bx0FGwSpuqfYn+Ir6RQY5ENNQ8SbIiG/m5gVa7CD5RriO4f4Lsg==",
+      "license": "MIT",
+      "dependencies": {
+        "js-binary-schema-parser": "^2.0.3"
+      }
+    },
     "node_modules/glob-parent": {
       "version": "6.0.2",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-6.0.2.tgz",
@@ -2006,6 +2055,12 @@
         "node": ">=0.12.0"
       }
     },
+    "node_modules/ismobilejs": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "license": "MIT"
+    },
     "node_modules/jiti": {
       "version": "1.21.7",
       "resolved": "https://registry.npmjs.org/jiti/-/jiti-1.21.7.tgz",
@@ -2015,6 +2070,12 @@
       "bin": {
         "jiti": "bin/jiti.js"
       }
+    },
+    "node_modules/js-binary-schema-parser": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/js-binary-schema-parser/-/js-binary-schema-parser-2.0.3.tgz",
+      "integrity": "sha512-xezGJmOb4lk/M1ZZLTR/jaBHQ4gG/lqQnJqdIv4721DMggsa1bDVlHXNeHYogaIEHD9vCRv0fcL4hMA+Coarkg==",
+      "license": "MIT"
     },
     "node_modules/js-tokens": {
       "version": "4.0.0",
@@ -2246,6 +2307,12 @@
         "node": ">= 6"
       }
     },
+    "node_modules/parse-svg-path": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.2.0.tgz",
+      "integrity": "sha512-Tf7FFIrguPKQwzD4pWnYkR2VOv3raoHeKED80Bm+BYHI3KxC8KsgsGC5+fSMzAGDA6UEk4bHvmi+RsjmL3khpg==",
+      "license": "MIT"
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -2291,6 +2358,32 @@
       "license": "MIT",
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/pixi.js": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-8.19.0.tgz",
+      "integrity": "sha512-pq1O6emA/GFjjeF+8d3Pb5t7knD8FsnfWGqQcRjYjsqFZ7QdzG1XgjLDUu0DFJRbafjV5+g8iNLFBx0b9649lg==",
+      "license": "MIT",
+      "workspaces": [
+        "examples",
+        "playground"
+      ],
+      "dependencies": {
+        "@pixi/colord": "^2.9.6",
+        "@types/earcut": "^3.0.0",
+        "@webgpu/types": "^0.1.69",
+        "@xmldom/xmldom": "^0.8.13",
+        "earcut": "^3.0.2",
+        "eventemitter3": "^5.0.1",
+        "gifuct-js": "^2.1.2",
+        "ismobilejs": "^1.1.1",
+        "parse-svg-path": "^0.2.0",
+        "tiny-lru": "^11.4.7"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/pixijs"
       }
     },
     "node_modules/postcss": {
@@ -2790,6 +2883,15 @@
       },
       "engines": {
         "node": ">=0.8"
+      }
+    },
+    "node_modules/tiny-lru": {
+      "version": "11.4.7",
+      "resolved": "https://registry.npmjs.org/tiny-lru/-/tiny-lru-11.4.7.tgz",
+      "integrity": "sha512-w/Te7uMUVeH0CR8vZIjr+XiN41V+30lkDdK+NRIDCUYKKuL9VcmaUEmaPISuwGhLlrTGh5yu18lENtR9axSxYw==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/tinyglobby": {

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -23,6 +23,7 @@
     "@phosphor-icons/react": "^2.1.10",
     "gsap": "^3.15.0",
     "motion": "^12.42.2",
+    "pixi.js": "^8.19.0",
     "react": "^19.2.5",
     "react-dom": "^19.2.5",
     "uiohook-napi": "^1.5.5"

--- a/desktop/renderer/src/app/useWorldWorkspacePresentation.tsx
+++ b/desktop/renderer/src/app/useWorldWorkspacePresentation.tsx
@@ -168,8 +168,27 @@ export function useWorldWorkspacePresentation({ roles, client, controller }: Use
       );
     }
     if (mode === "focus") {
-      const beat = [...world.scene.beats].reverse().find((item) => item.isCritical) ?? world.scene.beats.at(-1);
-      return beat ? <GalgameFocusMode worldName={world.name} beat={beat} onExit={() => setMode("workspace")} onRedrawShot={controller.redrawShot} /> : null;
+      const plan = world.presentation?.plans[0];
+      const beat = (plan ? world.scene.beats.find((item) => item.id === plan.eventId) : undefined)
+        ?? [...world.scene.beats].reverse().find((item) => item.isCritical)
+        ?? world.scene.beats.at(-1);
+      return beat ? (
+        <GalgameFocusMode
+          worldName={world.name}
+          beat={beat}
+          plan={plan}
+          preloadPlan={world.presentation?.plans[1]}
+          startCueIndex={world.presentation?.session.activePlanId === plan?.planId
+            ? world.presentation?.session.activeCueIndex ?? 0
+            : 0}
+          paused={world.presentation?.session.status === "paused"}
+          onExit={() => setMode("workspace")}
+          onRedrawShot={controller.redrawShot}
+          onPause={controller.pausePresentation}
+          onResume={controller.resumePresentation}
+          onCheckpoint={controller.checkpointPresentation}
+        />
+      ) : null;
     }
     return (
       <WorldWorkspace

--- a/desktop/renderer/src/shared/format.ts
+++ b/desktop/renderer/src/shared/format.ts
@@ -1,6 +1,7 @@
 import { unavailableLocalAssetUrl } from "../../../src/shared";
 
-type LocalAssetUrlResolver = (path: string) => string;
+/** Converts one trusted bridge path into its renderer-safe opaque URL. */
+export type LocalAssetUrlResolver = (path: string) => string;
 
 function resolveDesktopLocalAssetUrl(path: string): string {
   if (typeof window === "undefined") {

--- a/desktop/renderer/src/world/GalgameFocusMode.test.tsx
+++ b/desktop/renderer/src/world/GalgameFocusMode.test.tsx
@@ -9,9 +9,11 @@ describe("GalgameFocusMode", () => {
   it("takes over the viewport with dialogue and always keeps an exit", () => {
     const markup = renderToStaticMarkup(<GalgameFocusMode worldName="雨港" beat={createSceneBeat({ isCritical: true })} onExit={() => undefined} onRedrawShot={() => undefined} />);
     assert.match(markup, /fixed inset-0/);
+    assert.match(markup, /data-testid="world-stage"/);
     assert.match(markup, />你终于来了。</);
+    assert.match(markup, /aria-label="暂停演出"/);
+    assert.match(markup, /aria-label="跳过当前演出"/);
     assert.match(markup, /aria-label="退出焦点模式"/);
     assert.match(markup, />返回工作台</);
-    assert.doesNotMatch(markup, />暂停演出</);
   });
 });

--- a/desktop/renderer/src/world/GalgameFocusMode.tsx
+++ b/desktop/renderer/src/world/GalgameFocusMode.tsx
@@ -2,6 +2,7 @@ import { ArrowClockwise, ArrowLeft, Pause, Play, SkipForward, X } from "@phospho
 import { useEffect, useMemo, useState } from "react";
 import type { PerformancePlan } from "./presentationProtocol";
 import type { SceneBeat } from "./types";
+import { hydrateWorldPresentationAssets } from "./worldPresentationAssets";
 import { WorldStage } from "./WorldStage";
 
 type GalgameFocusModeProps = {
@@ -46,7 +47,14 @@ function fallbackPlan(beat: SceneBeat): PerformancePlan {
 export function GalgameFocusMode({ worldName, beat, plan, preloadPlan, startCueIndex = 0, paused = false, onExit, onRedrawShot, onPause, onResume, onCheckpoint }: GalgameFocusModeProps) {
   const [locallyPaused, setLocallyPaused] = useState(paused);
   const [skipVersion, setSkipVersion] = useState(0);
-  const activePlan = useMemo(() => plan ?? beat.performancePlan ?? fallbackPlan(beat), [beat, plan]);
+  const activePlan = useMemo(
+    () => hydrateWorldPresentationAssets(plan ?? beat.performancePlan ?? fallbackPlan(beat)),
+    [beat, plan],
+  );
+  const hydratedPreloadPlan = useMemo(
+    () => preloadPlan ? hydrateWorldPresentationAssets(preloadPlan) : undefined,
+    [preloadPlan],
+  );
   const initialShot = useMemo(() => {
     const shot = beat.shot;
     if (!shot) return undefined;
@@ -60,7 +68,7 @@ export function GalgameFocusMode({ worldName, beat, plan, preloadPlan, startCueI
     <section className="fixed inset-0 z-[100] overflow-hidden bg-[#171A18] text-white" data-testid="galgame-focus-mode">
       <WorldStage
         plan={activePlan}
-        preloadPlan={preloadPlan}
+        preloadPlan={hydratedPreloadPlan}
         fallbackText={beat.content}
         initialVisual={initialShot}
         startCueIndex={startCueIndex}

--- a/desktop/renderer/src/world/GalgameFocusMode.tsx
+++ b/desktop/renderer/src/world/GalgameFocusMode.tsx
@@ -1,21 +1,88 @@
-import { ArrowLeft, X } from "@phosphor-icons/react";
-import { SceneShot } from "./SceneShot";
+import { ArrowClockwise, ArrowLeft, Pause, Play, SkipForward, X } from "@phosphor-icons/react";
+import { useEffect, useMemo, useState } from "react";
+import type { PerformancePlan } from "./presentationProtocol";
 import type { SceneBeat } from "./types";
+import { WorldStage } from "./WorldStage";
 
 type GalgameFocusModeProps = {
   worldName: string;
   beat: SceneBeat;
+  plan?: PerformancePlan;
+  preloadPlan?: PerformancePlan;
+  startCueIndex?: number;
+  paused?: boolean;
   onExit: () => void;
   onRedrawShot: (shotId: string) => void;
+  onPause?: () => Promise<void> | void;
+  onResume?: () => Promise<void> | void;
+  onCheckpoint?: (planId: string, cueIndex: number) => Promise<void> | void;
 };
 
-/** Renders an app-level visual-novel presentation without controlling run lifecycle. */
-export function GalgameFocusMode({ worldName, beat, onExit, onRedrawShot }: GalgameFocusModeProps) {
+function fallbackPlan(beat: SceneBeat): PerformancePlan {
+  const planId = `fallback-${beat.id}`;
+  return {
+    schemaVersion: 1,
+    planId,
+    worldId: "fallback",
+    eventId: beat.id,
+    sourceSequence: beat.order,
+    cues: [{
+      schemaVersion: 1,
+      cueId: `${planId}-text`,
+      planId,
+      sequence: 0,
+      kind: "text",
+      payload: { text: beat.content },
+      parallelGroup: null,
+      blocking: true,
+      completionState: "completed",
+      skipState: "skipped",
+      checkpoint: true,
+    }],
+  };
+}
+
+/** Owns React presentation controls without coupling the stage to world simulation. */
+export function GalgameFocusMode({ worldName, beat, plan, preloadPlan, startCueIndex = 0, paused = false, onExit, onRedrawShot, onPause, onResume, onCheckpoint }: GalgameFocusModeProps) {
+  const [locallyPaused, setLocallyPaused] = useState(paused);
+  const [skipVersion, setSkipVersion] = useState(0);
+  const activePlan = useMemo(() => plan ?? beat.performancePlan ?? fallbackPlan(beat), [beat, plan]);
+  const initialShot = useMemo(() => {
+    const shot = beat.shot;
+    if (!shot) return undefined;
+    const asset = shot.assets.find((item) => item.id === shot.activeAssetId) ?? shot.assets[0];
+    return asset ? { id: `shot-${asset.id}`, url: asset.imageUrl } : undefined;
+  }, [beat.shot]);
+
+  useEffect(() => setLocallyPaused(paused), [paused]);
+
   return (
     <section className="fixed inset-0 z-[100] overflow-hidden bg-[#171A18] text-white" data-testid="galgame-focus-mode">
-      {beat.shot ? <SceneShot shot={beat.shot} immersive onRedraw={onRedrawShot} /> : <div className="absolute inset-0 bg-[radial-gradient(circle_at_65%_25%,#647068_0%,#303632_38%,#151816_78%)]" />}
+      <WorldStage
+        plan={activePlan}
+        preloadPlan={preloadPlan}
+        fallbackText={beat.content}
+        initialVisual={initialShot}
+        startCueIndex={startCueIndex}
+        paused={locallyPaused}
+        skipVersion={skipVersion}
+        onCueComplete={(cue) => onCheckpoint?.(activePlan.planId, cue.sequence)}
+      />
       <div className="pointer-events-none absolute inset-0 bg-gradient-to-t from-black/90 via-transparent to-black/35" />
-      <header className="absolute inset-x-0 top-0 z-10 flex items-center justify-between p-5"><span className="font-serif text-sm tracking-normal text-white/75">{worldName}</span><button className="pointer-events-auto grid h-10 w-10 place-items-center rounded-md bg-black/35 text-white backdrop-blur-sm hover:bg-black/55" type="button" aria-label="退出焦点模式" onClick={onExit}><X /></button></header>
+      <header className="absolute inset-x-0 top-0 z-10 flex items-center justify-between p-5">
+        <span className="font-serif text-sm tracking-normal text-white/75">{worldName}</span>
+        <div className="flex items-center gap-2">
+          {beat.shot ? <button className="pointer-events-auto grid h-10 w-10 place-items-center rounded-md bg-black/35 text-white backdrop-blur-sm hover:bg-black/55" type="button" aria-label="重绘镜头" title="重绘镜头" onClick={() => onRedrawShot(beat.shot!.id)}><ArrowClockwise /></button> : null}
+          <button className="pointer-events-auto grid h-10 w-10 place-items-center rounded-md bg-black/35 text-white backdrop-blur-sm hover:bg-black/55" type="button" aria-label={locallyPaused ? "继续演出" : "暂停演出"} title={locallyPaused ? "继续演出" : "暂停演出"} onClick={() => {
+            const nextPaused = !locallyPaused;
+            setLocallyPaused(nextPaused);
+            if (nextPaused) void onPause?.();
+            else void onResume?.();
+          }}>{locallyPaused ? <Play /> : <Pause />}</button>
+          <button className="pointer-events-auto grid h-10 w-10 place-items-center rounded-md bg-black/35 text-white backdrop-blur-sm hover:bg-black/55" type="button" aria-label="跳过当前演出" title="跳过当前演出" onClick={() => setSkipVersion((value) => value + 1)}><SkipForward /></button>
+          <button className="pointer-events-auto grid h-10 w-10 place-items-center rounded-md bg-black/35 text-white backdrop-blur-sm hover:bg-black/55" type="button" aria-label="退出焦点模式" title="退出焦点模式" onClick={onExit}><X /></button>
+        </div>
+      </header>
       <div className="absolute inset-x-0 bottom-0 z-10 px-[clamp(24px,8vw,120px)] pb-[clamp(28px,7vh,72px)]"><div className="max-w-4xl border-l-2 border-[#E59A70] bg-black/45 px-6 py-5 backdrop-blur-md">{beat.speakerName ? <h1 className="m-0 mb-2 font-serif text-lg font-semibold text-[#F3B18B]">{beat.speakerName}</h1> : null}<p className="m-0 whitespace-pre-wrap font-serif text-lg leading-8 text-white">{beat.content}</p></div><button className="pointer-events-auto mt-3 inline-flex h-9 items-center gap-2 rounded-md bg-black/35 px-3 text-xs text-white/80 hover:bg-black/55" type="button" onClick={onExit}><ArrowLeft />返回工作台</button></div>
     </section>
   );

--- a/desktop/renderer/src/world/WorldStage.tsx
+++ b/desktop/renderer/src/world/WorldStage.tsx
@@ -1,0 +1,132 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useLatestRef } from "../shared/useLatestRef";
+import type { PerformancePlan, PresentationCue } from "./presentationProtocol";
+import {
+  createWorldAssetManifest,
+  playPresentationPlan,
+  TextWorldPresentationRenderer,
+  type TextPresentationSnapshot,
+  type WorldPresentationPrepareRequest,
+  type WorldPresentationRenderer,
+} from "./worldPresentationRenderer";
+
+type WorldStageProps = {
+  plan: PerformancePlan;
+  preloadPlan?: PerformancePlan;
+  fallbackText: string;
+  initialVisual?: { id: string; url: string };
+  startCueIndex?: number;
+  paused?: boolean;
+  skipVersion?: number;
+  onCueComplete?: (cue: PresentationCue) => Promise<void> | void;
+};
+
+type PixiRendererModule = {
+  createPixiWorldPresentationRenderer(options: { onContextLoss: () => void }): WorldPresentationRenderer;
+};
+
+function initialRequest(
+  plan: PerformancePlan,
+  preloadPlan: PerformancePlan | undefined,
+  fallbackText: string,
+  initialVisual: WorldStageProps["initialVisual"],
+): WorldPresentationPrepareRequest {
+  const manifestById = new Map(
+    [...createWorldAssetManifest(plan), ...(preloadPlan ? createWorldAssetManifest(preloadPlan) : [])]
+      .map((entry) => [entry.id, entry] as const),
+  );
+  const manifest = [...manifestById.values()];
+  if (initialVisual) {
+    manifest.push({ id: initialVisual.id, url: initialVisual.url, kind: "background" });
+  }
+  return { plan, manifest, initialAssetId: initialVisual?.id, fallbackText };
+}
+
+/** Thin React host that owns playback controls while adapters own rendering details. */
+export function WorldStage({ plan, preloadPlan, fallbackText, initialVisual, startCueIndex = 0, paused = false, skipVersion = 0, onCueComplete }: WorldStageProps) {
+  const hostRef = useRef<HTMLDivElement | null>(null);
+  const rendererRef = useRef<WorldPresentationRenderer | null>(null);
+  const checkpointRef = useLatestRef(onCueComplete);
+  const skipVersionRef = useRef(skipVersion);
+  const pausedRef = useLatestRef(paused);
+  const [fallback, setFallback] = useState<TextPresentationSnapshot | null>(null);
+  const initialVisualId = initialVisual?.id;
+  const initialVisualUrl = initialVisual?.url;
+  const request = useMemo(
+    () => initialRequest(
+      plan,
+      preloadPlan,
+      fallbackText,
+      initialVisualId && initialVisualUrl ? { id: initialVisualId, url: initialVisualUrl } : undefined,
+    ),
+    [fallbackText, initialVisualId, initialVisualUrl, plan, preloadPlan],
+  );
+
+  useEffect(() => {
+    const host = hostRef.current;
+    if (!host) return;
+    const controller = new AbortController();
+    let active = true;
+    let renderer: WorldPresentationRenderer | null = null;
+    const textRenderer = new TextWorldPresentationRenderer((snapshot) => {
+      if (active) setFallback(snapshot);
+    });
+
+    const activateTextFallback = async () => {
+      if (!active || renderer?.kind === "text") return;
+      renderer?.dispose();
+      renderer = textRenderer;
+      rendererRef.current = renderer;
+      await renderer.initialize(host);
+      await playPresentationPlan(renderer, request, { signal: controller.signal });
+    };
+
+    void (async () => {
+      try {
+        const module = await import("./pixiWorldPresentationRenderer") as PixiRendererModule;
+        if (!active) return;
+        renderer = module.createPixiWorldPresentationRenderer({ onContextLoss: () => void activateTextFallback() });
+        rendererRef.current = renderer;
+        await renderer.initialize(host);
+        if (!active) return;
+        if (pausedRef.current) renderer.pause();
+        await playPresentationPlan(renderer, request, {
+          signal: controller.signal,
+          startCueIndex,
+          onCueComplete: (cue) => checkpointRef.current?.(cue),
+        });
+      } catch {
+        if (!controller.signal.aborted) await activateTextFallback();
+      }
+    })();
+
+    return () => {
+      active = false;
+      controller.abort();
+      renderer?.dispose();
+      textRenderer.dispose();
+      rendererRef.current = null;
+    };
+  }, [checkpointRef, pausedRef, request, startCueIndex]);
+
+  useEffect(() => {
+    if (paused) rendererRef.current?.pause();
+    else rendererRef.current?.resume();
+  }, [paused]);
+
+  useEffect(() => {
+    if (skipVersion !== skipVersionRef.current) rendererRef.current?.skip();
+    skipVersionRef.current = skipVersion;
+  }, [skipVersion]);
+
+  return (
+    <div className="absolute inset-0 overflow-hidden bg-[#151816]" data-testid="world-stage">
+      <div ref={hostRef} className="absolute inset-0" data-testid="world-stage-canvas-host" />
+      {fallback ? (
+        <div className="absolute inset-0 grid place-items-center bg-[#151816] px-[max(10vw,32px)] text-center" data-testid="world-stage-text-fallback">
+          <p className="m-0 max-w-3xl font-serif text-xl leading-9 text-white/75">{fallback.text}</p>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/desktop/renderer/src/world/index.ts
+++ b/desktop/renderer/src/world/index.ts
@@ -1,6 +1,7 @@
 export { createWorldBridgeClient } from "./bridgeClient";
 export type { WorldBridgeClient } from "./bridgeClient";
 export { GalgameFocusMode } from "./GalgameFocusMode";
+export { WorldStage } from "./WorldStage";
 export { WorldAppSurface } from "./WorldAppSurface";
 export { SceneShot } from "./SceneShot";
 export { useWorldWorkspaceController } from "./useWorldWorkspaceController";

--- a/desktop/renderer/src/world/pixiCuePayload.test.ts
+++ b/desktop/renderer/src/world/pixiCuePayload.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { PresentationCue } from "./presentationProtocol";
+import { cuePayloadItems, normalizedCharacterPosition, numericCueValue, stringCueValue } from "./pixiCuePayload";
+
+describe("pixiCuePayload", () => {
+  it("reads compatible fields and rejects malformed plural items", () => {
+    assert.equal(stringCueValue({ asset_id: "mood-1" }, "assetId", "asset_id"), "mood-1");
+    assert.equal(numericCueValue({ duration_ms: 240 }, "durationMs", "duration_ms"), 240);
+    const cue: PresentationCue = {
+      schemaVersion: 1,
+      cueId: "cue-1",
+      planId: "plan-1",
+      sequence: 0,
+      kind: "sprites",
+      payload: { items: [{ id: "one" }, null, "bad"] },
+      parallelGroup: null,
+      blocking: false,
+      completionState: "completed",
+      skipState: "skipped",
+      checkpoint: false,
+    };
+    assert.deepEqual(cuePayloadItems(cue, "items"), [{ id: "one" }]);
+  });
+
+  it("maps named and implicit character slots", () => {
+    assert.equal(normalizedCharacterPosition("left", 0, 1), 0.22);
+    assert.equal(normalizedCharacterPosition("right", 0, 1), 0.78);
+    assert.equal(normalizedCharacterPosition(undefined, 1, 3), 0.5);
+  });
+});

--- a/desktop/renderer/src/world/pixiCuePayload.ts
+++ b/desktop/renderer/src/world/pixiCuePayload.ts
@@ -1,0 +1,36 @@
+import type { PresentationCue } from "./presentationProtocol";
+
+/** Returns the first non-empty string field in cue-compatible naming styles. */
+export function stringCueValue(record: Record<string, unknown>, ...keys: string[]): string | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "string" && value.trim()) return value;
+  }
+  return null;
+}
+
+/** Returns the first finite numeric field in cue-compatible naming styles. */
+export function numericCueValue(record: Record<string, unknown>, ...keys: string[]): number | null {
+  for (const key of keys) {
+    const value = record[key];
+    if (typeof value === "number" && Number.isFinite(value)) return value;
+  }
+  return null;
+}
+
+/** Resolves named or numeric character positions into one normalized stage slot. */
+export function normalizedCharacterPosition(value: unknown, index: number, total: number): number {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  if (value === "left") return 0.22;
+  if (value === "right") return 0.78;
+  if (value === "center") return 0.5;
+  return total <= 1 ? 0.5 : (index + 1) / (total + 1);
+}
+
+/** Reads a sanitized object array from a plural cue payload field. */
+export function cuePayloadItems(cue: PresentationCue, key: "items" | "tasks"): Record<string, unknown>[] {
+  const value = cue.payload[key];
+  return Array.isArray(value)
+    ? value.filter((item): item is Record<string, unknown> => typeof item === "object" && item !== null && !Array.isArray(item))
+    : [];
+}

--- a/desktop/renderer/src/world/pixiWorldAssetLoader.ts
+++ b/desktop/renderer/src/world/pixiWorldAssetLoader.ts
@@ -1,0 +1,38 @@
+import { Texture } from "pixi.js";
+import type { WorldAssetLoader } from "./worldAssetManager";
+
+export const maxWorldTextureDimension = 4096;
+
+/** Decodes one controlled local image into a Pixi texture with a hard GPU-size guard. */
+export const loadPixiWorldTexture: WorldAssetLoader<Texture> = (entry, { signal }) => (
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    const cleanup = () => {
+      image.onload = null;
+      image.onerror = null;
+      signal.removeEventListener("abort", abort);
+    };
+    const abort = () => {
+      image.src = "";
+      cleanup();
+      reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+    };
+    image.onload = () => {
+      cleanup();
+      if (image.naturalWidth > maxWorldTextureDimension || image.naturalHeight > maxWorldTextureDimension) {
+        reject(new Error(`world asset ${entry.id} exceeds ${maxWorldTextureDimension}px`));
+        return;
+      }
+      resolve({
+        asset: Texture.from(image, true),
+        sizeBytes: image.naturalWidth * image.naturalHeight * 4,
+      });
+    };
+    image.onerror = () => {
+      cleanup();
+      reject(new Error(`world asset ${entry.id} could not be decoded`));
+    };
+    signal.addEventListener("abort", abort, { once: true });
+    image.src = entry.url;
+  })
+);

--- a/desktop/renderer/src/world/pixiWorldPresentationRenderer.test.ts
+++ b/desktop/renderer/src/world/pixiWorldPresentationRenderer.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { maxWorldTextureDimension } from "./pixiWorldAssetLoader";
+import { worldStageLayerNames } from "./pixiWorldPresentationRenderer";
+
+describe("PixiWorldPresentationRenderer", () => {
+  it("keeps the required stage layer ordering explicit", () => {
+    assert.deepEqual(worldStageLayerNames, [
+      "BackgroundLayer",
+      "CharacterLayer",
+      "CgLayer",
+      "AtmosphereLayer",
+      "TransitionLayer",
+    ]);
+    assert.equal(maxWorldTextureDimension, 4096);
+  });
+});

--- a/desktop/renderer/src/world/pixiWorldPresentationRenderer.ts
+++ b/desktop/renderer/src/world/pixiWorldPresentationRenderer.ts
@@ -1,0 +1,425 @@
+import {
+  Application,
+  Container,
+  Graphics,
+  Sprite,
+  Texture,
+  type Ticker,
+} from "pixi.js";
+import type { PresentationCue } from "./presentationProtocol";
+import { cuePayloadItems, normalizedCharacterPosition, numericCueValue, stringCueValue } from "./pixiCuePayload";
+import { loadPixiWorldTexture } from "./pixiWorldAssetLoader";
+import { WorldAssetManager, type WorldAssetManifestEntry } from "./worldAssetManager";
+import { coverWorldStage, fitWorldStage, placeWorldCharacter, worldStageSize } from "./worldStageGeometry";
+import type { WorldPresentationPrepareRequest, WorldPresentationRenderer } from "./worldPresentationRenderer";
+
+export const worldStageLayerNames = [
+  "BackgroundLayer",
+  "CharacterLayer",
+  "CgLayer",
+  "AtmosphereLayer",
+  "TransitionLayer",
+] as const;
+
+type StageLayerName = typeof worldStageLayerNames[number];
+type ActiveDisplay = { display: Container; assetId: string | null };
+type ActiveAnimation = { finish: () => void };
+
+type PixiWorldPresentationRendererOptions = {
+  onContextLoss: () => void;
+  reducedMotion?: boolean;
+};
+
+/** PixiJS implementation of the presentation renderer boundary. */
+export class PixiWorldPresentationRenderer implements WorldPresentationRenderer {
+  readonly kind = "pixi" as const;
+  readonly #onContextLoss: () => void;
+  readonly #reducedMotion: boolean;
+  readonly #assets: WorldAssetManager<Texture>;
+  readonly #manifest = new Map<string, WorldAssetManifestEntry>();
+  readonly #layers = new Map<StageLayerName, Container>();
+  readonly #characters = new Map<string, ActiveDisplay>();
+  readonly #animations = new Set<ActiveAnimation>();
+  #app: Application | null = null;
+  #host: HTMLElement | null = null;
+  #stageRoot: Container | null = null;
+  #cameraRoot: Container | null = null;
+  #background: ActiveDisplay | null = null;
+  #cg: ActiveDisplay | null = null;
+  #curtain: Graphics | null = null;
+  #resizeObserver: ResizeObserver | null = null;
+  #contextLossHandler: ((event: Event) => void) | null = null;
+  #disposed = false;
+
+  constructor(options: PixiWorldPresentationRendererOptions) {
+    this.#onContextLoss = options.onContextLoss;
+    this.#reducedMotion = options.reducedMotion
+      ?? globalThis.matchMedia?.("(prefers-reduced-motion: reduce)").matches
+      ?? false;
+    this.#assets = new WorldAssetManager<Texture>({
+      loader: loadPixiWorldTexture,
+      destroy: (texture) => texture.destroy(true),
+      softBudgetBytes: 256 * 1024 * 1024,
+      maxEntries: 64,
+      timeoutMs: 10_000,
+    });
+  }
+
+  async initialize(host: HTMLElement): Promise<void> {
+    this.#assertActive();
+    if (this.#app) throw new Error("Pixi world renderer is already initialized");
+    this.#host = host;
+    const app = new Application();
+    await app.init({
+      resizeTo: host,
+      preference: "webgl",
+      antialias: true,
+      autoDensity: true,
+      resolution: Math.min(globalThis.devicePixelRatio || 1, 2),
+      backgroundColor: 0x151816,
+      backgroundAlpha: 1,
+      powerPreference: "high-performance",
+    });
+    this.#app = app;
+    app.canvas.style.width = "100%";
+    app.canvas.style.height = "100%";
+    app.canvas.style.display = "block";
+    host.replaceChildren(app.canvas);
+
+    const stageRoot = new Container({ label: "WorldLogicalStage" });
+    const cameraRoot = new Container({ label: "WorldCamera" });
+    cameraRoot.pivot.set(worldStageSize.width / 2, worldStageSize.height / 2);
+    cameraRoot.position.set(worldStageSize.width / 2, worldStageSize.height / 2);
+    stageRoot.addChild(cameraRoot);
+    this.#stageRoot = stageRoot;
+    this.#cameraRoot = cameraRoot;
+    for (const name of worldStageLayerNames) {
+      const layer = new Container({ label: name });
+      this.#layers.set(name, layer);
+      if (name === "TransitionLayer") stageRoot.addChild(layer);
+      else cameraRoot.addChild(layer);
+    }
+    app.stage.addChild(stageRoot);
+    this.#installDefaultBackground();
+    this.#resize();
+    this.#resizeObserver = new ResizeObserver(() => this.#resize());
+    this.#resizeObserver.observe(host);
+    this.#contextLossHandler = (event) => {
+      event.preventDefault();
+      this.#onContextLoss();
+    };
+    app.canvas.addEventListener("webglcontextlost", this.#contextLossHandler);
+  }
+
+  async prepare(request: WorldPresentationPrepareRequest, signal?: AbortSignal): Promise<void> {
+    this.#assertReady();
+    this.#assets.registerManifest(request.manifest);
+    request.manifest.forEach((entry) => this.#manifest.set(entry.id, entry));
+    await Promise.all(request.manifest.map(async (entry) => {
+      try {
+        await this.#assets.preload([entry.id], { signal });
+      } catch {
+        // Each cue owns its documented visual fallback; one bad asset cannot block the plan.
+      }
+    }));
+    if (request.initialAssetId) await this.#showBackground(request.initialAssetId, signal, 0);
+  }
+
+  async render(cue: PresentationCue, signal?: AbortSignal): Promise<void> {
+    await this.#renderCue(cue, signal, false);
+  }
+
+  async recover(cues: readonly PresentationCue[], signal?: AbortSignal): Promise<void> {
+    for (const cue of cues) await this.#renderCue(cue, signal, true);
+  }
+
+  async #renderCue(cue: PresentationCue, signal: AbortSignal | undefined, recovering: boolean): Promise<void> {
+    this.#assertReady();
+    if (cue.kind === "background") {
+      const assetId = stringCueValue(cue.payload, "assetId", "asset", "id");
+      if (assetId) {
+        const duration = recovering ? 0 : this.#duration(cue.payload, 320);
+        if (stringCueValue(cue.payload, "transition", "transitionKind", "transition_kind") === "curtain") {
+          await this.#showCurtain(true, signal, duration / 2);
+          await this.#showBackground(assetId, signal, 0);
+          await this.#showCurtain(false, signal, duration / 2);
+        } else {
+          await this.#showBackground(assetId, signal, duration);
+        }
+      }
+      return;
+    }
+    if (cue.kind === "sprites") {
+      await this.#showCharacters(cuePayloadItems(cue, "items"), signal, recovering ? 0 : 220);
+      return;
+    }
+    if (cue.kind === "cg") {
+      const task = cuePayloadItems(cue, "tasks").at(-1) ?? cue.payload;
+      const assetId = stringCueValue(task, "assetId", "asset", "id");
+      if (assetId) await this.#showCg(assetId, signal, recovering ? 0 : this.#duration(task, 320));
+      return;
+    }
+    if (cue.kind === "camera") {
+      await this.#moveCamera(cuePayloadItems(cue, "items"), signal, recovering);
+    }
+  }
+
+  pause(): void {
+    this.#app?.ticker.stop();
+  }
+
+  resume(): void {
+    if (!this.#disposed) this.#app?.ticker.start();
+  }
+
+  skip(): void {
+    [...this.#animations].forEach((animation) => animation.finish());
+  }
+
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    this.skip();
+    this.#resizeObserver?.disconnect();
+    this.#resizeObserver = null;
+    if (this.#app && this.#contextLossHandler) {
+      this.#app.canvas.removeEventListener("webglcontextlost", this.#contextLossHandler);
+    }
+    this.#contextLossHandler = null;
+    this.#releaseDisplay(this.#background);
+    this.#releaseDisplay(this.#cg);
+    this.#characters.forEach((display) => this.#releaseDisplay(display));
+    this.#characters.clear();
+    this.#background = null;
+    this.#cg = null;
+    this.#curtain = null;
+    this.#assets.dispose();
+    this.#app?.destroy({ removeView: true }, { children: true, texture: false, textureSource: false, context: true });
+    this.#app = null;
+    this.#host = null;
+    this.#stageRoot = null;
+    this.#cameraRoot = null;
+    this.#layers.clear();
+  }
+
+  #installDefaultBackground(): void {
+    const layer = this.#layer("BackgroundLayer");
+    const background = new Graphics({ label: "DefaultWorldBackground" })
+      .rect(0, 0, worldStageSize.width, worldStageSize.height)
+      .fill(0x151816);
+    layer.addChild(background);
+    this.#background = { display: background, assetId: null };
+  }
+
+  async #showBackground(assetId: string, signal: AbortSignal | undefined, durationMs: number): Promise<void> {
+    let texture: Texture;
+    try {
+      texture = await this.#assets.acquire(assetId, { signal });
+    } catch {
+      return;
+    }
+    const sprite = this.#coverSprite(texture, `Background:${assetId}`);
+    const previous = this.#background;
+    this.#layer("BackgroundLayer").addChild(sprite);
+    sprite.alpha = durationMs > 0 && previous ? 0 : 1;
+    this.#background = { display: sprite, assetId };
+    await this.#animate(durationMs, (progress) => { sprite.alpha = progress; }, signal);
+    if (previous) {
+      previous.display.removeFromParent();
+      this.#releaseDisplay(previous);
+    }
+  }
+
+  async #showCg(assetId: string, signal: AbortSignal | undefined, durationMs: number): Promise<void> {
+    let texture: Texture;
+    try {
+      texture = await this.#assets.acquire(assetId, { signal });
+    } catch {
+      return; // Failed CG retains the current stage and current CG.
+    }
+    const sprite = this.#coverSprite(texture, `Cg:${assetId}`);
+    const previous = this.#cg;
+    this.#layer("CgLayer").addChild(sprite);
+    sprite.alpha = durationMs > 0 ? 0 : 1;
+    this.#cg = { display: sprite, assetId };
+    await this.#animate(durationMs, (progress) => { sprite.alpha = progress; }, signal);
+    if (previous) {
+      previous.display.removeFromParent();
+      this.#releaseDisplay(previous);
+    }
+  }
+
+  async #showCharacters(items: Record<string, unknown>[], signal: AbortSignal | undefined, durationMs: number): Promise<void> {
+    const activeActors = new Set<string>();
+    await Promise.all(items.map(async (item, index) => {
+      const actorId = stringCueValue(item, "actorId", "actor_id", "id") ?? `actor-${index}`;
+      activeActors.add(actorId);
+      const requestedId = stringCueValue(item, "assetId", "asset", "moodAssetId", "mood_asset_id");
+      const avatarId = stringCueValue(item, "avatarAssetId", "avatar_asset_id");
+      const fallbackIds = requestedId ? this.#manifest.get(requestedId)?.fallbackIds ?? [] : [];
+      const candidates = [requestedId, avatarId, ...fallbackIds].filter((value): value is string => Boolean(value));
+      let active: ActiveDisplay | null = null;
+      for (const assetId of candidates) {
+        try {
+          const texture = await this.#assets.acquire(assetId, { signal });
+          const sprite = new Sprite({ texture, anchor: { x: 0.5, y: 1 }, label: `Character:${actorId}` });
+          const placement = placeWorldCharacter(normalizedCharacterPosition(item.position ?? item.normalizedX, index, items.length), texture.height);
+          sprite.position.set(placement.x, placement.y);
+          sprite.scale.set(placement.scale);
+          active = { display: sprite, assetId };
+          break;
+        } catch {
+          // Continue through mood -> avatar -> silhouette.
+        }
+      }
+      if (!active) {
+        const silhouette = new Graphics({ label: `CharacterSilhouette:${actorId}` })
+          .circle(0, -650, 130)
+          .roundRect(-190, -540, 380, 540, 170)
+          .fill({ color: 0x0b0d0c, alpha: 0.82 });
+        const placement = placeWorldCharacter(normalizedCharacterPosition(item.position ?? item.normalizedX, index, items.length), 800);
+        silhouette.position.set(placement.x, placement.y);
+        active = { display: silhouette, assetId: null };
+      }
+      const previous = this.#characters.get(actorId);
+      this.#layer("CharacterLayer").addChild(active.display);
+      active.display.alpha = durationMs > 0 && !this.#reducedMotion ? 0 : 1;
+      this.#characters.set(actorId, active);
+      await this.#animate(durationMs, (progress) => { active!.display.alpha = progress; }, signal);
+      if (previous) {
+        previous.display.removeFromParent();
+        this.#releaseDisplay(previous);
+      }
+    }));
+    for (const [actorId, display] of this.#characters) {
+      if (activeActors.has(actorId)) continue;
+      display.display.removeFromParent();
+      this.#releaseDisplay(display);
+      this.#characters.delete(actorId);
+    }
+  }
+
+  async #showCurtain(visible: boolean, signal: AbortSignal | undefined, durationMs: number): Promise<void> {
+    if (!this.#curtain) {
+      this.#curtain = new Graphics({ label: "WorldCurtain" })
+        .rect(0, 0, worldStageSize.width, worldStageSize.height)
+        .fill(0x080908);
+      this.#curtain.alpha = 0;
+      this.#layer("TransitionLayer").addChild(this.#curtain);
+    }
+    const curtain = this.#curtain;
+    const start = curtain.alpha;
+    const target = visible ? 1 : 0;
+    await this.#animate(durationMs, (progress) => {
+      curtain.alpha = start + (target - start) * progress;
+    }, signal);
+  }
+
+  async #moveCamera(items: Record<string, unknown>[], signal?: AbortSignal, recovering = false): Promise<void> {
+    const camera = this.#cameraRoot;
+    if (!camera || this.#reducedMotion) return;
+    for (const item of items) {
+      const startX = camera.position.x;
+      const startY = camera.position.y;
+      const startScale = camera.scale.x;
+      const targetX = worldStageSize.width / 2 + (numericCueValue(item, "x", "offsetX", "offset_x") ?? 0);
+      const targetY = worldStageSize.height / 2 + (numericCueValue(item, "y", "offsetY", "offset_y") ?? 0);
+      const targetScale = Math.max(0.8, Math.min(1.4, numericCueValue(item, "zoom", "scale") ?? startScale));
+      await this.#animate(recovering ? 0 : this.#duration(item, 400), (progress) => {
+        camera.position.set(
+          startX + (targetX - startX) * progress,
+          startY + (targetY - startY) * progress,
+        );
+        camera.scale.set(startScale + (targetScale - startScale) * progress);
+      }, signal);
+    }
+  }
+
+  #coverSprite(texture: Texture, label: string): Sprite {
+    const fit = coverWorldStage(texture.width, texture.height);
+    const sprite = new Sprite({ texture, label });
+    sprite.position.set(fit.x, fit.y);
+    sprite.scale.set(fit.scale);
+    return sprite;
+  }
+
+  async #animate(durationMs: number, update: (progress: number) => void, signal?: AbortSignal): Promise<void> {
+    const app = this.#app;
+    if (!app || this.#reducedMotion || durationMs <= 0) {
+      update(1);
+      return;
+    }
+    await new Promise<void>((resolve, reject) => {
+      let elapsed = 0;
+      let settled = false;
+      const cleanup = () => {
+        app.ticker.remove(tick);
+        signal?.removeEventListener("abort", abort);
+        this.#animations.delete(animation);
+      };
+      const finish = () => {
+        if (settled) return;
+        settled = true;
+        update(1);
+        cleanup();
+        resolve();
+      };
+      const abort = () => {
+        if (settled) return;
+        settled = true;
+        cleanup();
+        reject(signal?.reason ?? new DOMException("Aborted", "AbortError"));
+      };
+      const tick = (ticker: Ticker) => {
+        elapsed += ticker.elapsedMS;
+        const progress = Math.min(1, elapsed / durationMs);
+        update(progress);
+        if (progress === 1) finish();
+      };
+      const animation = { finish };
+      this.#animations.add(animation);
+      signal?.addEventListener("abort", abort, { once: true });
+      app.ticker.add(tick);
+    });
+  }
+
+  #duration(payload: Record<string, unknown>, fallback: number): number {
+    if (this.#reducedMotion) return 0;
+    return Math.max(0, numericCueValue(payload, "durationMs", "duration_ms") ?? fallback);
+  }
+
+  #resize(): void {
+    const host = this.#host;
+    const stage = this.#stageRoot;
+    if (!host || !stage) return;
+    const fit = fitWorldStage(Math.max(1, host.clientWidth), Math.max(1, host.clientHeight));
+    stage.position.set(fit.offsetX, fit.offsetY);
+    stage.scale.set(fit.scale);
+  }
+
+  #releaseDisplay(active: ActiveDisplay | null): void {
+    if (!active) return;
+    active.display.destroy({ children: true, texture: false, textureSource: false });
+    if (active.assetId) this.#assets.release(active.assetId);
+  }
+
+  #layer(name: StageLayerName): Container {
+    const layer = this.#layers.get(name);
+    if (!layer) throw new Error(`Pixi world stage layer ${name} is unavailable`);
+    return layer;
+  }
+
+  #assertReady(): void {
+    this.#assertActive();
+    if (!this.#app) throw new Error("Pixi world renderer is not initialized");
+  }
+
+  #assertActive(): void {
+    if (this.#disposed) throw new Error("Pixi world renderer is disposed");
+  }
+}
+
+/** Creates the graphical adapter without exposing PixiJS to React callers. */
+export function createPixiWorldPresentationRenderer(options: PixiWorldPresentationRendererOptions) {
+  return new PixiWorldPresentationRenderer(options);
+}

--- a/desktop/renderer/src/world/useWorldWorkspaceController.ts
+++ b/desktop/renderer/src/world/useWorldWorkspaceController.ts
@@ -134,6 +134,39 @@ export function useWorldWorkspaceController(client: WorldBridgeClient = createWo
     });
   }, [client, run, state.world]);
 
+  const pausePresentation = useCallback(async () => {
+    if (!state.world) return;
+    await run(
+      () => client.pausePresentation(state.world!.id),
+      (presentation) => setState((current) => current.world ? ({
+        ...current,
+        world: { ...current.world, presentation },
+      }) : current),
+    );
+  }, [client, run, state.world]);
+
+  const resumePresentation = useCallback(async () => {
+    if (!state.world) return;
+    await run(
+      () => client.resumePresentation(state.world!.id),
+      (presentation) => setState((current) => current.world ? ({
+        ...current,
+        world: { ...current.world, presentation },
+      }) : current),
+    );
+  }, [client, run, state.world]);
+
+  const checkpointPresentation = useCallback(async (planId: string, cueIndex: number) => {
+    if (!state.world) return;
+    await run(
+      () => client.checkpointPresentation(state.world!.id, planId, cueIndex),
+      (presentation) => setState((current) => current.world ? ({
+        ...current,
+        world: { ...current.world, presentation },
+      }) : current),
+    );
+  }, [client, run, state.world]);
+
   return useMemo(() => ({
     ...state,
     activeOc: selectActiveOc(state.world),
@@ -146,5 +179,8 @@ export function useWorldWorkspaceController(client: WorldBridgeClient = createWo
     cancelRun,
     catchUp,
     redrawShot,
-  }), [advance, cancelRun, catchUp, loadWorld, redrawShot, reloadWorlds, resolveBarrier, state, submitAction, switchOc]);
+    pausePresentation,
+    resumePresentation,
+    checkpointPresentation,
+  }), [advance, cancelRun, catchUp, checkpointPresentation, loadWorld, pausePresentation, redrawShot, reloadWorlds, resolveBarrier, resumePresentation, state, submitAction, switchOc]);
 }

--- a/desktop/renderer/src/world/worldAssetManager.test.ts
+++ b/desktop/renderer/src/world/worldAssetManager.test.ts
@@ -1,0 +1,127 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { WorldAssetManager, WorldAssetTimeoutError } from "./worldAssetManager";
+
+type FakeAsset = { id: string };
+
+describe("WorldAssetManager", () => {
+  it("deduplicates preload, reference counts current assets, and evicts unused LRU entries", async () => {
+    const loads: string[] = [];
+    const destroyed: string[] = [];
+    const manager = new WorldAssetManager<FakeAsset>({
+      softBudgetBytes: 12,
+      maxEntries: 2,
+      loader: async (entry) => {
+        loads.push(entry.id);
+        return { asset: { id: entry.id }, sizeBytes: 8 };
+      },
+      destroy: (asset) => destroyed.push(asset.id),
+    });
+    manager.registerManifest([
+      { id: "bg-1", url: "shiori-asset://local/bg-1", kind: "background" },
+      { id: "bg-2", url: "shiori-asset://local/bg-2", kind: "background" },
+    ]);
+
+    const [first, duplicate] = await Promise.all([
+      manager.acquire("bg-1"),
+      manager.acquire("bg-1"),
+    ]);
+    assert.equal(first, duplicate);
+    assert.deepEqual(loads, ["bg-1"]);
+    manager.release("bg-1");
+    await manager.preload(["bg-2"]);
+    assert.deepEqual(destroyed, ["bg-2"]);
+    assert.equal(manager.stats().retainedEntries, 1);
+
+    manager.release("bg-1");
+    assert.deepEqual(destroyed, ["bg-2"]);
+    manager.dispose();
+    assert.deepEqual(destroyed, ["bg-2", "bg-1"]);
+    assert.equal(manager.stats().manifestEntries, 0);
+  });
+
+  it("rejects URLs that bypass the controlled local asset transport", () => {
+    const manager = new WorldAssetManager<FakeAsset>({
+      loader: async (entry) => ({ asset: { id: entry.id } }),
+      destroy: () => undefined,
+    });
+    assert.throws(() => manager.registerManifest([
+      { id: "private", url: "file:///C:/private.png", kind: "cg" },
+    ]), /controlled local asset transport/);
+  });
+
+  it("replaces an unused manifest URL before the asset is loaded again", async () => {
+    const urls: string[] = [];
+    const manager = new WorldAssetManager<FakeAsset>({
+      softBudgetBytes: 0,
+      loader: async (entry) => {
+        urls.push(entry.url);
+        return { asset: { id: entry.id }, sizeBytes: 1 };
+      },
+      destroy: () => undefined,
+    });
+    manager.registerManifest([{ id: "bg", url: "shiori-asset://local/old", kind: "background" }]);
+    await manager.preload(["bg"]);
+    manager.registerManifest([{ id: "bg", url: "shiori-asset://local/new", kind: "background" }]);
+    await manager.preload(["bg"]);
+    assert.deepEqual(urls, ["shiori-asset://local/old", "shiori-asset://local/new"]);
+    manager.dispose();
+  });
+
+  it("supports caller cancellation without cancelling a shared load", async () => {
+    let finish: ((value: { asset: FakeAsset; sizeBytes: number }) => void) | undefined;
+    const manager = new WorldAssetManager<FakeAsset>({
+      loader: async () => await new Promise((resolve) => { finish = resolve; }),
+      destroy: () => undefined,
+    });
+    manager.registerManifest([{ id: "cg", url: "shiori-asset://local/cg", kind: "cg" }]);
+    const controller = new AbortController();
+    const cancelled = manager.preload(["cg"], { signal: controller.signal });
+    const shared = manager.preload(["cg"]);
+    controller.abort(new Error("cancelled by scene change"));
+    await assert.rejects(cancelled, /scene change/);
+    finish?.({ asset: { id: "cg" }, sizeBytes: 4 });
+    assert.equal((await shared).get("cg")?.id, "cg");
+    manager.dispose();
+  });
+
+  it("aborts stalled loaders at the configured timeout", async () => {
+    const manager = new WorldAssetManager<FakeAsset>({
+      timeoutMs: 5,
+      loader: async (_entry, { signal }) => await new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => reject(new Error("loader aborted")), { once: true });
+      }),
+      destroy: () => undefined,
+    });
+    manager.registerManifest([{ id: "slow", url: "shiori-asset://local/slow", kind: "cg" }]);
+    await assert.rejects(manager.preload(["slow"]), WorldAssetTimeoutError);
+    assert.equal(manager.stats().pendingEntries, 0);
+    manager.dispose();
+  });
+
+  it("cancels pending loads when disposed and remains idempotent", async () => {
+    let aborted = false;
+    const manager = new WorldAssetManager<FakeAsset>({
+      loader: async (_entry, { signal }) => await new Promise((_resolve, reject) => {
+        signal.addEventListener("abort", () => {
+          aborted = true;
+          reject(new Error("disposed"));
+        }, { once: true });
+      }),
+      destroy: () => undefined,
+    });
+    manager.registerManifest([{ id: "pending", url: "shiori-asset://local/pending", kind: "cg" }]);
+    const pending = manager.preload(["pending"]);
+    manager.dispose();
+    manager.dispose();
+    await assert.rejects(pending, /disposed/);
+    assert.equal(aborted, true);
+    assert.deepEqual(manager.stats(), {
+      manifestEntries: 0,
+      readyEntries: 0,
+      pendingEntries: 0,
+      retainedEntries: 0,
+      totalBytes: 0,
+    });
+  });
+});

--- a/desktop/renderer/src/world/worldAssetManager.ts
+++ b/desktop/renderer/src/world/worldAssetManager.ts
@@ -1,0 +1,238 @@
+const controlledLocalAssetPattern = /^shiori-asset:\/\/local\/[^/?#]+$/;
+
+export type WorldAssetKind = "background" | "character" | "cg" | "avatar";
+
+/** One renderer-safe local asset addressable by presentation cues. */
+export type WorldAssetManifestEntry = {
+  id: string;
+  url: string;
+  kind: WorldAssetKind;
+  estimatedBytes?: number;
+  fallbackIds?: string[];
+};
+
+export type LoadedWorldAsset<TAsset> = {
+  asset: TAsset;
+  sizeBytes?: number;
+};
+
+export type WorldAssetLoader<TAsset> = (
+  entry: WorldAssetManifestEntry,
+  options: { signal: AbortSignal },
+) => Promise<LoadedWorldAsset<TAsset>>;
+
+type ManagedAsset<TAsset> = {
+  entry: WorldAssetManifestEntry;
+  asset: TAsset | null;
+  load: Promise<TAsset> | null;
+  loadController: AbortController | null;
+  refCount: number;
+  lastAccess: number;
+  sizeBytes: number;
+};
+
+export type WorldAssetManagerOptions<TAsset> = {
+  loader: WorldAssetLoader<TAsset>;
+  destroy: (asset: TAsset) => void;
+  softBudgetBytes?: number;
+  maxEntries?: number;
+  timeoutMs?: number;
+};
+
+export class WorldAssetTimeoutError extends Error {
+  constructor(readonly assetId: string, timeoutMs: number) {
+    super(`world asset ${assetId} timed out after ${timeoutMs}ms`);
+    this.name = "WorldAssetTimeoutError";
+  }
+}
+
+/** Owns world-stage asset loading, retention, eviction, cancellation, and disposal. */
+export class WorldAssetManager<TAsset> {
+  readonly #assets = new Map<string, ManagedAsset<TAsset>>();
+  readonly #loader: WorldAssetLoader<TAsset>;
+  readonly #destroy: (asset: TAsset) => void;
+  readonly #softBudgetBytes: number;
+  readonly #maxEntries: number;
+  readonly #timeoutMs: number;
+  #accessSequence = 0;
+  #disposed = false;
+
+  constructor(options: WorldAssetManagerOptions<TAsset>) {
+    this.#loader = options.loader;
+    this.#destroy = options.destroy;
+    this.#softBudgetBytes = options.softBudgetBytes ?? 256 * 1024 * 1024;
+    this.#maxEntries = options.maxEntries ?? 64;
+    this.#timeoutMs = options.timeoutMs ?? 10_000;
+  }
+
+  /** Registers validated opaque local URLs without starting I/O. */
+  registerManifest(entries: readonly WorldAssetManifestEntry[]): void {
+    this.#assertActive();
+    for (const entry of entries) {
+      if (!entry.id.trim()) throw new Error("world asset id is required");
+      if (!controlledLocalAssetPattern.test(entry.url)) {
+        throw new Error(`world asset ${entry.id} must use the controlled local asset transport`);
+      }
+      const existing = this.#assets.get(entry.id);
+      if (existing && existing.entry.url !== entry.url) {
+        if (existing.refCount > 0 || existing.load) {
+          throw new Error(`cannot replace active world asset ${entry.id}`);
+        }
+        this.#evict(existing);
+        existing.entry = { ...entry, fallbackIds: entry.fallbackIds ? [...entry.fallbackIds] : undefined };
+        existing.lastAccess = this.#touch();
+        existing.sizeBytes = Math.max(0, entry.estimatedBytes ?? 0);
+      }
+      if (!this.#assets.has(entry.id)) {
+        this.#assets.set(entry.id, {
+          entry: { ...entry, fallbackIds: entry.fallbackIds ? [...entry.fallbackIds] : undefined },
+          asset: null,
+          load: null,
+          loadController: null,
+          refCount: 0,
+          lastAccess: this.#touch(),
+          sizeBytes: Math.max(0, entry.estimatedBytes ?? 0),
+        });
+      }
+    }
+  }
+
+  /** Preloads assets without retaining them as part of the current stage. */
+  async preload(ids: readonly string[], options: { signal?: AbortSignal; timeoutMs?: number } = {}) {
+    const assets = await Promise.all(ids.map(async (id) => [id, await this.#load(id, options)] as const));
+    this.#enforceBudget();
+    return new Map(assets);
+  }
+
+  /** Loads and retains one asset until a matching release. */
+  async acquire(id: string, options: { signal?: AbortSignal; timeoutMs?: number } = {}): Promise<TAsset> {
+    const asset = await this.#load(id, options);
+    const managed = this.#required(id);
+    managed.refCount += 1;
+    managed.lastAccess = this.#touch();
+    return asset;
+  }
+
+  /** Releases one active reference and evicts unused LRU entries over budget. */
+  release(id: string): void {
+    this.#assertActive();
+    const managed = this.#required(id);
+    if (managed.refCount === 0) throw new Error(`world asset ${id} has no active reference`);
+    managed.refCount -= 1;
+    managed.lastAccess = this.#touch();
+    this.#enforceBudget();
+  }
+
+  /** Returns observable lifecycle data for diagnostics and leak tests. */
+  stats() {
+    const ready = [...this.#assets.values()].filter((item) => item.asset !== null);
+    return {
+      manifestEntries: this.#assets.size,
+      readyEntries: ready.length,
+      pendingEntries: [...this.#assets.values()].filter((item) => item.load !== null).length,
+      retainedEntries: ready.filter((item) => item.refCount > 0).length,
+      totalBytes: ready.reduce((total, item) => total + item.sizeBytes, 0),
+    };
+  }
+
+  /** Cancels pending loads and destroys every owned asset exactly once. */
+  dispose(): void {
+    if (this.#disposed) return;
+    this.#disposed = true;
+    for (const managed of this.#assets.values()) {
+      managed.loadController?.abort();
+      if (managed.asset !== null) this.#destroy(managed.asset);
+      managed.asset = null;
+      managed.load = null;
+      managed.loadController = null;
+      managed.refCount = 0;
+    }
+    this.#assets.clear();
+  }
+
+  async #load(id: string, options: { signal?: AbortSignal; timeoutMs?: number }): Promise<TAsset> {
+    this.#assertActive();
+    const managed = this.#required(id);
+    managed.lastAccess = this.#touch();
+    if (managed.asset !== null) return managed.asset;
+    if (!managed.load) {
+      const controller = new AbortController();
+      const timeoutMs = options.timeoutMs ?? this.#timeoutMs;
+      let timedOut = false;
+      const timeout = setTimeout(() => {
+        timedOut = true;
+        controller.abort();
+      }, timeoutMs);
+      managed.loadController = controller;
+      managed.load = this.#loader(managed.entry, { signal: controller.signal })
+        .then((loaded) => {
+          if (this.#disposed) {
+            this.#destroy(loaded.asset);
+            throw new Error("world asset manager is disposed");
+          }
+          managed.asset = loaded.asset;
+          managed.sizeBytes = Math.max(0, loaded.sizeBytes ?? managed.entry.estimatedBytes ?? 0);
+          managed.lastAccess = this.#touch();
+          return loaded.asset;
+        })
+        .catch((error) => {
+          if (timedOut) throw new WorldAssetTimeoutError(id, timeoutMs);
+          throw error;
+        })
+        .finally(() => {
+          clearTimeout(timeout);
+          managed.load = null;
+          managed.loadController = null;
+        });
+    }
+    return await this.#waitForCaller(managed.load, options.signal);
+  }
+
+  async #waitForCaller(load: Promise<TAsset>, signal?: AbortSignal): Promise<TAsset> {
+    if (!signal) return await load;
+    if (signal.aborted) throw signal.reason ?? new DOMException("Aborted", "AbortError");
+    return await new Promise<TAsset>((resolve, reject) => {
+      const abort = () => reject(signal.reason ?? new DOMException("Aborted", "AbortError"));
+      signal.addEventListener("abort", abort, { once: true });
+      void load.then(resolve, reject).finally(() => signal.removeEventListener("abort", abort));
+    });
+  }
+
+  #enforceBudget(): void {
+    const unused = [...this.#assets.values()]
+      .filter((item) => item.asset !== null && item.refCount === 0)
+      .sort((left, right) => left.lastAccess - right.lastAccess);
+    let readyCount = [...this.#assets.values()].filter((item) => item.asset !== null).length;
+    let totalBytes = [...this.#assets.values()].reduce(
+      (total, item) => total + (item.asset === null ? 0 : item.sizeBytes),
+      0,
+    );
+    for (const managed of unused) {
+      if (readyCount <= this.#maxEntries && totalBytes <= this.#softBudgetBytes) break;
+      totalBytes -= managed.sizeBytes;
+      readyCount -= 1;
+      this.#evict(managed);
+    }
+  }
+
+  #evict(managed: ManagedAsset<TAsset>): void {
+    if (managed.asset !== null) this.#destroy(managed.asset);
+    managed.asset = null;
+    managed.sizeBytes = Math.max(0, managed.entry.estimatedBytes ?? 0);
+  }
+
+  #required(id: string): ManagedAsset<TAsset> {
+    const managed = this.#assets.get(id);
+    if (!managed) throw new Error(`unknown world asset ${id}`);
+    return managed;
+  }
+
+  #assertActive(): void {
+    if (this.#disposed) throw new Error("world asset manager is disposed");
+  }
+
+  #touch(): number {
+    this.#accessSequence += 1;
+    return this.#accessSequence;
+  }
+}

--- a/desktop/renderer/src/world/worldPresentationAssets.test.ts
+++ b/desktop/renderer/src/world/worldPresentationAssets.test.ts
@@ -1,0 +1,64 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { PerformancePlan } from "./presentationProtocol";
+import { hydrateWorldPresentationAssets } from "./worldPresentationAssets";
+import { createWorldAssetManifest } from "./worldPresentationRenderer";
+
+describe("worldPresentationAssets", () => {
+  it("turns snapshot mood and avatar paths into a controlled Pixi manifest", () => {
+    const plan: PerformancePlan = {
+      schemaVersion: 1,
+      planId: "plan-1",
+      worldId: "world-1",
+      eventId: "event-1",
+      sourceSequence: 1,
+      cues: [{
+        schemaVersion: 1,
+        cueId: "cue-1",
+        planId: "plan-1",
+        sequence: 0,
+        kind: "sprites",
+        payload: {
+          items: [{
+            actor_id: "resident-1",
+            mood: "平静",
+            assetId: "asset-mood",
+            image_path: "C:/world-assets/mood.png",
+            fallbackIds: ["asset-avatar"],
+            fallbackAssets: [{
+              assetId: "asset-avatar",
+              image_path: "C:/world-assets/avatar.png",
+            }],
+          }],
+        },
+        parallelGroup: null,
+        blocking: false,
+        completionState: "completed",
+        skipState: "skipped",
+        checkpoint: false,
+      }],
+    };
+    const hydrated = hydrateWorldPresentationAssets(
+      plan,
+      (path) => `shiori-asset://local/${path.includes("mood") ? "mood-token" : "avatar-token"}`,
+    );
+
+    assert.doesNotMatch(JSON.stringify(hydrated), /C:\/world-assets/);
+    assert.deepEqual(createWorldAssetManifest(hydrated), [
+      {
+        id: "asset-mood",
+        url: "shiori-asset://local/mood-token",
+        kind: "character",
+        fallbackIds: ["asset-avatar"],
+      },
+      {
+        id: "asset-avatar",
+        url: "shiori-asset://local/avatar-token",
+        kind: "character",
+        fallbackIds: undefined,
+      },
+    ]);
+  });
+});

--- a/desktop/renderer/src/world/worldPresentationAssets.ts
+++ b/desktop/renderer/src/world/worldPresentationAssets.ts
@@ -1,0 +1,37 @@
+import { unavailableLocalAssetUrl } from "../../../src/shared";
+import { toFileUrl, type LocalAssetUrlResolver } from "../shared/format";
+import type { PerformancePlan } from "./presentationProtocol";
+
+function hydrateValue(value: unknown, resolveLocalAssetUrl: LocalAssetUrlResolver): unknown {
+  if (Array.isArray(value)) return value.map((item) => hydrateValue(item, resolveLocalAssetUrl));
+  if (typeof value !== "object" || value === null) return value;
+
+  const source = value as Record<string, unknown>;
+  const hydrated = Object.fromEntries(
+    Object.entries(source)
+      .filter(([key]) => key !== "image_path")
+      .map(([key, item]) => [key, hydrateValue(item, resolveLocalAssetUrl)]),
+  );
+  if (typeof source.image_path === "string") {
+    const imageUrl = resolveLocalAssetUrl(source.image_path);
+    if (imageUrl !== unavailableLocalAssetUrl && typeof hydrated.imageUrl !== "string") {
+      hydrated.imageUrl = imageUrl;
+    }
+  }
+  return hydrated;
+}
+
+/** Replaces trusted bridge paths with opaque local URLs before Pixi sees a plan. */
+export function hydrateWorldPresentationAssets(
+  plan: PerformancePlan,
+  resolveLocalAssetUrl?: LocalAssetUrlResolver,
+): PerformancePlan {
+  const resolver = resolveLocalAssetUrl ?? toFileUrl;
+  return {
+    ...plan,
+    cues: plan.cues.map((cue) => ({
+      ...cue,
+      payload: hydrateValue(cue.payload, resolver) as Record<string, unknown>,
+    })),
+  };
+}

--- a/desktop/renderer/src/world/worldPresentationRenderer.test.ts
+++ b/desktop/renderer/src/world/worldPresentationRenderer.test.ts
@@ -1,0 +1,103 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { PerformancePlan, PresentationCue } from "./presentationProtocol";
+import {
+  createWorldAssetManifest,
+  playPresentationPlan,
+  TextWorldPresentationRenderer,
+  type WorldPresentationRenderer,
+} from "./worldPresentationRenderer";
+
+function cue(sequence: number, kind: PresentationCue["kind"], payload: Record<string, unknown>): PresentationCue {
+  return {
+    schemaVersion: 1,
+    cueId: `cue-${sequence}`,
+    planId: "plan-1",
+    sequence,
+    kind,
+    payload,
+    parallelGroup: null,
+    blocking: kind === "dialogue",
+    completionState: "completed",
+    skipState: "skipped",
+    checkpoint: kind === "dialogue",
+  };
+}
+
+function plan(cues: PresentationCue[]): PerformancePlan {
+  return { schemaVersion: 1, planId: "plan-1", worldId: "world-1", eventId: "event-1", sourceSequence: 1, cues };
+}
+
+describe("worldPresentationRenderer", () => {
+  it("plays cues in order and checkpoints only after rendering", async () => {
+    const events: string[] = [];
+    const renderer: WorldPresentationRenderer = {
+      kind: "pixi",
+      initialize: async () => undefined,
+      prepare: async () => { events.push("prepare"); },
+      recover: async () => undefined,
+      render: async (item) => { events.push(`render:${item.cueId}`); },
+      pause: () => undefined,
+      resume: () => undefined,
+      skip: () => undefined,
+      dispose: () => undefined,
+    };
+    const value = plan([cue(0, "background", {}), cue(1, "dialogue", { content: "到了。" })]);
+    await playPresentationPlan(renderer, { plan: value, manifest: [], fallbackText: "fallback" }, {
+      onCueComplete: (item) => { events.push(`checkpoint:${item.cueId}`); },
+    });
+    assert.deepEqual(events, ["prepare", "render:cue-0", "render:cue-1", "checkpoint:cue-1"]);
+  });
+
+  it("reconstructs completed visuals without repeating their checkpoints", async () => {
+    const rendered: string[] = [];
+    const recovered: string[] = [];
+    const renderer: WorldPresentationRenderer = {
+      kind: "pixi",
+      initialize: async () => undefined,
+      prepare: async () => undefined,
+      recover: async (items) => { recovered.push(...items.map((item) => item.cueId)); },
+      render: async (item) => { rendered.push(item.cueId); },
+      pause: () => undefined,
+      resume: () => undefined,
+      skip: () => undefined,
+      dispose: () => undefined,
+    };
+    const value = plan([
+      cue(0, "background", {}),
+      cue(1, "sprites", {}),
+      cue(2, "dialogue", { content: "继续。" }),
+    ]);
+
+    await playPresentationPlan(
+      renderer,
+      { plan: value, manifest: [], fallbackText: "fallback" },
+      { startCueIndex: 2 },
+    );
+
+    assert.deepEqual(recovered, ["cue-0", "cue-1"]);
+    assert.deepEqual(rendered, ["cue-2"]);
+  });
+
+  it("keeps the latest readable dialogue in the text adapter", async () => {
+    const snapshots: string[] = [];
+    const renderer = new TextWorldPresentationRenderer((snapshot) => snapshots.push(snapshot.text));
+    await renderer.prepare({ plan: plan([]), manifest: [], fallbackText: "事件继续。" });
+    await renderer.render(cue(0, "dialogue", { content: "你终于来了。" }));
+    await renderer.render(cue(1, "camera", { kind: "pan" }));
+    assert.deepEqual(snapshots, ["事件继续。", "你终于来了。"]) ;
+    assert.equal(renderer.snapshot().cueId, "cue-0");
+  });
+
+  it("builds a manifest only from explicit controlled asset references", () => {
+    const value = plan([
+      cue(0, "background", { asset: "harbor", assetUrl: "shiori-asset://local/harbor-token" }),
+      cue(1, "sprites", { items: [{ actorId: "oc-1", assetId: "mood-alert", imageUrl: "shiori-asset://local/mood-token", fallbackIds: ["avatar-1"] }] }),
+      cue(2, "cg", { tasks: [{ assetId: "remote", url: "https://example.com/cg.png" }] }),
+    ]);
+    assert.deepEqual(createWorldAssetManifest(value), [
+      { id: "harbor", url: "shiori-asset://local/harbor-token", kind: "background", fallbackIds: undefined },
+      { id: "mood-alert", url: "shiori-asset://local/mood-token", kind: "character", fallbackIds: ["avatar-1"] },
+    ]);
+  });
+});

--- a/desktop/renderer/src/world/worldPresentationRenderer.ts
+++ b/desktop/renderer/src/world/worldPresentationRenderer.ts
@@ -1,0 +1,152 @@
+import type { PerformancePlan, PresentationCue } from "./presentationProtocol";
+import type { WorldAssetManifestEntry } from "./worldAssetManager";
+
+export type WorldPresentationPrepareRequest = {
+  plan: PerformancePlan;
+  manifest: readonly WorldAssetManifestEntry[];
+  initialAssetId?: string;
+  fallbackText: string;
+};
+
+/** Rendering boundary shared by the Pixi stage and its text-only fallback. */
+export interface WorldPresentationRenderer {
+  readonly kind: "pixi" | "text";
+  initialize(host: HTMLElement): Promise<void>;
+  prepare(request: WorldPresentationPrepareRequest, signal?: AbortSignal): Promise<void>;
+  recover(cues: readonly PresentationCue[], signal?: AbortSignal): Promise<void>;
+  render(cue: PresentationCue, signal?: AbortSignal): Promise<void>;
+  pause(): void;
+  resume(): void;
+  skip(): void;
+  dispose(): void;
+}
+
+export type TextPresentationSnapshot = {
+  text: string;
+  cueId: string | null;
+};
+
+function cueText(cue: PresentationCue): string {
+  const value = cue.payload.content ?? cue.payload.text;
+  return typeof value === "string" && value.trim() ? value : "";
+}
+
+/** Maintains readable narrative state when graphical presentation is unavailable. */
+export class TextWorldPresentationRenderer implements WorldPresentationRenderer {
+  readonly kind = "text" as const;
+  #snapshot: TextPresentationSnapshot = { text: "", cueId: null };
+  #onChange: (snapshot: TextPresentationSnapshot) => void;
+  #disposed = false;
+
+  constructor(onChange: (snapshot: TextPresentationSnapshot) => void = () => undefined) {
+    this.#onChange = onChange;
+  }
+
+  async initialize(): Promise<void> {
+    this.#assertActive();
+  }
+
+  async prepare(request: WorldPresentationPrepareRequest): Promise<void> {
+    this.#assertActive();
+    this.#publish({ text: request.fallbackText, cueId: null });
+  }
+
+  async recover(cues: readonly PresentationCue[]): Promise<void> {
+    for (const cue of cues) await this.render(cue);
+  }
+
+  async render(cue: PresentationCue): Promise<void> {
+    this.#assertActive();
+    const text = cueText(cue);
+    if (text) this.#publish({ text, cueId: cue.cueId });
+  }
+
+  pause(): void {}
+
+  resume(): void {}
+
+  skip(): void {}
+
+  dispose(): void {
+    this.#disposed = true;
+    this.#onChange = () => undefined;
+  }
+
+  snapshot(): TextPresentationSnapshot {
+    return { ...this.#snapshot };
+  }
+
+  #publish(snapshot: TextPresentationSnapshot): void {
+    this.#snapshot = snapshot;
+    this.#onChange(this.snapshot());
+  }
+
+  #assertActive(): void {
+    if (this.#disposed) throw new Error("text presentation renderer is disposed");
+  }
+}
+
+/** Runs one plan in order while keeping persistence checkpoints outside renderers. */
+export async function playPresentationPlan(
+  renderer: WorldPresentationRenderer,
+  request: WorldPresentationPrepareRequest,
+  options: {
+    signal?: AbortSignal;
+    startCueIndex?: number;
+    onCueComplete?: (cue: PresentationCue) => Promise<void> | void;
+  } = {},
+): Promise<void> {
+  await renderer.prepare(request, options.signal);
+  const startCueIndex = Math.min(
+    request.plan.cues.length,
+    Math.max(0, options.startCueIndex ?? 0),
+  );
+  await renderer.recover(request.plan.cues.slice(0, startCueIndex), options.signal);
+  for (const [index, cue] of request.plan.cues.entries()) {
+    if (index < startCueIndex) continue;
+    if (options.signal?.aborted) {
+      throw options.signal.reason ?? new DOMException("Aborted", "AbortError");
+    }
+    await renderer.render(cue, options.signal);
+    if (cue.checkpoint || index === request.plan.cues.length - 1) {
+      await options.onCueComplete?.(cue);
+    }
+  }
+}
+
+function assetKindForCue(cue: PresentationCue): WorldAssetManifestEntry["kind"] | null {
+  if (cue.kind === "background") return "background";
+  if (cue.kind === "sprites") return "character";
+  if (cue.kind === "cg") return "cg";
+  return null;
+}
+
+/** Extracts explicit opaque asset references without interpreting bridge paths in PixiJS. */
+export function createWorldAssetManifest(plan: PerformancePlan): WorldAssetManifestEntry[] {
+  const entries = new Map<string, WorldAssetManifestEntry>();
+  for (const cue of plan.cues) {
+    const kind = assetKindForCue(cue);
+    if (!kind) continue;
+    const visit = (value: unknown): void => {
+      if (Array.isArray(value)) {
+        value.forEach(visit);
+        return;
+      }
+      if (typeof value !== "object" || value === null) return;
+      const record = value as Record<string, unknown>;
+      const url = [record.assetUrl, record.imageUrl, record.url]
+        .find((candidate): candidate is string => typeof candidate === "string" && candidate.startsWith("shiori-asset://"));
+      const id = [record.assetId, record.id, record.asset]
+        .find((candidate): candidate is string => typeof candidate === "string" && Boolean(candidate.trim()));
+      if (url && id) {
+        const fallbackIds = Array.isArray(record.fallbackIds)
+          ? record.fallbackIds.filter((candidate): candidate is string => typeof candidate === "string")
+          : undefined;
+        entries.set(id, { id, url, kind, fallbackIds });
+      }
+      Object.values(record).forEach(visit);
+    };
+    visit(cue.payload);
+  }
+  return [...entries.values()];
+}

--- a/desktop/renderer/src/world/worldStageGeometry.test.ts
+++ b/desktop/renderer/src/world/worldStageGeometry.test.ts
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  coverWorldStage,
+  fitWorldStage,
+  placeWorldCharacter,
+  worldStageSafeArea,
+  worldStageSize,
+} from "./worldStageGeometry";
+
+describe("worldStageGeometry", () => {
+  it("keeps the 1920x1080 logical stage centered at required viewport sizes", () => {
+    assert.deepEqual(fitWorldStage(1920, 1080), {
+      scale: 1,
+      offsetX: 0,
+      offsetY: 0,
+      renderedWidth: 1920,
+      renderedHeight: 1080,
+    });
+    assert.deepEqual(fitWorldStage(1280, 720), {
+      scale: 2 / 3,
+      offsetX: 0,
+      offsetY: 0,
+      renderedWidth: 1280,
+      renderedHeight: 720,
+    });
+    const compact = fitWorldStage(1024, 640);
+    assert.equal(compact.renderedWidth, 1024);
+    assert.equal(compact.offsetY, 32);
+    const ultrawide = fitWorldStage(2560, 1080);
+    assert.equal(ultrawide.renderedHeight, 1080);
+    assert.equal(ultrawide.offsetX, 320);
+  });
+
+  it("covers the logical stage with centered source cropping", () => {
+    assert.deepEqual(coverWorldStage(1920, 1200), {
+      x: 0,
+      y: -60,
+      width: 1920,
+      height: 1200,
+      scale: 1,
+    });
+    const portrait = coverWorldStage(1080, 1920);
+    assert.equal(portrait.height, 1920 * (1920 / 1080));
+    assert.equal(portrait.x, 0);
+    assert.ok(portrait.y < 0);
+  });
+
+  it("maps normalized character slots to one stable safe-area baseline", () => {
+    assert.deepEqual(worldStageSize, { width: 1920, height: 1080 });
+    assert.deepEqual(worldStageSafeArea, { x: 160, y: 90, width: 1600, height: 900 });
+    assert.deepEqual(placeWorldCharacter(0.5, 1200), { x: 960, y: 990, scale: 0.75 });
+    assert.equal(placeWorldCharacter(-1, 900).x, 160);
+    assert.equal(placeWorldCharacter(2, 900).x, 1760);
+  });
+});

--- a/desktop/renderer/src/world/worldStageGeometry.ts
+++ b/desktop/renderer/src/world/worldStageGeometry.ts
@@ -1,0 +1,67 @@
+export const worldStageSize = Object.freeze({ width: 1920, height: 1080 });
+
+/** Central region that must remain readable across window aspect ratios. */
+export const worldStageSafeArea = Object.freeze({ x: 160, y: 90, width: 1600, height: 900 });
+
+export type WorldStageViewport = {
+  scale: number;
+  offsetX: number;
+  offsetY: number;
+  renderedWidth: number;
+  renderedHeight: number;
+};
+
+export type WorldStageRect = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  scale: number;
+};
+
+/** Fits the logical stage inside a viewport while preserving its aspect ratio. */
+export function fitWorldStage(viewportWidth: number, viewportHeight: number): WorldStageViewport {
+  if (viewportWidth <= 0 || viewportHeight <= 0) {
+    throw new Error("world stage viewport must be positive");
+  }
+  const scale = Math.min(viewportWidth / worldStageSize.width, viewportHeight / worldStageSize.height);
+  const renderedWidth = worldStageSize.width * scale;
+  const renderedHeight = worldStageSize.height * scale;
+  return {
+    scale,
+    offsetX: (viewportWidth - renderedWidth) / 2,
+    offsetY: (viewportHeight - renderedHeight) / 2,
+    renderedWidth,
+    renderedHeight,
+  };
+}
+
+/** Covers a logical target with an image without distorting or exposing gaps. */
+export function coverWorldStage(sourceWidth: number, sourceHeight: number): WorldStageRect {
+  if (sourceWidth <= 0 || sourceHeight <= 0) {
+    throw new Error("world stage source dimensions must be positive");
+  }
+  const scale = Math.max(worldStageSize.width / sourceWidth, worldStageSize.height / sourceHeight);
+  const width = sourceWidth * scale;
+  const height = sourceHeight * scale;
+  return {
+    x: (worldStageSize.width - width) / 2,
+    y: (worldStageSize.height - height) / 2,
+    width,
+    height,
+    scale,
+  };
+}
+
+/** Resolves a normalized character slot onto the shared baseline in the safe area. */
+export function placeWorldCharacter(normalizedX: number, sourceHeight: number) {
+  if (sourceHeight <= 0) {
+    throw new Error("character source height must be positive");
+  }
+  const clampedX = Math.min(1, Math.max(0, normalizedX));
+  return {
+    x: worldStageSafeArea.x + worldStageSafeArea.width * clampedX,
+    y: worldStageSafeArea.y + worldStageSafeArea.height,
+    scale: Math.min(1, worldStageSafeArea.height / sourceHeight),
+  };
+}

--- a/desktop/src/localAssetRegistry.test.ts
+++ b/desktop/src/localAssetRegistry.test.ts
@@ -64,12 +64,16 @@ describe("LocalAssetRegistry", () => {
     const references = registry.grantTrustedPayload({
       role: { avatar_abs: avatarPath, arbitrary: arbitraryPath },
       session: { media: [documentPath, launderedPath] },
+      presentation: { items: [{ image_path: arbitraryPath }] },
     });
 
-    assert.deepEqual(references.map((reference) => reference.path).sort(), [avatarPath, documentPath].sort());
+    assert.deepEqual(
+      references.map((reference) => reference.path).sort(),
+      [avatarPath, arbitraryPath, documentPath].sort(),
+    );
     assert.equal(registry.resolveReference(avatarPath)?.kind, "image");
+    assert.equal(registry.resolveReference(arbitraryPath)?.kind, "image");
     assert.equal(registry.resolveReference(documentPath)?.kind, "document");
-    assert.equal(registry.resolveReference(arbitraryPath), null);
     assert.equal(registry.resolveReference(launderedPath), null);
   });
 

--- a/desktop_bridge/world_presentation_assets.py
+++ b/desktop_bridge/world_presentation_assets.py
@@ -1,0 +1,79 @@
+"""Resolve immutable world snapshot assets into renderer-facing plans."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from world_simulation.performance import PerformancePlan
+from world_simulation.visuals import WorldVisualResolver
+from world_simulation.world import NativeResident, RoleTemplateSnapshot
+
+
+class WorldPresentationAssetResolver:
+    """Enrich semantic sprite cues from world-owned role snapshots."""
+
+    def __init__(
+        self,
+        *,
+        snapshots: list[RoleTemplateSnapshot],
+        residents: list[NativeResident],
+    ) -> None:
+        snapshots_by_id = {snapshot.id: snapshot for snapshot in snapshots}
+        self._snapshots_by_actor = {
+            actor_id: snapshot
+            for resident in residents
+            if (snapshot := snapshots_by_id.get(resident.snapshot_id)) is not None
+            for actor_id in (resident.id, snapshot.source_role_id)
+        }
+        self._visuals = WorldVisualResolver()
+
+    def to_bridge_dict(self, plan: PerformancePlan) -> dict[str, Any]:
+        """Return one plan with trusted snapshot paths attached to sprite cues."""
+
+        value = plan.to_bridge_dict()
+        for cue in value["cues"]:
+            if cue["kind"] != "sprites":
+                continue
+            payload = cue["payload"]
+            items = payload.get("items") if isinstance(payload, dict) else None
+            if isinstance(items, list):
+                payload["items"] = [self._sprite(item) for item in items]
+        return value
+
+    def _sprite(self, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        item = dict(value)
+        actor_id = str(item.get("actor_id") or item.get("actorId") or "").strip()
+        snapshot = self._snapshots_by_actor.get(actor_id)
+        if snapshot is None:
+            return item
+        mood = str(item.get("mood") or "").strip()
+        resolved = self._visuals.resolve(snapshot, mood)
+        if not resolved.asset_id or not resolved.path:
+            return item
+
+        item["assetId"] = resolved.asset_id
+        item["image_path"] = resolved.path
+        avatar = self._asset(
+            snapshot, str(snapshot.visual_profile.get("avatar_asset_id") or "")
+        )
+        if avatar is not None and avatar["assetId"] != resolved.asset_id:
+            item["fallbackIds"] = [avatar["assetId"]]
+            item["fallbackAssets"] = [avatar]
+        return item
+
+    @staticmethod
+    def _asset(snapshot: RoleTemplateSnapshot, asset_id: str) -> dict[str, str] | None:
+        if not asset_id:
+            return None
+        asset = next(
+            (
+                item
+                for item in snapshot.assets
+                if isinstance(item, dict) and str(item.get("id") or "") == asset_id
+            ),
+            None,
+        )
+        path = str(asset.get("path") or "") if asset else ""
+        return {"assetId": asset_id, "image_path": path} if path else None

--- a/desktop_bridge/world_simulation_handler.py
+++ b/desktop_bridge/world_simulation_handler.py
@@ -10,6 +10,7 @@ from typing import Any
 from uuid import uuid4
 
 from core.roles import RoleStore
+from desktop_bridge.world_presentation_assets import WorldPresentationAssetResolver
 from world_simulation.actors import AutonomyPolicy, PlayerOC
 from world_simulation.dependencies import DependencySet
 from world_simulation.errors import HistoricalConflictError
@@ -454,9 +455,13 @@ class WorldSimulationHandler:
             if session.status != desired:
                 session = replace(session, status=desired, updated_at=utc_now())
                 self._repository.save_presentation_session(session)
+        asset_resolver = WorldPresentationAssetResolver(
+            snapshots=self._repository.list_role_snapshots(world_id),
+            residents=self._repository.list_residents(world_id),
+        )
         return {
             "session": session.to_bridge_dict(),
-            "plans": [plan.to_bridge_dict() for plan in plans],
+            "plans": [asset_resolver.to_bridge_dict(plan) for plan in plans],
         }
 
     def _waiting_status(

--- a/docs/knowledge/impact/change-impact-index.md
+++ b/docs/knowledge/impact/change-impact-index.md
@@ -38,6 +38,7 @@ related:
 | Bridge API | dispatcher、service、presenter、Electron client、renderer hook | `DesktopBridgeService request_dispatcher DesktopBridgeClient` |
 | ASR / TTS / 声音资产 | 全局与角色 provider、turn 归属、播放队列、取消、指标、ownership 与供应商清理 | `DesktopVoiceController TtsTurnCoordinator VoiceService` |
 | 调度任务 | scheduler、工具、持久化、主动投递、角色删除、桌面表单 | `ScheduleRoleTaskService compute_fire_at` |
+| 持久世界 / 演出 | timeline、settlement、角色快照、presentation protocol、asset transport、Pixi adapter | `WorldInstance RoleTemplateSnapshot PerformancePlan PixiWorldPresentationRenderer` |
 
 ## 判断顺序
 

--- a/docs/knowledge/index.md
+++ b/docs/knowledge/index.md
@@ -40,6 +40,7 @@ related:
 | 渠道 | [渠道系统](modules/channels.md) | Telegram、QQ 和统一 Channel 合约如何连接消息总线 |
 | Agent、工具、插件、MCP | [Agent 生命周期与工具](modules/agent-lifecycle-and-tools.md) | 一个回合经历哪些 phase；工具怎样注册、搜索、执行和拦截 |
 | 桌面端与桥接 | [桌面端与桥接](modules/desktop-and-bridge.md) | Electron、React 和 Python 服务如何通信；状态由谁装配 |
+| 持久世界与演出 | [持久世界与演出](modules/persistent-world-and-presentation.md) | 世界事实与演出状态如何分离；角色快照素材怎样进入 Pixi 舞台 |
 | 桌宠语音 | [桌宠语音交互](modules/voice.md) | ASR 如何进入现有 Loop；TTS turn、中断、声音资产和指标由谁管理 |
 | 调度与角色任务 | [调度与任务](modules/scheduling.md) | 定时任务如何创建、触发和展示；角色任务如何执行 |
 | 本地数据与迁移 | [本地工作区数据](data/local-workspace.md) | 哪些数据是权威数据；删除、迁移和备份要注意什么 |

--- a/docs/knowledge/map.md
+++ b/docs/knowledge/map.md
@@ -36,6 +36,7 @@ related:
 | 调度任务 | `agent/scheduler.py`、`agent/tools/schedule.py`、`desktop_bridge/schedule_role_task_service.py` | 主动触发、角色任务、桌面展示 |
 | 桌面桥接 | `desktop_bridge/` | Electron 主进程、React renderer、后端服务 |
 | 桌面界面 | `desktop/src/`、`desktop/renderer/src/` | 角色管理、聊天、设置、图片、任务 |
+| 持久世界 | `world_simulation/`、`desktop_bridge/world_simulation_handler.py`、`desktop/renderer/src/world/` | 世界事实、角色快照、演出计划、Pixi 舞台 |
 | 桌宠语音 | `desktop/src/voice/`、`desktop/renderer/src/voice/`、`desktop_bridge/voice_service.py`、`desktop_bridge/tts_coordinator.py` | 录音、ASR、角色 Loop、按句 TTS、播放与中断 |
 
 ```mermaid

--- a/docs/knowledge/modules/persistent-world-and-presentation.md
+++ b/docs/knowledge/modules/persistent-world-and-presentation.md
@@ -1,0 +1,43 @@
+---
+title: 持久世界与演出
+kind: 领域说明
+status: 当前有效
+last_verified_commit: 12f37fe5
+source_paths:
+  - world_simulation/
+  - desktop_bridge/world_simulation_handler.py
+  - desktop_bridge/world_presentation_assets.py
+  - desktop/renderer/src/world/
+  - desktop/src/localAssetRegistry.ts
+related:
+  - roles.md
+  - desktop-and-bridge.md
+---
+
+# 持久世界与演出
+
+## 模块边界
+
+`world_simulation/` 拥有世界实例、共享时间线、事件结算、决策屏障、角色模板快照和演出协议。`WorldRepository` 将权威事实与派生的播放游标保存到独立 `worlds.db`；React 世界工作台只消费 bridge read model，不直接读数据库。
+
+角色进入世界时会冻结为 `RoleTemplateSnapshot`，角色素材复制到世界私有目录。后续角色修改或删除不能改变已有世界中的 persona、心情立绘、avatar 或声音配置。`WorldVisualResolver` 按“当前 mood、默认 mood、avatar、剪影”解析冻结素材。
+
+## 演出链路
+
+已提交事件由 `compile_performance_plan()` 确定性编译为版本化 cue。`WorldPresentationAssetResolver` 在 bridge read boundary 将 `{actor_id, mood}` 补成冻结快照中的素材 ID、路径和 avatar fallback；Electron `LocalAssetRegistry` 只为受信字段和工作区内文件签发 `shiori-asset://local/<token>`。
+
+React 在进入 `WorldStage` 前用 `hydrateWorldPresentationAssets()` 将 bridge 路径替换为 opaque URL 并移除原始路径。Pixi adapter 只接收 `PerformancePlan` 与 `WorldAssetManifestEntry`，不读取 bridge、store 或世界数据库；WebGL 失效时切换文本 adapter。
+
+## 修改影响
+
+- 修改世界事实或结算：检查 repository transaction、timeline projection、idempotency、outbox、复制世界和 backfill 因果约束。
+- 修改演出 cue：同步检查 Python protocol、renderer parser、checkpoint 恢复、文本降级和 Pixi adapter。
+- 修改角色快照素材：同步检查复制边界、`WorldVisualResolver`、bridge asset resolver、本地资源授权与 manifest fallback。
+- 修改播放状态：检查 pause/resume/checkpoint 的持久游标、重连重建、skip 和 dispose 清理。
+
+## 不变量
+
+- 世界事实只由结算流程提交；演出进度和纹理缓存都是可重建派生状态。
+- 已有世界只读取自己的角色快照，不回读可变角色定义。
+- Pixi 不接触本地路径；本地图片只能通过 opaque asset transport 加载。
+- 恢复已完成 cue 时不得重复业务 checkpoint。

--- a/tests/desktop_bridge/test_world_presentation_assets.py
+++ b/tests/desktop_bridge/test_world_presentation_assets.py
@@ -1,0 +1,53 @@
+from world_simulation.performance import compile_performance_plan
+from world_simulation.timeline import TimelineEvent
+from world_simulation.world import NativeResident, RoleTemplateSnapshot
+
+from desktop_bridge.world_presentation_assets import WorldPresentationAssetResolver
+
+
+def test_resolver_enriches_semantic_mood_with_avatar_fallback():
+    snapshot = RoleTemplateSnapshot(
+        id="snapshot-1",
+        source_role_id="role-1",
+        source_version="v1",
+        persona={},
+        visual_profile={
+            "default_mood": "平静",
+            "mood_illustration_bindings": {"平静": "asset-mood"},
+            "avatar_asset_id": "asset-avatar",
+        },
+        assets=(
+            {"id": "asset-mood", "path": "C:/world-assets/mood.png"},
+            {"id": "asset-avatar", "path": "C:/world-assets/avatar.png"},
+        ),
+    )
+    plan = compile_performance_plan(
+        TimelineEvent(
+            id="event-1",
+            world_id="world-1",
+            event_type="scene.action.committed",
+            effective_at="2026-07-29T10:00:00+00:00",
+            sequence=1,
+            changes={
+                "presentation": {
+                    "sprites": [{"actor_id": "resident-1", "mood": "警觉"}]
+                }
+            },
+        )
+    )
+    resolver = WorldPresentationAssetResolver(
+        snapshots=[snapshot],
+        residents=[NativeResident(id="resident-1", snapshot_id=snapshot.id, name="凛")],
+    )
+
+    sprite = resolver.to_bridge_dict(plan)["cues"][0]["payload"]["items"][0]
+
+    assert sprite["assetId"] == "asset-mood"
+    assert sprite["image_path"] == "C:/world-assets/mood.png"
+    assert sprite["fallbackIds"] == ["asset-avatar"]
+    assert sprite["fallbackAssets"] == [
+        {
+            "assetId": "asset-avatar",
+            "image_path": "C:/world-assets/avatar.png",
+        }
+    ]

--- a/tests/desktop_bridge/test_world_simulation_handler.py
+++ b/tests/desktop_bridge/test_world_simulation_handler.py
@@ -223,3 +223,81 @@ def test_world_draft_freezes_role_visual_and_voice_snapshots(tmp_path):
     role_store.delete_role(role.id)
     assert all(Path(path).is_file() for path in copied_paths)
     handler.close()
+
+
+def test_world_read_model_resolves_snapshot_visuals_for_sprite_cues(tmp_path):
+    avatar_source = tmp_path / "avatar.png"
+    mood_source = tmp_path / "mood.png"
+    avatar_source.write_bytes(b"avatar")
+    mood_source.write_bytes(b"mood")
+    role_store = RoleStore(tmp_path)
+    role = role_store.create_role(
+        name="凛",
+        system_prompt="保持冷静",
+        avatar_source=avatar_source,
+        illustration_sources=[mood_source],
+    )
+    role = role_store.update_role(
+        role.id,
+        runtime_config={
+            "default_mood": "平静",
+            "mood_catalog": ["平静"],
+            "mood_illustration_bindings": {"平静": role.illustrations[0]},
+        },
+    )
+    handler = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    draft = handler.handle(
+        "worlds.drafts.preview",
+        _creation_input(role.id),
+        request_id="preview-visual-world",
+    )
+    assert draft is not None
+    confirmed = handler.handle(
+        "worlds.drafts.confirm",
+        {
+            "draft_id": draft["draft"]["id"],
+            "native_identities": draft["draft"]["nativeIdentities"],
+        },
+        request_id="confirm-visual-world",
+    )
+    assert confirmed is not None
+    world_id = confirmed["world"]["id"]
+    world = handler._repository.require_world(world_id)
+    resident = handler._repository.list_residents(world_id)[0]
+    run = handler._service.start_run(
+        world_id,
+        kind="action",
+        request_id="visual-action:run",
+        expected_revision=world.revision,
+        random_seed="visual-action",
+    )
+    proposal = handler._proposal(
+        world=world,
+        run_id=run.id,
+        random_seed=run.random_seed,
+        event_type="scene.action.committed",
+        effective_at=world.current_time,
+        participants=(resident.id,),
+        presentation={
+            "content": "她望向潮水。",
+            "sprites": [{"actor_id": resident.id, "mood": "平静"}],
+        },
+    )
+    handler._service.submit_action(proposal, request_id="visual-action")
+
+    result = handler.handle(
+        "worlds.get", {"world_id": world_id}, request_id="get-visual-world"
+    )
+
+    assert result is not None
+    sprite_cue = next(
+        cue
+        for plan in result["world"]["presentation"]["plans"]
+        for cue in plan["cues"]
+        if cue["kind"] == "sprites"
+    )
+    sprite = sprite_cue["payload"]["items"][0]
+    assert Path(sprite["image_path"]).read_bytes() == b"mood"
+    assert sprite["fallbackIds"] == [sprite["fallbackAssets"][0]["assetId"]]
+    assert Path(sprite["fallbackAssets"][0]["image_path"]).read_bytes() == b"avatar"
+    handler.close()


### PR DESCRIPTION
Closes #43

Stacked on #49 (`codex/issue-42-role-snapshots`). The lower stack is #47 -> #48 -> #49.

## 变更摘要

- 新增 PixiJS 世界舞台，固定 `1920x1080` 逻辑坐标、`1600x900` 安全区和五层渲染结构。
- 实现背景 cover、角色 baseline、CG、镜头、遮幕、交叉淡化、减少动态效果与 WebGL 文本降级。
- 新增 `WorldPresentationRenderer` adapter seam，以及支持 manifest、预加载、引用计数、LRU、取消、超时、替换和释放的 `WorldAssetManager`。
- 接入当前段/下一段预加载、持久播放游标恢复、暂停、继续、跳过、退出和 checkpoint 控制。
- 将 #42 的 `RoleTemplateSnapshot` mood/avatar 素材解析到 renderer-facing plan，经 `LocalAssetRegistry` 与 preload cache 转换为 opaque `shiori-asset://local/<token>` manifest；Pixi 不接触本地路径或 bridge/store/database。
- 补充持久世界与演出知识页及影响索引。

## 实际验证

- Desktop 全套：`414 tests`，`413 passed`，`1 environment skip`。
- World simulation + desktop bridge：`24 passed`。
- 新增资产链路定向验证：handler 快照 mood/avatar -> bridge plan -> trusted asset grant -> renderer hydration -> Pixi manifest。
- `npm run typecheck` 通过。
- `npm run build` 通过；Pixi renderer 保持独立约 `246.63 kB` chunk。
- `npm audit --omit=dev`：`0 vulnerabilities`。
- 实际浏览器画面检查：`1024x640`、`1280x720`、`1920x1080`、`2560x1080`；canvas 覆盖、DPR backing store、非空像素、无文本/控制重叠均通过。
- 暂停 -> 继续 -> 跳过交互通过，浏览器 console 无错误。
- `graphify update .` 完成：`8074 nodes / 21073 edges / 330 communities`；超过 5000 节点，按规则跳过 HTML。

## 已知阻塞项

- 合并顺序受堆叠 Draft PR #49 阻塞；#49 继续依赖 #48 和 #47。
- 当前实现与自动化验证无其他已知阻塞。


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Builds a PixiJS world stage with a clear renderer boundary to play performance plans, including text fallback and persistent pause/resume/skip/checkpoint controls. Assets now load via a controlled `shiori-asset://local/<token>` transport with preloading, LRU eviction, and timeouts.

- **New Features**
  - Pixi world stage: 1920x1080 logical stage, 1600x900 safe area, five layers (background, characters, CG, atmosphere, transitions), cover-fit backgrounds, character baseline placement, CG, camera moves, curtain transitions, reduced-motion support, and auto text fallback on WebGL loss.
  - Renderer boundary: `WorldStage` host, `pixiWorldPresentationRenderer` adapter, `TextWorldPresentationRenderer` fallback, and `playPresentationPlan` for ordered playback, recovery from `startCueIndex`, and external checkpoints.
  - Asset pipeline: `WorldPresentationAssetResolver` enriches sprite cues from role snapshots (mood/avatar with fallback). `hydrateWorldPresentationAssets` replaces trusted paths with opaque URLs before Pixi. `WorldAssetManager` handles manifest, preload, ref-count, LRU eviction, cancellation, and per-load timeouts.
  - Focus mode: `GalgameFocusMode` integrates the stage, start cue index restore, pause/resume/skip UI, and checkpoint callbacks to the workspace controller.
  - Geometry helpers: fit/cover calculations and safe-area character placement for consistent visuals across window sizes.

- **Dependencies**
  - Added `pixi.js` ^8.19.0.

<sup>Written for commit e6ec581d45bab33f475fcec9080ba6bf2f6107f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/50?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

