### PR TITLE
feat(world): implement World Game Surface UI

### DIFF
--- a/desktop/renderer/src/app/useWorldWorkspacePresentation.tsx
+++ b/desktop/renderer/src/app/useWorldWorkspacePresentation.tsx
@@ -2,8 +2,8 @@ import { useCallback, useMemo, useState } from "react";
 import { toFileUrl } from "../shared/format";
 import type { RoleRecord } from "../shared/types";
 import {
-  GalgameFocusMode,
   WorldCreateFlow,
+  WorldGameSurface,
   WorldTimelineView,
   WorldWorkspace,
   type BackfillPreview,
@@ -13,7 +13,8 @@ import {
 import type { WorldBridgeClient } from "../world/bridgeClient";
 import type { useWorldWorkspaceController } from "../world/useWorldWorkspaceController";
 
-type WorldPresentationMode = "workspace" | "create" | "timeline" | "focus";
+type WorldPresentationMode = "game" | "workspace" | "create" | "timeline";
+type TimelineReturnMode = "game" | "workspace";
 
 type UseWorldWorkspacePresentationArgs = {
   roles: RoleRecord[];
@@ -27,7 +28,8 @@ function createWorldSeed(): string {
 
 /** Coordinates world-only presentation modes around the persistent workspace controller. */
 export function useWorldWorkspacePresentation({ roles, client, controller }: UseWorldWorkspacePresentationArgs) {
-  const [mode, setMode] = useState<WorldPresentationMode>("workspace");
+  const [mode, setMode] = useState<WorldPresentationMode>("game");
+  const [timelineReturnMode, setTimelineReturnMode] = useState<TimelineReturnMode>("game");
   const [seed, setSeed] = useState(createWorldSeed);
   const [draft, setDraft] = useState<Awaited<ReturnType<WorldBridgeClient["previewDraft"]>> | null>(null);
   const [timeline, setTimeline] = useState<Awaited<ReturnType<WorldBridgeClient["getTimeline"]>>>([]);
@@ -57,8 +59,9 @@ export function useWorldWorkspacePresentation({ roles, client, controller }: Use
     }
   }, []);
 
-  const openTimeline = useCallback(() => {
+  const openTimeline = useCallback((returnMode: TimelineReturnMode) => {
     if (!world) return;
+    setTimelineReturnMode(returnMode);
     void runPresentation(
       () => client.getTimeline(world.id, perspective, perspective === "known" ? world.activeOcId ?? undefined : undefined),
       (entries) => {
@@ -89,7 +92,7 @@ export function useWorldWorkspacePresentation({ roles, client, controller }: Use
         await controller.reloadWorlds();
         await controller.loadWorld(createdWorld.id);
         setDraft(null);
-        setMode("workspace");
+        setMode("game");
       },
     );
   }, [client, controller, runPresentation]);
@@ -101,7 +104,7 @@ export function useWorldWorkspacePresentation({ roles, client, controller }: Use
       async (copiedWorld) => {
         await controller.reloadWorlds();
         await controller.loadWorld(copiedWorld.id);
-        setMode("workspace");
+        setMode("game");
       },
     );
   }, [client, controller, runPresentation, world]);
@@ -119,21 +122,24 @@ export function useWorldWorkspacePresentation({ roles, client, controller }: Use
         await controller.reloadWorlds();
         await controller.loadWorld(updatedWorld.id);
         setBackfillPreview(null);
-        setMode("workspace");
+        setMode("game");
       },
     );
   }, [client, controller, runPresentation, world]);
 
-  const openFocus = useCallback(() => {
+  const openGame = useCallback(() => {
     if (!world?.scene.beats.length) {
       setPresentationError("当前场景尚无可播放的剧情。");
       return;
     }
-    setMode("focus");
+    setMode("game");
   }, [world]);
 
   const content = useMemo(() => {
     const error = presentationError || controller.error;
+    if (controller.loading && !world) {
+      return <div className="grid h-full place-items-center bg-[#151816] text-sm text-white/70" aria-busy="true">正在载入世界</div>;
+    }
     if (mode === "create" || !world) {
       return (
         <WorldCreateFlow
@@ -159,7 +165,7 @@ export function useWorldWorkspacePresentation({ roles, client, controller }: Use
           entries={timeline}
           perspective={perspective}
           backfillPreview={backfillPreview}
-          onBack={() => setMode("workspace")}
+          onBack={() => setMode(timelineReturnMode)}
           onPerspectiveChange={changePerspective}
           onCopyWorld={copyWorld}
           onPreviewBackfill={previewBackfill}
@@ -167,28 +173,22 @@ export function useWorldWorkspacePresentation({ roles, client, controller }: Use
         />
       );
     }
-    if (mode === "focus") {
-      const plan = world.presentation?.plans[0];
-      const beat = (plan ? world.scene.beats.find((item) => item.id === plan.eventId) : undefined)
-        ?? [...world.scene.beats].reverse().find((item) => item.isCritical)
-        ?? world.scene.beats.at(-1);
-      return beat ? (
-        <GalgameFocusMode
-          worldName={world.name}
-          beat={beat}
-          plan={plan}
-          preloadPlan={world.presentation?.plans[1]}
-          startCueIndex={world.presentation?.session.activePlanId === plan?.planId
-            ? world.presentation?.session.activeCueIndex ?? 0
-            : 0}
-          paused={world.presentation?.session.status === "paused"}
-          onExit={() => setMode("workspace")}
+    if (mode === "game") {
+      return (
+        <WorldGameSurface
+          world={world}
+          busy={busy || controller.busy}
+          onOpenTimeline={() => openTimeline("game")}
+          onExitWorkspace={() => setMode("workspace")}
+          onSubmitAction={controller.submitAction}
+          onAdvance={controller.advance}
+          onResolveBarrier={controller.resolveBarrier}
           onRedrawShot={controller.redrawShot}
           onPause={controller.pausePresentation}
           onResume={controller.resumePresentation}
           onCheckpoint={controller.checkpointPresentation}
         />
-      ) : null;
+      );
     }
     return (
       <WorldWorkspace
@@ -202,8 +202,8 @@ export function useWorldWorkspacePresentation({ roles, client, controller }: Use
           setDraft(null);
           setMode("create");
         }}
-        onOpenTimeline={openTimeline}
-        onOpenFocus={openFocus}
+        onOpenTimeline={() => openTimeline("workspace")}
+        onOpenFocus={openGame}
         onSubmitAction={controller.submitAction}
         onAdvance={controller.advance}
         onResolveBarrier={controller.resolveBarrier}
@@ -211,7 +211,7 @@ export function useWorldWorkspacePresentation({ roles, client, controller }: Use
         onRedrawShot={controller.redrawShot}
       />
     );
-  }, [backfillPreview, busy, changePerspective, commitBackfill, confirmDraft, controller, copyWorld, draft, mode, openFocus, openTimeline, perspective, presentationError, previewBackfill, previewDraft, seed, timeline, world, worldRoles]);
+  }, [backfillPreview, busy, changePerspective, commitBackfill, confirmDraft, controller, copyWorld, draft, mode, openGame, openTimeline, perspective, presentationError, previewBackfill, previewDraft, seed, timeline, timelineReturnMode, world, worldRoles]);
 
   return { content };
 }

--- a/desktop/renderer/src/main.tsx
+++ b/desktop/renderer/src/main.tsx
@@ -56,6 +56,24 @@ import type {
 } from "./shared/types";
 import "./styles.css";
 
+type WorldRouteProps = {
+  roles: RoleRecord[];
+  onExit: () => void;
+};
+
+/** Mounts World-only bridge and presentation state only while the World route is active. */
+function WorldRoute({ roles, onExit }: WorldRouteProps): React.ReactElement {
+  const worldBridgeClient = useMemo(() => createWorldBridgeClient(), []);
+  const worldController = useWorldWorkspaceController(worldBridgeClient);
+  const worldPresentation = useWorldWorkspacePresentation({
+    roles,
+    client: worldBridgeClient,
+    controller: worldController,
+  });
+
+  return <WorldAppSurface onExit={onExit}>{worldPresentation.content}</WorldAppSurface>;
+}
+
 function App(): React.ReactElement {
   const [health, setHealth] = useState("connecting");
   const [promptTagWorkspaceSection, setPromptTagWorkspaceSection] = useState<PromptTagWorkspaceSectionId>("list");
@@ -150,14 +168,6 @@ function App(): React.ReactElement {
     activeRole: roles.find((role) => role.id === activeRoleId) ?? null,
     roles,
   });
-  const worldBridgeClient = useMemo(() => createWorldBridgeClient(), []);
-  const worldController = useWorldWorkspaceController(worldBridgeClient);
-  const worldWorkspace = useWorldWorkspacePresentation({
-    roles,
-    client: worldBridgeClient,
-    controller: worldController,
-  });
-
   const { updateRoleForm, updateNewRoleForm } = useRoleFormAdapters({
     roleFormRef,
     newRoleFormRef,
@@ -463,7 +473,7 @@ function App(): React.ReactElement {
   }
 
   if (mainView.kind === "world") {
-    return <WorldAppSurface onExit={() => openChatView()}>{worldWorkspace.content}</WorldAppSurface>;
+    return <WorldRoute roles={roles} onExit={() => openChatView()} />;
   }
 
   return (

--- a/desktop/renderer/src/world/WorldGameControls.tsx
+++ b/desktop/renderer/src/world/WorldGameControls.tsx
@@ -1,0 +1,56 @@
+import { ArrowClockwise, List, Pause, Play, SkipForward, X } from "@phosphor-icons/react";
+import { useState } from "react";
+
+type WorldGameControlsProps = {
+  worldName: string;
+  paused: boolean;
+  onPause: () => void;
+  onResume: () => void;
+  onSkip: () => void;
+  onRedraw?: () => void;
+  onOpenTimeline: () => void;
+  onExitWorkspace: () => void;
+};
+
+/** Owns the small set of controls that can interrupt a World performance. */
+export function WorldGameControls({ worldName, paused, onPause, onResume, onSkip, onRedraw, onOpenTimeline, onExitWorkspace }: WorldGameControlsProps) {
+  const [menuOpen, setMenuOpen] = useState(false);
+
+  function openMenu() {
+    setMenuOpen(true);
+    if (!paused) onPause();
+  }
+
+  function closeMenu() {
+    setMenuOpen(false);
+  }
+
+  function resumeFromMenu() {
+    setMenuOpen(false);
+    onResume();
+  }
+
+  return (
+    <>
+      <header className="absolute inset-x-0 top-0 z-20 flex items-center justify-between px-5 py-4 text-white">
+        <span className="font-serif text-sm text-white/75">{worldName}</span>
+        <div className="flex items-center gap-2">
+          {onRedraw ? <button className="grid h-10 w-10 place-items-center rounded-md bg-black/35 text-white backdrop-blur-sm hover:bg-black/55" type="button" aria-label="重绘镜头" title="重绘镜头" onClick={onRedraw}><ArrowClockwise /></button> : null}
+          <button className="grid h-10 w-10 place-items-center rounded-md bg-black/35 text-white backdrop-blur-sm hover:bg-black/55" type="button" aria-label={paused ? "继续演出" : "暂停演出"} title={paused ? "继续演出" : "暂停演出"} onClick={paused ? onResume : onPause}>
+            {paused ? <Play /> : <Pause />}
+          </button>
+          <button className="grid h-10 w-10 place-items-center rounded-md bg-black/35 text-white backdrop-blur-sm hover:bg-black/55" type="button" aria-label="跳过当前演出" title="跳过当前演出" onClick={onSkip}><SkipForward /></button>
+          <button className="grid h-10 w-10 place-items-center rounded-md bg-black/35 text-white backdrop-blur-sm hover:bg-black/55" type="button" aria-label="打开演出菜单" title="打开演出菜单" onClick={openMenu}><List /></button>
+        </div>
+      </header>
+      {menuOpen ? (
+        <aside className="absolute right-5 top-20 z-30 grid w-64 gap-2 rounded-md border border-white/15 bg-[#171A18]/95 p-3 text-white shadow-2xl backdrop-blur-md" role="dialog" aria-label="演出菜单">
+          <div className="flex items-center justify-between px-1 pb-1"><strong className="font-serif text-base">演出菜单</strong><button className="grid h-8 w-8 place-items-center rounded-md text-white/70 hover:bg-white/10" type="button" aria-label="关闭演出菜单" title="关闭演出菜单" onClick={closeMenu}><X /></button></div>
+          <button className="flex h-10 items-center rounded-md px-3 text-left text-sm hover:bg-white/10" type="button" onClick={() => { setMenuOpen(false); onOpenTimeline(); }}>打开时间线</button>
+          <button className="flex h-10 items-center rounded-md px-3 text-left text-sm hover:bg-white/10" type="button" onClick={onExitWorkspace}>返回世界管理</button>
+          <button className="flex h-10 items-center rounded-md px-3 text-left text-sm hover:bg-white/10" type="button" onClick={resumeFromMenu}>继续演出</button>
+        </aside>
+      ) : null}
+    </>
+  );
+}

--- a/desktop/renderer/src/world/WorldGameInteraction.tsx
+++ b/desktop/renderer/src/world/WorldGameInteraction.tsx
@@ -1,0 +1,53 @@
+import { ArrowRight, PaperPlaneTilt, Play } from "@phosphor-icons/react";
+import { useState } from "react";
+import { AutosizeTextarea } from "../shared/AutosizeTextarea";
+import { canSubmitWorldAction } from "./selectors";
+import type { DecisionBarrier, SceneBeat, WorldDetails } from "./types";
+
+type WorldGameInteractionProps = {
+  world: WorldDetails;
+  beat: SceneBeat | null;
+  paused: boolean;
+  performing: boolean;
+  busy: boolean;
+  onSubmitAction: (content: string) => Promise<boolean>;
+  onAdvance: () => void;
+  onResolveBarrier: (barrier: DecisionBarrier, choiceId: string) => void;
+};
+
+/** Renders dialogue and swaps the bottom area to action or barrier input. */
+export function WorldGameInteraction({ world, beat, paused, performing, busy, onSubmitAction, onAdvance, onResolveBarrier }: WorldGameInteractionProps) {
+  const [action, setAction] = useState("");
+  const barrier = world.scene.barriers[0] ?? null;
+  const canAct = !paused && !performing && canSubmitWorldAction(world);
+
+  async function submit() {
+    if (!canAct || !action.trim()) return;
+    if (await onSubmitAction(action)) setAction("");
+  }
+
+  return (
+    <section className="pointer-events-none absolute inset-x-0 bottom-0 z-20 px-[clamp(20px,8vw,120px)] pb-[clamp(24px,6vh,64px)]">
+      <div className="pointer-events-auto mx-auto max-w-5xl border-l-2 border-[#E59A70] bg-black/55 px-6 py-5 backdrop-blur-md">
+        {beat?.speakerName ? <h1 className="m-0 mb-2 font-serif text-lg font-semibold text-[#F3B18B]">{beat.speakerName}</h1> : null}
+        <p className="m-0 min-h-8 whitespace-pre-wrap font-serif text-lg leading-8 text-white">{beat?.content ?? ""}</p>
+        {paused ? <p className="m-0 mt-3 text-xs text-white/60">演出已暂停</p> : null}
+        {!paused && barrier ? (
+          <section className="mt-5 grid gap-3" aria-label="待决事件">
+            <div><h2 className="m-0 font-serif text-base font-semibold">{barrier.title}</h2><p className="m-0 mt-1 text-sm leading-6 text-white/70">{barrier.context}</p></div>
+            <div className="grid gap-2 sm:grid-cols-2">
+              {barrier.choices.map((choice) => <button key={choice.id} className="flex min-h-11 items-center justify-between rounded-md border border-white/20 bg-white/10 px-3 text-left text-sm hover:bg-white/15 disabled:opacity-50" type="button" disabled={busy} onClick={() => onResolveBarrier(barrier, choice.id)}><span>{choice.label}</span><ArrowRight /></button>)}
+            </div>
+          </section>
+        ) : null}
+        {!paused && canAct ? (
+          <div className="mt-5 flex items-end gap-2 rounded-md border border-white/20 bg-black/20 p-2 transition focus-within:border-[#E59A70] focus-within:ring-2 focus-within:ring-[#E59A70]/20">
+            <AutosizeTextarea className="min-h-10 w-full bg-transparent px-2 py-2 text-sm leading-6 text-white placeholder:text-white/45 focus:outline-none" containerClassName="min-h-10 flex-1" mirrorClassName="px-2 py-2 text-sm leading-6" value={action} placeholder={world.scene.actionPrompt} onChange={(event) => setAction(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); void submit(); } }} />
+            <button className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-[#A75F41] text-white disabled:opacity-40" type="button" aria-label="提交行动" disabled={busy || !action.trim()} onClick={() => void submit()}><PaperPlaneTilt weight="fill" /></button>
+          </div>
+        ) : null}
+        {!paused && !performing && !barrier && !canAct ? <button className="mt-5 inline-flex h-10 items-center gap-2 rounded-md bg-white/15 px-4 text-sm text-white hover:bg-white/20 disabled:opacity-50" type="button" disabled={busy} onClick={onAdvance}><Play weight="fill" />继续世界</button> : null}
+      </div>
+    </section>
+  );
+}

--- a/desktop/renderer/src/world/WorldGameSurface.test.tsx
+++ b/desktop/renderer/src/world/WorldGameSurface.test.tsx
@@ -1,0 +1,174 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it } from "node:test";
+import { WorldGameSurface } from "./WorldGameSurface";
+import { createWorldDetails } from "./testFixtures";
+import { selectWorldGamePresentation } from "./worldGamePresentation";
+
+function render(world = createWorldDetails()) {
+  return renderToStaticMarkup(
+    <WorldGameSurface
+      world={world}
+      onOpenTimeline={() => undefined}
+      onExitWorkspace={() => undefined}
+      onSubmitAction={async () => true}
+      onAdvance={() => undefined}
+      onResolveBarrier={() => undefined}
+      onRedrawShot={() => undefined}
+      onPause={() => undefined}
+      onResume={() => undefined}
+      onCheckpoint={() => undefined}
+    />,
+  );
+}
+
+describe("WorldGameSurface", () => {
+  it("renders the stage and performance controls for a queued plan", () => {
+    const base = createWorldDetails();
+    const markup = render({
+      ...base,
+      presentation: {
+        session: {
+          worldId: base.id,
+          lastPresentedEventSequence: 0,
+          activePlanId: null,
+          activeCueIndex: 0,
+          status: "playing",
+          updatedAt: "2026-07-30T00:00:00+00:00",
+        },
+        plans: [{
+          schemaVersion: 1,
+          planId: "plan-1",
+          worldId: base.id,
+          eventId: base.scene.beats[0].id,
+          sourceSequence: 1,
+          cues: [{
+            schemaVersion: 1,
+            cueId: "cue-1",
+            planId: "plan-1",
+            sequence: 0,
+            kind: "dialogue",
+            payload: { content: base.scene.beats[0].content },
+            parallelGroup: null,
+            blocking: true,
+            completionState: "completed",
+            skipState: "skipped",
+            checkpoint: true,
+          }],
+        }],
+      },
+    });
+
+    assert.match(markup, /data-testid="world-game-surface"/);
+    assert.match(markup, /data-testid="world-stage"/);
+    assert.match(markup, /aria-label="暂停演出"/);
+    assert.match(markup, /aria-label="跳过当前演出"/);
+    assert.match(markup, /aria-label="打开演出菜单"/);
+    assert.match(markup, />你终于来了。</);
+    assert.doesNotMatch(markup, /aria-label="提交行动"/);
+  });
+
+  it("shows action input after the presentation queue is empty", () => {
+    const markup = render(createWorldDetails({ presentation: undefined }));
+
+    assert.doesNotMatch(markup, /data-testid="world-stage"/);
+    assert.match(markup, /aria-label="提交行动"/);
+    assert.match(markup, /岚准备怎么做？/);
+  });
+
+  it("shows a decision barrier instead of the action composer", () => {
+    const base = createWorldDetails({ status: "barrier" });
+    const markup = render({
+      ...base,
+      scene: {
+        ...base.scene,
+        barriers: [{ id: "barrier-1", title: "钟声之后", context: "必须决定是否开门", affectedOcNames: ["岚"], choices: [{ id: "open", label: "打开门" }] }],
+      },
+    });
+
+    assert.match(markup, /aria-label="待决事件"/);
+    assert.match(markup, />打开门</);
+    assert.doesNotMatch(markup, /aria-label="提交行动"/);
+  });
+
+  it("does not start a stale plan while the world is awaiting a barrier", () => {
+    const base = createWorldDetails({ status: "barrier" });
+    const world = {
+      ...base,
+      scene: {
+        ...base.scene,
+        barriers: [{ id: "barrier-1", title: "钟声之后", context: "必须决定是否开门", affectedOcNames: ["岚"], choices: [{ id: "open", label: "打开门" }] }],
+      },
+      presentation: {
+        session: {
+          worldId: base.id,
+          lastPresentedEventSequence: 1,
+          activePlanId: null,
+          activeCueIndex: 0,
+          status: "awaiting_barrier" as const,
+          updatedAt: "2026-07-30T00:00:00+00:00",
+        },
+        plans: [{
+          schemaVersion: 1 as const,
+          planId: "stale-plan",
+          worldId: base.id,
+          eventId: base.scene.beats[0].id,
+          sourceSequence: 2,
+          cues: [],
+        }],
+      },
+    };
+    const selection = selectWorldGamePresentation(world);
+    assert.equal(selection.plan, null);
+    assert.equal(selection.canPlay, false);
+  });
+
+  it("selects the active plan and restores its cue cursor", () => {
+    const base = createWorldDetails();
+    const plans = [
+      { planId: "plan-1", eventId: "beat-1", sourceSequence: 1 },
+      { planId: "plan-2", eventId: "beat-2", sourceSequence: 2 },
+    ].map(({ planId, eventId, sourceSequence }) => ({
+      schemaVersion: 1 as const,
+      planId,
+      worldId: base.id,
+      eventId,
+      sourceSequence,
+      cues: [{
+        schemaVersion: 1 as const,
+        cueId: `${planId}-cue`,
+        planId,
+        sequence: 0,
+        kind: "dialogue" as const,
+        payload: { content: "继续。" },
+        parallelGroup: null,
+        blocking: true,
+        completionState: "completed",
+        skipState: "skipped",
+        checkpoint: true,
+      }],
+    }));
+    const world = {
+      ...base,
+      scene: { ...base.scene, beats: [...base.scene.beats, { ...base.scene.beats[0], id: "beat-2", content: "第二段。" }] },
+      presentation: {
+        session: {
+          worldId: base.id,
+          lastPresentedEventSequence: 1,
+          activePlanId: "plan-2",
+          activeCueIndex: 1,
+          status: "playing" as const,
+          updatedAt: "2026-07-30T00:00:00+00:00",
+        },
+        plans,
+      },
+    };
+    const selection = selectWorldGamePresentation(world);
+    assert.equal(selection.plan?.planId, "plan-2");
+    assert.equal(selection.preloadPlan, undefined);
+    assert.equal(selection.startCueIndex, 1);
+    assert.equal(selection.beat?.id, "beat-2");
+  });
+});

--- a/desktop/renderer/src/world/WorldGameSurface.tsx
+++ b/desktop/renderer/src/world/WorldGameSurface.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { WorldGameControls } from "./WorldGameControls";
 import { WorldGameInteraction } from "./WorldGameInteraction";
 import type { DecisionBarrier, SceneBeat, WorldDetails } from "./types";
@@ -36,6 +36,10 @@ export function WorldGameSurface({ world, busy = false, onOpenTimeline, onExitWo
   const performing = canPlay && !isPaused;
   const hydratedPlan = useMemo(() => plan ? hydrateWorldPresentationAssets(plan) : null, [plan]);
   const hydratedPreloadPlan = useMemo(() => preloadPlan ? hydrateWorldPresentationAssets(preloadPlan) : undefined, [preloadPlan]);
+
+  useEffect(() => {
+    setPaused(session?.status === "paused");
+  }, [session?.status]);
 
   const pause = useCallback(() => {
     if (!canPlay || isPaused) return;

--- a/desktop/renderer/src/world/WorldGameSurface.tsx
+++ b/desktop/renderer/src/world/WorldGameSurface.tsx
@@ -1,0 +1,63 @@
+import { useCallback, useMemo, useState } from "react";
+import { WorldGameControls } from "./WorldGameControls";
+import { WorldGameInteraction } from "./WorldGameInteraction";
+import type { DecisionBarrier, SceneBeat, WorldDetails } from "./types";
+import { hydrateWorldPresentationAssets } from "./worldPresentationAssets";
+import { WorldStage } from "./WorldStage";
+import { selectWorldGamePresentation } from "./worldGamePresentation";
+
+type WorldGameSurfaceProps = {
+  world: WorldDetails;
+  busy?: boolean;
+  onOpenTimeline: () => void;
+  onExitWorkspace: () => void;
+  onSubmitAction: (content: string) => Promise<boolean>;
+  onAdvance: () => void;
+  onResolveBarrier: (barrier: DecisionBarrier, choiceId: string) => void;
+  onRedrawShot: (shotId: string) => void;
+  onPause: () => Promise<void> | void;
+  onResume: () => Promise<void> | void;
+  onCheckpoint: (planId: string, cueIndex: number) => Promise<void> | void;
+};
+
+function initialVisual(beat: SceneBeat | null) {
+  const shot = beat?.shot;
+  if (!shot) return undefined;
+  const asset = shot.assets.find((item) => item.id === shot.activeAssetId) ?? shot.assets[0];
+  return asset ? { id: `shot-${asset.id}`, url: asset.imageUrl } : undefined;
+}
+
+/** Owns the World visual-novel lifecycle while management views remain separate. */
+export function WorldGameSurface({ world, busy = false, onOpenTimeline, onExitWorkspace, onSubmitAction, onAdvance, onResolveBarrier, onRedrawShot, onPause, onResume, onCheckpoint }: WorldGameSurfaceProps) {
+  const { plan, preloadPlan, beat, session, startCueIndex, canPlay } = selectWorldGamePresentation(world);
+  const [paused, setPaused] = useState(session?.status === "paused");
+  const [skipVersion, setSkipVersion] = useState(0);
+  const isPaused = paused || session?.status === "paused";
+  const performing = canPlay && !isPaused;
+  const hydratedPlan = useMemo(() => plan ? hydrateWorldPresentationAssets(plan) : null, [plan]);
+  const hydratedPreloadPlan = useMemo(() => preloadPlan ? hydrateWorldPresentationAssets(preloadPlan) : undefined, [preloadPlan]);
+
+  const pause = useCallback(() => {
+    if (!canPlay || isPaused) return;
+    setPaused(true);
+    void onPause();
+  }, [canPlay, isPaused, onPause]);
+  const resume = useCallback(() => {
+    if (!canPlay || !isPaused) return;
+    setPaused(false);
+    void onResume();
+  }, [canPlay, isPaused, onResume]);
+  const exitWorkspace = useCallback(() => {
+    if (canPlay && !isPaused) pause();
+    onExitWorkspace();
+  }, [canPlay, isPaused, onExitWorkspace, pause]);
+
+  return (
+    <section className="relative h-full min-h-0 overflow-hidden bg-[#151816] text-white" data-testid="world-game-surface">
+      {hydratedPlan ? <WorldStage plan={hydratedPlan} preloadPlan={hydratedPreloadPlan} fallbackText={beat?.content ?? ""} initialVisual={initialVisual(beat)} startCueIndex={startCueIndex} paused={isPaused} skipVersion={skipVersion} onCueComplete={(cue) => onCheckpoint(cue.planId, cue.sequence)} /> : beat?.shot?.assets[0] ? <img className="absolute inset-0 h-full w-full object-cover" src={beat.shot.assets[0].imageUrl} alt={beat.shot.prompt} /> : <div className="absolute inset-0 bg-[#252C28]" />}
+      <div className="pointer-events-none absolute inset-0 bg-black/35" />
+      <WorldGameControls worldName={world.name} paused={isPaused} onPause={pause} onResume={resume} onSkip={() => setSkipVersion((value) => value + 1)} onRedraw={beat?.shot ? () => onRedrawShot(beat.shot!.id) : undefined} onOpenTimeline={onOpenTimeline} onExitWorkspace={exitWorkspace} />
+      <WorldGameInteraction world={world} beat={beat} paused={isPaused} performing={performing} busy={busy} onSubmitAction={onSubmitAction} onAdvance={onAdvance} onResolveBarrier={onResolveBarrier} />
+    </section>
+  );
+}

--- a/desktop/renderer/src/world/WorldStage.test.tsx
+++ b/desktop/renderer/src/world/WorldStage.test.tsx
@@ -1,0 +1,141 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type { PerformancePlan, PresentationCue } from "./presentationProtocol";
+import {
+  createWorldStagePlaybackCoordinator,
+  type WorldStagePlaybackCoordinatorOptions,
+} from "./WorldStage";
+import type {
+  WorldPresentationPrepareRequest,
+  WorldPresentationRenderer,
+} from "./worldPresentationRenderer";
+
+function cue(sequence: number): PresentationCue {
+  return {
+    schemaVersion: 1,
+    cueId: `cue-${sequence}`,
+    planId: "plan-1",
+    sequence,
+    kind: "dialogue",
+    payload: { content: `内容 ${sequence}` },
+    parallelGroup: null,
+    blocking: true,
+    completionState: "completed",
+    skipState: "skipped",
+    checkpoint: true,
+  };
+}
+
+function request(): WorldPresentationPrepareRequest {
+  const plan: PerformancePlan = {
+    schemaVersion: 1,
+    planId: "plan-1",
+    worldId: "world-1",
+    eventId: "event-1",
+    sourceSequence: 1,
+    cues: [cue(0), cue(1), cue(2)],
+  };
+  return { plan, manifest: [], fallbackText: "fallback" };
+}
+
+function renderer(
+  kind: WorldPresentationRenderer["kind"],
+  events: string[],
+  failCueId?: string,
+): WorldPresentationRenderer {
+  return {
+    kind,
+    initialize: async () => undefined,
+    prepare: async () => { events.push(`${kind}:prepare`); },
+    recover: async (items) => { events.push(`${kind}:recover:${items.map((item) => item.cueId).join(",")}`); },
+    render: async (item) => {
+      events.push(`${kind}:render:${item.cueId}`);
+      if (item.cueId === failCueId) throw new Error(`${kind} render failed`);
+    },
+    pause: () => undefined,
+    resume: () => undefined,
+    skip: () => undefined,
+    dispose: () => undefined,
+  };
+}
+
+function coordinatorOptions(
+  overrides: Partial<WorldStagePlaybackCoordinatorOptions> = {},
+): WorldStagePlaybackCoordinatorOptions {
+  const events: string[] = [];
+  return {
+    request: request(),
+    startCueIndex: 0,
+    signal: new AbortController().signal,
+    pixiRenderer: renderer("pixi", events),
+    textRenderer: renderer("text", events),
+    onFallback: () => { events.push("fallback"); },
+    ...overrides,
+  };
+}
+
+describe("WorldStage playback coordinator", () => {
+  it("keeps startCueIndex when a renderer failure activates text fallback", async () => {
+    const events: string[] = [];
+    const options = coordinatorOptions({
+      pixiRenderer: renderer("pixi", events, "cue-1"),
+      textRenderer: renderer("text", events),
+      startCueIndex: 1,
+      onFallback: () => { events.push("fallback"); },
+    });
+    const checkpoints: string[] = [];
+    const coordinator = createWorldStagePlaybackCoordinator({
+      ...options,
+      onCueComplete: async (item) => { checkpoints.push(item.cueId); },
+    });
+
+    assert.equal(await coordinator.playPixi(), "text");
+    assert.deepEqual(events, [
+      "pixi:prepare",
+      "pixi:recover:cue-0",
+      "pixi:render:cue-1",
+      "fallback",
+      "text:prepare",
+      "text:recover:cue-0",
+      "text:render:cue-1",
+      "text:render:cue-2",
+    ]);
+    assert.deepEqual(checkpoints, ["cue-1", "cue-2"]);
+  });
+
+  it("does not checkpoint a cue twice when Pixi falls back after a completed cue", async () => {
+    const events: string[] = [];
+    const options = coordinatorOptions({
+      pixiRenderer: renderer("pixi", events, "cue-1"),
+      textRenderer: renderer("text", events),
+      onFallback: () => { events.push("fallback"); },
+    });
+    const checkpoints: string[] = [];
+    const coordinator = createWorldStagePlaybackCoordinator({
+      ...options,
+      onCueComplete: async (item) => { checkpoints.push(item.cueId); },
+    });
+
+    assert.equal(await coordinator.playPixi(), "text");
+    assert.deepEqual(checkpoints, ["cue-0", "cue-1", "cue-2"]);
+  });
+
+  it("does not activate text fallback when checkpoint persistence fails", async () => {
+    const events: string[] = [];
+    const options = coordinatorOptions({
+      pixiRenderer: renderer("pixi", events),
+      textRenderer: renderer("text", events),
+      onFallback: () => { events.push("fallback"); },
+    });
+    const coordinator = createWorldStagePlaybackCoordinator({
+      ...options,
+      onCueComplete: async () => { throw new Error("bridge checkpoint failed"); },
+    });
+
+    await assert.rejects(() => coordinator.playPixi(), /bridge checkpoint failed/);
+    assert.equal(events.includes("fallback"), false);
+    assert.equal(events.some((event) => event.startsWith("text:")), false);
+  });
+});

--- a/desktop/renderer/src/world/WorldStage.tsx
+++ b/desktop/renderer/src/world/WorldStage.tsx
@@ -25,6 +25,85 @@ type PixiRendererModule = {
   createPixiWorldPresentationRenderer(options: { onContextLoss: () => void }): WorldPresentationRenderer;
 };
 
+export type WorldStagePlaybackCoordinatorOptions = {
+  request: WorldPresentationPrepareRequest;
+  startCueIndex: number;
+  signal?: AbortSignal;
+  pixiRenderer: WorldPresentationRenderer;
+  textRenderer: WorldPresentationRenderer;
+  onCueComplete?: (cue: PresentationCue) => Promise<void> | void;
+  onFallback?: () => Promise<void> | void;
+};
+
+/** Keeps renderer fallback and durable checkpointing on separate failure paths. */
+export function createWorldStagePlaybackCoordinator(options: WorldStagePlaybackCoordinatorOptions) {
+  const checkpointedCueIds = new Set<string>();
+  const pixiController = new AbortController();
+  const textController = new AbortController();
+  let nextCueIndex = Math.min(
+    options.request.plan.cues.length,
+    Math.max(0, options.startCueIndex),
+  );
+  let checkpointFailed = false;
+  let checkpointFailure: unknown = null;
+  let fallbackPromise: Promise<void> | null = null;
+
+  const abortPlayback = () => {
+    pixiController.abort(options.signal?.reason);
+    textController.abort(options.signal?.reason);
+  };
+  if (options.signal?.aborted) abortPlayback();
+  else options.signal?.addEventListener("abort", abortPlayback, { once: true });
+
+  const checkpoint = async (cue: PresentationCue) => {
+    if (!options.onCueComplete || checkpointedCueIds.has(cue.cueId)) return;
+    try {
+      await options.onCueComplete(cue);
+      checkpointedCueIds.add(cue.cueId);
+      nextCueIndex = Math.max(nextCueIndex, cue.sequence + 1);
+    } catch (error) {
+      checkpointFailed = true;
+      checkpointFailure = error;
+      throw error;
+    }
+  };
+
+  const play = (renderer: WorldPresentationRenderer, signal: AbortSignal) => playPresentationPlan(renderer, options.request, {
+    signal,
+    startCueIndex: nextCueIndex,
+    onCueComplete: checkpoint,
+  });
+
+  const activateTextFallback = () => {
+    if (fallbackPromise) return fallbackPromise;
+    if (checkpointFailed || options.signal?.aborted) return Promise.resolve();
+    pixiController.abort();
+    fallbackPromise = (async () => {
+      await options.onFallback?.();
+      await play(options.textRenderer, textController.signal);
+    })();
+    return fallbackPromise;
+  };
+
+  const playPixi = async (): Promise<"pixi" | "text"> => {
+    try {
+      await play(options.pixiRenderer, pixiController.signal);
+      return "pixi";
+    } catch (error) {
+      if (options.signal?.aborted || checkpointFailed) throw error;
+      await activateTextFallback();
+      return "text";
+    }
+  };
+
+  return {
+    activateTextFallback,
+    hasCheckpointFailure: () => checkpointFailed,
+    getCheckpointFailure: () => checkpointFailure,
+    playPixi,
+  };
+}
+
 function initialRequest(
   plan: PerformancePlan,
   preloadPlan: PerformancePlan | undefined,
@@ -50,6 +129,7 @@ export function WorldStage({ plan, preloadPlan, fallbackText, initialVisual, sta
   const skipVersionRef = useRef(skipVersion);
   const pausedRef = useLatestRef(paused);
   const [fallback, setFallback] = useState<TextPresentationSnapshot | null>(null);
+  const [presentationError, setPresentationError] = useState<string | null>(null);
   const initialVisualId = initialVisual?.id;
   const initialVisualUrl = initialVisual?.url;
   const request = useMemo(
@@ -68,35 +148,71 @@ export function WorldStage({ plan, preloadPlan, fallbackText, initialVisual, sta
     const controller = new AbortController();
     let active = true;
     let renderer: WorldPresentationRenderer | null = null;
+    let coordinator: ReturnType<typeof createWorldStagePlaybackCoordinator> | null = null;
+    setFallback(null);
+    setPresentationError(null);
     const textRenderer = new TextWorldPresentationRenderer((snapshot) => {
       if (active) setFallback(snapshot);
     });
 
-    const activateTextFallback = async () => {
+    const reportFailure = (error: unknown) => {
+      if (active && !controller.signal.aborted) {
+        setPresentationError(error instanceof Error ? error.message : "演出无法继续");
+      }
+    };
+
+    const activateTextRenderer = async () => {
       if (!active || renderer?.kind === "text") return;
       renderer?.dispose();
       renderer = textRenderer;
       rendererRef.current = renderer;
       await renderer.initialize(host);
-      await playPresentationPlan(renderer, request, { signal: controller.signal });
     };
 
     void (async () => {
       try {
         const module = await import("./pixiWorldPresentationRenderer") as PixiRendererModule;
         if (!active) return;
-        renderer = module.createPixiWorldPresentationRenderer({ onContextLoss: () => void activateTextFallback() });
+        renderer = module.createPixiWorldPresentationRenderer({
+          onContextLoss: () => {
+            const fallbackPromise = coordinator?.activateTextFallback();
+            if (fallbackPromise) void fallbackPromise.catch(reportFailure);
+          },
+        });
         rendererRef.current = renderer;
+        coordinator = createWorldStagePlaybackCoordinator({
+          request,
+          startCueIndex,
+          signal: controller.signal,
+          pixiRenderer: renderer,
+          textRenderer,
+          onCueComplete: (cue) => active ? checkpointRef.current?.(cue) : undefined,
+          onFallback: activateTextRenderer,
+        });
         await renderer.initialize(host);
         if (!active) return;
         if (pausedRef.current) renderer.pause();
-        await playPresentationPlan(renderer, request, {
-          signal: controller.signal,
-          startCueIndex,
-          onCueComplete: (cue) => checkpointRef.current?.(cue),
-        });
-      } catch {
-        if (!controller.signal.aborted) await activateTextFallback();
+        await coordinator.playPixi();
+      } catch (error) {
+        if (!active || controller.signal.aborted) return;
+        if (coordinator?.hasCheckpointFailure()) {
+          reportFailure(error);
+          return;
+        }
+        try {
+          if (coordinator) {
+            await coordinator.activateTextFallback();
+          } else {
+            await activateTextRenderer();
+            await playPresentationPlan(textRenderer, request, {
+              signal: controller.signal,
+              startCueIndex,
+              onCueComplete: (cue) => active ? checkpointRef.current?.(cue) : undefined,
+            });
+          }
+        } catch (fallbackError) {
+          reportFailure(fallbackError);
+        }
       }
     })();
 
@@ -127,6 +243,7 @@ export function WorldStage({ plan, preloadPlan, fallbackText, initialVisual, sta
           <p className="m-0 max-w-3xl font-serif text-xl leading-9 text-white/75">{fallback.text}</p>
         </div>
       ) : null}
+      {presentationError ? <div className="absolute inset-x-4 bottom-4 z-10 rounded-md border border-[#E9C8B6] bg-[#3A2520]/95 px-4 py-3 text-sm text-[#FFE8DB]" data-testid="world-stage-error" role="alert">{presentationError}</div> : null}
     </div>
   );
 }

--- a/desktop/renderer/src/world/index.ts
+++ b/desktop/renderer/src/world/index.ts
@@ -1,6 +1,7 @@
 export { createWorldBridgeClient } from "./bridgeClient";
 export type { WorldBridgeClient } from "./bridgeClient";
 export { GalgameFocusMode } from "./GalgameFocusMode";
+export { WorldGameSurface } from "./WorldGameSurface";
 export { WorldStage } from "./WorldStage";
 export { WorldAppSurface } from "./WorldAppSurface";
 export { SceneShot } from "./SceneShot";

--- a/desktop/renderer/src/world/worldGamePresentation.ts
+++ b/desktop/renderer/src/world/worldGamePresentation.ts
@@ -1,0 +1,41 @@
+import type { PerformancePlan, WorldPresentationSession } from "./presentationProtocol";
+import type { SceneBeat, WorldDetails } from "./types";
+
+export type WorldGamePresentationSelection = {
+  plan: PerformancePlan | null;
+  preloadPlan?: PerformancePlan;
+  beat: SceneBeat | null;
+  session: WorldPresentationSession | null;
+  startCueIndex: number;
+  canPlay: boolean;
+};
+
+function selectBeat(world: WorldDetails, plan: PerformancePlan | null): SceneBeat | null {
+  if (plan) return world.scene.beats.find((beat) => beat.id === plan.eventId) ?? null;
+  return [...world.scene.beats].reverse()[0] ?? null;
+}
+
+/** Selects the durable active plan and cursor without treating stale queues as playable. */
+export function selectWorldGamePresentation(world: WorldDetails): WorldGamePresentationSelection {
+  const plans = world.presentation?.plans ?? [];
+  const session = world.presentation?.session ?? null;
+  const activeIndex = session?.activePlanId
+    ? plans.findIndex((candidate) => candidate.planId === session.activePlanId)
+    : 0;
+  const planIndex = activeIndex >= 0 ? activeIndex : 0;
+  const queuedPlan = plans[planIndex] ?? null;
+  const canPlay = Boolean(queuedPlan && (!session || session.status === "playing" || session.status === "paused"));
+  const plan = canPlay ? queuedPlan : null;
+  const startCueIndex = plan && session?.activePlanId === plan.planId
+    ? Math.min(plan.cues.length, Math.max(0, session.activeCueIndex))
+    : 0;
+
+  return {
+    plan,
+    preloadPlan: plan ? plans[planIndex + 1] : undefined,
+    beat: selectBeat(world, plan),
+    session,
+    startCueIndex,
+    canPlay,
+  };
+}

--- a/docs/knowledge/modules/persistent-world-and-presentation.md
+++ b/docs/knowledge/modules/persistent-world-and-presentation.md
@@ -2,7 +2,7 @@
 title: 持久世界与演出
 kind: 领域说明
 status: 当前有效
-last_verified_commit: 12f37fe5
+last_verified_commit: 9896f304
 source_paths:
   - world_simulation/
   - desktop_bridge/world_simulation_handler.py
@@ -28,6 +28,8 @@ related:
 
 React 在进入 `WorldStage` 前用 `hydrateWorldPresentationAssets()` 将 bridge 路径替换为 opaque URL 并移除原始路径。Pixi adapter 只接收 `PerformancePlan` 与 `WorldAssetManifestEntry`，不读取 bridge、store 或世界数据库；WebGL 失效时切换文本 adapter。
 
+World 入口在独立的 `WorldRoute` 中挂载 bridge/controller，进入后由 `WorldGameSurface` 按持久化 `activePlanId` 和 `activeCueIndex` 选择当前计划；空队列切换到自由行动，待决屏障阻止陈旧计划继续播放。`WorldStage` 的 Pixi 失败降级从最近一次成功 checkpoint 的下一个 cue 恢复，checkpoint 或 bridge 失败则保留错误状态，不以文本重播掩盖持久化问题。
+
 ## 修改影响
 
 - 修改世界事实或结算：检查 repository transaction、timeline projection、idempotency、outbox、复制世界和 backfill 因果约束。
@@ -41,3 +43,5 @@ React 在进入 `WorldStage` 前用 `hydrateWorldPresentationAssets()` 将 bridg
 - 已有世界只读取自己的角色快照，不回读可变角色定义。
 - Pixi 不接触本地路径；本地图片只能通过 opaque asset transport 加载。
 - 恢复已完成 cue 时不得重复业务 checkpoint。
+- 非 World 路由不得初始化 World bridge、controller 或演出舞台。
+- 表现 renderer 失败可以降级为文本，但不得重复提交已经成功的 checkpoint；checkpoint 失败必须原样暴露给界面。


### PR DESCRIPTION
Part of #39\nCloses #44\n\n## Summary\n- enter World directly into the full-screen game surface and keep World bridge/controller lifecycle route-scoped\n- add fixed Galgame controls, action input, DecisionBarrier choices, timeline access, pause/resume and scene redraw actions\n- select and restore the durable active presentation plan/cue cursor\n- coordinate Pixi and text fallback playback without duplicate checkpoints or masking bridge failures\n\n## Validation\n- npm test (422 tests: 421 passed, 1 skipped)\n- npm run typecheck\n- npm run build:desktop\n- .\\.venv\\Scripts\\python.exe -m pytest tests/world_simulation tests/desktop_bridge/test_world_simulation_handler.py (23 passed)\n- graphify update .\n\n## Known follow-up\n- Real Electron/Playwright matrix, audio, performance budgets and failure-recovery acceptance remain in #45 and #46.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces the full-screen World Game Surface with playback controls and a route-scoped World bridge/controller, enabling durable plan/cue restoration and robust Pixi-to-text fallback during performances.

- **New Features**
  - Added `WorldGameSurface` with pause/resume, skip, redraw, open timeline, and exit controls.
  - Added `WorldGameInteraction` for actions and DecisionBarrier choices; shows action composer when the queue is empty.
  - Selects active plan/cue via `selectWorldGamePresentation` using `activePlanId` and `activeCueIndex`; preloads the next plan.
  - Coordinated fallback in `WorldStage`: keeps startCueIndex, checkpoints each cue once, and switches to text only on renderer failure.
  - Introduced `WorldRoute` to mount the World bridge/controller only on the World view; default entry mode is now "game", with timeline returning to the correct view.

- **Bug Fixes**
  - Ignores stale queued plans when a decision barrier is active.
  - Prevents duplicate checkpoints when falling back from Pixi to text.
  - Surfaces checkpoint/bridge errors instead of hiding them behind text fallback.

<sup>Written for commit cfa8b5164cbe0e1b4d9677aa9d9731f2b3f57cfa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

