### PR TITLE
feat(world): add dialogue voice playback

### DIFF
--- a/desktop/renderer/src/app/useWorldWorkspacePresentation.tsx
+++ b/desktop/renderer/src/app/useWorldWorkspacePresentation.tsx
@@ -187,6 +187,7 @@ export function useWorldWorkspacePresentation({ roles, client, controller }: Use
           onPause={controller.pausePresentation}
           onResume={controller.resumePresentation}
           onCheckpoint={controller.checkpointPresentation}
+          synthesizeVoice={client.synthesizeVoice}
         />
       );
     }

--- a/desktop/renderer/src/world/WorldGameSurface.test.tsx
+++ b/desktop/renderer/src/world/WorldGameSurface.test.tsx
@@ -20,6 +20,7 @@ function render(world = createWorldDetails()) {
       onPause={() => undefined}
       onResume={() => undefined}
       onCheckpoint={() => undefined}
+      synthesizeVoice={async () => ({ audioBase64: "", format: "mp3" })}
     />,
   );
 }

--- a/desktop/renderer/src/world/WorldGameSurface.tsx
+++ b/desktop/renderer/src/world/WorldGameSurface.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import type { WorldBridgeClient } from "./bridgeClient";
 import { WorldGameControls } from "./WorldGameControls";
 import { WorldGameInteraction } from "./WorldGameInteraction";
 import type { DecisionBarrier, SceneBeat, WorldDetails } from "./types";
@@ -18,6 +19,7 @@ type WorldGameSurfaceProps = {
   onPause: () => Promise<void> | void;
   onResume: () => Promise<void> | void;
   onCheckpoint: (planId: string, cueIndex: number) => Promise<void> | void;
+  synthesizeVoice: WorldBridgeClient["synthesizeVoice"];
 };
 
 function initialVisual(beat: SceneBeat | null) {
@@ -28,7 +30,7 @@ function initialVisual(beat: SceneBeat | null) {
 }
 
 /** Owns the World visual-novel lifecycle while management views remain separate. */
-export function WorldGameSurface({ world, busy = false, onOpenTimeline, onExitWorkspace, onSubmitAction, onAdvance, onResolveBarrier, onRedrawShot, onPause, onResume, onCheckpoint }: WorldGameSurfaceProps) {
+export function WorldGameSurface({ world, busy = false, onOpenTimeline, onExitWorkspace, onSubmitAction, onAdvance, onResolveBarrier, onRedrawShot, onPause, onResume, onCheckpoint, synthesizeVoice }: WorldGameSurfaceProps) {
   const { plan, preloadPlan, beat, session, startCueIndex, canPlay } = selectWorldGamePresentation(world);
   const [paused, setPaused] = useState(session?.status === "paused");
   const [skipVersion, setSkipVersion] = useState(0);
@@ -58,7 +60,7 @@ export function WorldGameSurface({ world, busy = false, onOpenTimeline, onExitWo
 
   return (
     <section className="relative h-full min-h-0 overflow-hidden bg-[#151816] text-white" data-testid="world-game-surface">
-      {hydratedPlan ? <WorldStage plan={hydratedPlan} preloadPlan={hydratedPreloadPlan} fallbackText={beat?.content ?? ""} initialVisual={initialVisual(beat)} startCueIndex={startCueIndex} paused={isPaused} skipVersion={skipVersion} onCueComplete={(cue) => onCheckpoint(cue.planId, cue.sequence)} /> : beat?.shot?.assets[0] ? <img className="absolute inset-0 h-full w-full object-cover" src={beat.shot.assets[0].imageUrl} alt={beat.shot.prompt} /> : <div className="absolute inset-0 bg-[#252C28]" />}
+      {hydratedPlan ? <WorldStage plan={hydratedPlan} preloadPlan={hydratedPreloadPlan} fallbackText={beat?.content ?? ""} initialVisual={initialVisual(beat)} startCueIndex={startCueIndex} paused={isPaused} skipVersion={skipVersion} synthesizeVoice={synthesizeVoice} onCueComplete={(cue) => onCheckpoint(cue.planId, cue.sequence)} /> : beat?.shot?.assets[0] ? <img className="absolute inset-0 h-full w-full object-cover" src={beat.shot.assets[0].imageUrl} alt={beat.shot.prompt} /> : <div className="absolute inset-0 bg-[#252C28]" />}
       <div className="pointer-events-none absolute inset-0 bg-black/35" />
       <WorldGameControls worldName={world.name} paused={isPaused} onPause={pause} onResume={resume} onSkip={() => setSkipVersion((value) => value + 1)} onRedraw={beat?.shot ? () => onRedrawShot(beat.shot!.id) : undefined} onOpenTimeline={onOpenTimeline} onExitWorkspace={exitWorkspace} />
       <WorldGameInteraction world={world} beat={beat} paused={isPaused} performing={performing} busy={busy} onSubmitAction={onSubmitAction} onAdvance={onAdvance} onResolveBarrier={onResolveBarrier} />

--- a/desktop/renderer/src/world/WorldStage.tsx
+++ b/desktop/renderer/src/world/WorldStage.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { useLatestRef } from "../shared/useLatestRef";
 import type { PerformancePlan, PresentationCue } from "./presentationProtocol";
+import { WorldVoicePlayback, type WorldVoiceCue, type WorldVoiceProfile } from "./worldVoicePlayback";
 import {
   createWorldAssetManifest,
   playPresentationPlan,
@@ -9,6 +10,7 @@ import {
   type WorldPresentationPrepareRequest,
   type WorldPresentationRenderer,
 } from "./worldPresentationRenderer";
+import type { WorldVoiceAudio } from "./worldVoicePlayback";
 
 type WorldStageProps = {
   plan: PerformancePlan;
@@ -18,6 +20,7 @@ type WorldStageProps = {
   startCueIndex?: number;
   paused?: boolean;
   skipVersion?: number;
+  synthesizeVoice?: (text: string, voiceProfile: Record<string, unknown>, signal: AbortSignal) => Promise<{ audioBase64: string; format: "mp3" }>;
   onCueComplete?: (cue: PresentationCue) => Promise<void> | void;
 };
 
@@ -32,6 +35,7 @@ export type WorldStagePlaybackCoordinatorOptions = {
   pixiRenderer: WorldPresentationRenderer;
   textRenderer: WorldPresentationRenderer;
   onCueComplete?: (cue: PresentationCue) => Promise<void> | void;
+  onCueRendered?: (cue: PresentationCue) => Promise<void> | void;
   onFallback?: () => Promise<void> | void;
 };
 
@@ -71,6 +75,7 @@ export function createWorldStagePlaybackCoordinator(options: WorldStagePlaybackC
   const play = (renderer: WorldPresentationRenderer, signal: AbortSignal) => playPresentationPlan(renderer, options.request, {
     signal,
     startCueIndex: nextCueIndex,
+    onCueRendered: options.onCueRendered,
     onCueComplete: checkpoint,
   });
 
@@ -121,13 +126,60 @@ function initialRequest(
   return { plan, manifest, initialAssetId: initialVisual?.id, fallbackText };
 }
 
+function voiceCueForPresentation(cue: PresentationCue, worldId: string): WorldVoiceCue | null {
+  if (cue.kind !== "dialogue") return null;
+  const text = cue.payload.content ?? cue.payload.text;
+  if (typeof text !== "string") return null;
+  const profile = cue.payload.voiceProfile;
+  return {
+    cueId: cue.cueId,
+    worldId,
+    text,
+    voiceProfile: typeof profile === "object" && profile !== null && !Array.isArray(profile)
+      ? profile as WorldVoiceProfile
+      : null,
+  };
+}
+
+function createBrowserVoiceAudio(audioBase64: string, _format: "mp3"): WorldVoiceAudio {
+  const audio = new Audio(`data:audio/mpeg;base64,${audioBase64}`);
+  let onended: (() => void) | null = null;
+  let onerror: ((event: unknown) => void) | null = null;
+  audio.onended = () => onended?.();
+  audio.onerror = (event) => onerror?.(event);
+  return {
+    get onended() {
+      return onended;
+    },
+    set onended(handler) {
+      onended = handler;
+    },
+    get onerror() {
+      return onerror;
+    },
+    set onerror(handler) {
+      onerror = handler;
+    },
+    get src() {
+      return audio.src;
+    },
+    set src(value) {
+      audio.src = value;
+    },
+    play: () => audio.play(),
+    pause: () => audio.pause(),
+    load: () => audio.load(),
+  };
+}
+
 /** Thin React host that owns playback controls while adapters own rendering details. */
-export function WorldStage({ plan, preloadPlan, fallbackText, initialVisual, startCueIndex = 0, paused = false, skipVersion = 0, onCueComplete }: WorldStageProps) {
+export function WorldStage({ plan, preloadPlan, fallbackText, initialVisual, startCueIndex = 0, paused = false, skipVersion = 0, synthesizeVoice, onCueComplete }: WorldStageProps) {
   const hostRef = useRef<HTMLDivElement | null>(null);
   const rendererRef = useRef<WorldPresentationRenderer | null>(null);
   const checkpointRef = useLatestRef(onCueComplete);
   const skipVersionRef = useRef(skipVersion);
   const pausedRef = useLatestRef(paused);
+  const voicePlaybackRef = useRef<WorldVoicePlayback | null>(null);
   const [fallback, setFallback] = useState<TextPresentationSnapshot | null>(null);
   const [presentationError, setPresentationError] = useState<string | null>(null);
   const initialVisualId = initialVisual?.id;
@@ -154,6 +206,11 @@ export function WorldStage({ plan, preloadPlan, fallbackText, initialVisual, sta
     const textRenderer = new TextWorldPresentationRenderer((snapshot) => {
       if (active) setFallback(snapshot);
     });
+    const voicePlayback = synthesizeVoice ? new WorldVoicePlayback({
+      synthesize: (text, profile, signal) => synthesizeVoice(text, profile as Record<string, unknown>, signal),
+      createAudio: createBrowserVoiceAudio,
+    }) : null;
+    voicePlaybackRef.current = voicePlayback;
 
     const reportFailure = (error: unknown) => {
       if (active && !controller.signal.aborted) {
@@ -187,6 +244,10 @@ export function WorldStage({ plan, preloadPlan, fallbackText, initialVisual, sta
           pixiRenderer: renderer,
           textRenderer,
           onCueComplete: (cue) => active ? checkpointRef.current?.(cue) : undefined,
+          onCueRendered: (cue) => {
+            const voiceCue = voiceCueForPresentation(cue, request.plan.worldId);
+            if (voiceCue) void voicePlayback?.playCue(voiceCue);
+          },
           onFallback: activateTextRenderer,
         });
         await renderer.initialize(host);
@@ -207,6 +268,10 @@ export function WorldStage({ plan, preloadPlan, fallbackText, initialVisual, sta
             await playPresentationPlan(textRenderer, request, {
               signal: controller.signal,
               startCueIndex,
+              onCueRendered: (cue) => {
+                const voiceCue = voiceCueForPresentation(cue, request.plan.worldId);
+                if (voiceCue) void voicePlayback?.playCue(voiceCue);
+              },
               onCueComplete: (cue) => active ? checkpointRef.current?.(cue) : undefined,
             });
           }
@@ -219,19 +284,27 @@ export function WorldStage({ plan, preloadPlan, fallbackText, initialVisual, sta
     return () => {
       active = false;
       controller.abort();
+      voicePlayback?.dispose();
+      voicePlaybackRef.current = null;
       renderer?.dispose();
       textRenderer.dispose();
       rendererRef.current = null;
     };
-  }, [checkpointRef, pausedRef, request, startCueIndex]);
+  }, [checkpointRef, pausedRef, request, startCueIndex, synthesizeVoice]);
 
   useEffect(() => {
-    if (paused) rendererRef.current?.pause();
-    else rendererRef.current?.resume();
+    if (paused) {
+      rendererRef.current?.pause();
+      voicePlaybackRef.current?.pause();
+    } else {
+      rendererRef.current?.resume();
+      voicePlaybackRef.current?.resume();
+    }
   }, [paused]);
 
   useEffect(() => {
     if (skipVersion !== skipVersionRef.current) rendererRef.current?.skip();
+    if (skipVersion !== skipVersionRef.current) voicePlaybackRef.current?.skip();
     skipVersionRef.current = skipVersion;
   }, [skipVersion]);
 

--- a/desktop/renderer/src/world/bridgeClient.test.ts
+++ b/desktop/renderer/src/world/bridgeClient.test.ts
@@ -54,4 +54,30 @@ describe("createWorldBridgeClient", () => {
       payload: { world_id: "world-1", plan_id: "plan-1", cue_index: 0 },
     }]);
   });
+
+  it("maps dialogue voice synthesis to the MiniMax voice bridge contract", async () => {
+    const requests: Array<{ method: string; payload: Record<string, unknown> }> = [];
+    const invoke = async (request: { method: string; payload: Record<string, unknown> }): Promise<BridgeResponse> => {
+      requests.push(request);
+      return {
+        id: "response",
+        type: "response",
+        method: request.method,
+        payload: { audio_base64: "encoded-mp3", format: "mp3" },
+        error: null,
+      };
+    };
+
+    const result = await createWorldBridgeClient(invoke).synthesizeVoice("你好", {
+      voiceId: "voice-1",
+      speed: 1.2,
+      emotion: "calm",
+    });
+
+    assert.deepEqual(result, { audioBase64: "encoded-mp3", format: "mp3" });
+    assert.deepEqual(requests, [{
+      method: "voice.synthesize",
+      payload: { text: "你好", voice_id: "voice-1", speed: 1.2, emotion: "calm" },
+    }]);
+  });
 });

--- a/desktop/renderer/src/world/bridgeClient.ts
+++ b/desktop/renderer/src/world/bridgeClient.ts
@@ -20,6 +20,11 @@ import { WorldBridgeError } from "./types";
 
 type DesktopInvoke = typeof window.miraDesktop.invoke;
 
+export type WorldVoiceSynthesis = {
+  audioBase64: string;
+  format: "mp3";
+};
+
 async function invokePayload<T>(invoke: DesktopInvoke, method: string, payload: Record<string, unknown>) {
   const response = await invoke({ method, payload });
   if (response.error) {
@@ -48,6 +53,7 @@ export interface WorldBridgeClient {
   pausePresentation(worldId: string): Promise<WorldPresentationState>;
   resumePresentation(worldId: string): Promise<WorldPresentationState>;
   checkpointPresentation(worldId: string, planId: string, cueIndex: number): Promise<WorldPresentationState>;
+  synthesizeVoice(text: string, voiceProfile: Record<string, unknown>): Promise<WorldVoiceSynthesis>;
   redrawShot(worldId: string, shotId: string): Promise<SceneShot>;
 }
 
@@ -141,6 +147,18 @@ export function createWorldBridgeClient(invoke: DesktopInvoke = window.miraDeskt
         plan_id: planId,
         cue_index: cueIndex,
       })).presentation);
+    },
+    async synthesizeVoice(text, voiceProfile) {
+      const payload = await invokePayload<{ audio_base64: string; format: string }>(invoke, "voice.synthesize", {
+        text,
+        voice_id: voiceProfile.voiceId,
+        speed: voiceProfile.speed,
+        emotion: voiceProfile.emotion,
+      });
+      if (typeof payload.audio_base64 !== "string" || payload.format !== "mp3") {
+        throw new WorldBridgeError("语音服务返回格式无效", "invalid_voice_response");
+      }
+      return { audioBase64: payload.audio_base64, format: "mp3" };
     },
     async redrawShot(worldId, shotId) {
       return (await invokePayload<{ shot: SceneShot }>(invoke, "worlds.shots.redraw", {

--- a/desktop/renderer/src/world/worldPresentationRenderer.ts
+++ b/desktop/renderer/src/world/worldPresentationRenderer.ts
@@ -93,6 +93,7 @@ export async function playPresentationPlan(
   options: {
     signal?: AbortSignal;
     startCueIndex?: number;
+    onCueRendered?: (cue: PresentationCue) => Promise<void> | void;
     onCueComplete?: (cue: PresentationCue) => Promise<void> | void;
   } = {},
 ): Promise<void> {
@@ -108,6 +109,7 @@ export async function playPresentationPlan(
       throw options.signal.reason ?? new DOMException("Aborted", "AbortError");
     }
     await renderer.render(cue, options.signal);
+    await options.onCueRendered?.(cue);
     if (cue.checkpoint || index === request.plan.cues.length - 1) {
       await options.onCueComplete?.(cue);
     }

--- a/desktop/renderer/src/world/worldVoicePlayback.test.ts
+++ b/desktop/renderer/src/world/worldVoicePlayback.test.ts
@@ -1,0 +1,249 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  WorldVoicePlayback,
+  type WorldVoiceAudio,
+  type WorldVoiceCue,
+  type WorldVoiceProfile,
+} from "./worldVoicePlayback";
+
+class FakeAudio implements WorldVoiceAudio {
+  onended: (() => void) | null = null;
+  onerror: ((event: unknown) => void) | null = null;
+  src = "audio";
+  playCount = 0;
+  pauseCount = 0;
+  loadCount = 0;
+  shouldRejectPlay = false;
+
+  play(): Promise<void> {
+    this.playCount += 1;
+    return this.shouldRejectPlay ? Promise.reject(new Error("play failed")) : Promise.resolve();
+  }
+
+  pause(): void {
+    this.pauseCount += 1;
+  }
+
+  load(): void {
+    this.loadCount += 1;
+  }
+
+  finish(): void {
+    this.onended?.();
+  }
+
+  fail(): void {
+    this.onerror?.(new Error("audio error"));
+  }
+}
+
+function profile(overrides: Partial<WorldVoiceProfile> = {}): WorldVoiceProfile {
+  return { configVersion: 1, voiceId: "voice-1", speed: 1, emotion: "calm", ...overrides };
+}
+
+function cue(overrides: Partial<WorldVoiceCue> = {}): WorldVoiceCue {
+  return { cueId: "cue-1", worldId: "world-1", text: "  你好   世界  ", voiceProfile: profile(), ...overrides };
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((promiseResolve, promiseReject) => {
+    resolve = promiseResolve;
+    reject = promiseReject;
+  });
+  return { promise, resolve, reject };
+}
+
+async function flush(): Promise<void> {
+  await new Promise<void>((resolve) => setImmediate(resolve));
+}
+
+describe("WorldVoicePlayback", () => {
+  it("serializes playback and normalizes text before synthesis", async () => {
+    const calls: string[] = [];
+    const audios: FakeAudio[] = [];
+    const playback = new WorldVoicePlayback({
+      synthesize: async (text, voice, signal) => {
+        calls.push(`${text}|${voice.voiceId}|${signal.aborted}`);
+        return { audioBase64: `audio-${calls.length}`, format: "mp3" };
+      },
+      createAudio: () => {
+        const audio = new FakeAudio();
+        audios.push(audio);
+        return audio;
+      },
+    });
+
+    const first = playback.playCue(cue());
+    const second = playback.playCue(cue({ cueId: "cue-2", text: "第二句" }));
+    await flush();
+    assert.deepEqual(calls, ["你好 世界|voice-1|false"]);
+    assert.equal(audios.length, 1);
+    audios[0].finish();
+    await flush();
+    assert.deepEqual(calls, ["你好 世界|voice-1|false", "第二句|voice-1|false"]);
+    audios[1].finish();
+    assert.deepEqual(await first, { cueId: "cue-1", status: "played" });
+    assert.deepEqual(await second, { cueId: "cue-2", status: "played" });
+  });
+
+  it("does not synthesize without a valid profile", async () => {
+    let synthesisCount = 0;
+    const playback = new WorldVoicePlayback({
+      synthesize: async () => {
+        synthesisCount += 1;
+        return { audioBase64: "audio", format: "mp3" };
+      },
+      createAudio: () => new FakeAudio(),
+    });
+
+    assert.deepEqual(await playback.playCue(cue({ voiceProfile: null })), {
+      cueId: "cue-1",
+      status: "no_voice",
+      reason: "no_voice_profile",
+    });
+    assert.deepEqual(await playback.playCue(cue({ voiceProfile: profile({ voiceId: "" }) })), {
+      cueId: "cue-1",
+      status: "no_voice",
+      reason: "no_voice_profile",
+    });
+    assert.equal(synthesisCount, 0);
+  });
+
+  it("caches by world, voice version, normalized text, speed, and emotion", async () => {
+    let synthesisCount = 0;
+    const audios: FakeAudio[] = [];
+    const playback = new WorldVoicePlayback({
+      synthesize: async () => {
+        synthesisCount += 1;
+        return { audioBase64: "cached-audio", format: "mp3" };
+      },
+      createAudio: () => {
+        const audio = new FakeAudio();
+        audios.push(audio);
+        return audio;
+      },
+    });
+
+    const first = playback.playCue(cue());
+    await flush();
+    audios[0].finish();
+    assert.deepEqual(await first, { cueId: "cue-1", status: "played" });
+    const second = playback.playCue(cue({ cueId: "cue-2" }));
+    await flush();
+    audios[1].finish();
+    assert.deepEqual(await second, { cueId: "cue-2", status: "played" });
+    assert.equal(synthesisCount, 1);
+    assert.equal(playback.cacheSize, 1);
+
+    const changedVersion = playback.playCue(cue({ cueId: "cue-3", voiceProfile: profile({ configVersion: 2 }) }));
+    await flush();
+    audios[2].finish();
+    await changedVersion;
+    assert.equal(synthesisCount, 2);
+  });
+
+  it("pauses and resumes current audio without starting queued cues", async () => {
+    const audios: FakeAudio[] = [];
+    const playback = new WorldVoicePlayback({
+      synthesize: async (text) => ({ audioBase64: text, format: "mp3" }),
+      createAudio: () => {
+        const audio = new FakeAudio();
+        audios.push(audio);
+        return audio;
+      },
+    });
+    const first = playback.playCue(cue());
+    const second = playback.playCue(cue({ cueId: "cue-2", text: "第二句" }));
+    await flush();
+    playback.pause();
+    assert.equal(audios[0].pauseCount, 1);
+    assert.equal(audios[0].playCount, 1);
+    playback.resume();
+    assert.equal(audios[0].playCount, 2);
+    audios[0].finish();
+    await flush();
+    assert.equal(audios.length, 2);
+    audios[1].finish();
+    assert.equal((await first).status, "played");
+    assert.equal((await second).status, "played");
+  });
+
+  it("skips active playback, aborts synthesis, and continues the queue", async () => {
+    const synthesis = deferred<{ audioBase64: string; format: "mp3" }>();
+    let receivedSignal: AbortSignal | undefined;
+    const audios: FakeAudio[] = [];
+    const playback = new WorldVoicePlayback({
+      synthesize: async (_text, _profile, signal) => {
+        receivedSignal = signal;
+        return synthesis.promise;
+      },
+      createAudio: () => {
+        const audio = new FakeAudio();
+        audios.push(audio);
+        return audio;
+      },
+    });
+    const first = playback.playCue(cue());
+    const second = playback.playCue(cue({ cueId: "cue-2" }));
+    await flush();
+    playback.skip();
+    assert.equal(receivedSignal?.aborted, true);
+    assert.equal((await first).status, "skipped");
+    synthesis.resolve({ audioBase64: "late", format: "mp3" });
+    await flush();
+    assert.equal(audios.length, 1);
+    audios[0].finish();
+    assert.equal((await second).status, "played");
+  });
+
+  it("falls back on synthesis and playback errors without throwing", async () => {
+    let audioNumber = 0;
+    const audios: FakeAudio[] = [];
+    const playback = new WorldVoicePlayback({
+      synthesize: async (text) => {
+        if (text === "合成失败") throw new Error("provider unavailable");
+        return { audioBase64: text, format: "mp3" };
+      },
+      createAudio: () => {
+        const audio = new FakeAudio();
+        audioNumber += 1;
+        audio.shouldRejectPlay = audioNumber === 1;
+        audios.push(audio);
+        return audio;
+      },
+    });
+
+    const synthesisFailure = playback.playCue(cue({ text: "合成失败" }));
+    assert.deepEqual(await synthesisFailure, { cueId: "cue-1", status: "fallback", reason: "synthesis_failed" });
+    const playbackFailure = playback.playCue(cue({ cueId: "cue-2", text: "播放失败" }));
+    await flush();
+    assert.deepEqual(await playbackFailure, { cueId: "cue-2", status: "fallback", reason: "playback_failed" });
+  });
+
+  it("cancels active work, destroys audio, and clears cache on dispose", async () => {
+    const audios: FakeAudio[] = [];
+    const playback = new WorldVoicePlayback({
+      synthesize: async () => ({ audioBase64: "audio", format: "mp3" }),
+      createAudio: () => {
+        const audio = new FakeAudio();
+        audios.push(audio);
+        return audio;
+      },
+    });
+    const outcome = playback.playCue(cue());
+    await flush();
+    playback.dispose();
+    assert.equal((await outcome).status, "cancelled");
+    assert.equal(playback.cacheSize, 0);
+    assert.equal(playback.isDisposed, true);
+    assert.equal(audios[0].pauseCount, 1);
+    assert.equal(audios[0].src, "");
+    assert.equal(audios[0].loadCount, 1);
+    assert.deepEqual(await playback.playCue(cue({ cueId: "late" })), { cueId: "late", status: "cancelled", reason: "aborted" });
+  });
+});

--- a/desktop/renderer/src/world/worldVoicePlayback.ts
+++ b/desktop/renderer/src/world/worldVoicePlayback.ts
@@ -1,0 +1,357 @@
+export type WorldVoiceProfile = Readonly<{
+  configVersion?: string | number;
+  config_version?: string | number;
+  voiceId?: string;
+  voice_id?: string;
+  speed?: number;
+  emotion?: string;
+  enabled?: boolean;
+  [key: string]: unknown;
+}>;
+
+export type WorldVoiceSynthesis = {
+  audioBase64: string;
+  format: "mp3";
+};
+
+export type WorldVoiceSynthesize = (
+  text: string,
+  voiceProfile: WorldVoiceProfile,
+  signal: AbortSignal,
+) => Promise<WorldVoiceSynthesis>;
+
+export type WorldVoiceAudio = {
+  onended: (() => void) | null;
+  onerror: ((event: unknown) => void) | null;
+  play(): Promise<void> | void;
+  pause(): void;
+  src?: string;
+  load?: () => void;
+};
+
+export type WorldVoiceAudioFactory = (audioBase64: string, format: "mp3") => WorldVoiceAudio;
+
+export type WorldVoiceCue = {
+  cueId: string;
+  worldId: string;
+  text: string;
+  voiceProfile?: WorldVoiceProfile | null;
+};
+
+export type WorldVoicePlaybackStatus = "played" | "fallback" | "skipped" | "cancelled" | "no_voice";
+
+export type WorldVoicePlaybackOutcome = {
+  cueId: string;
+  status: WorldVoicePlaybackStatus;
+  reason?: "no_voice_profile" | "synthesis_failed" | "playback_failed" | "invalid_audio" | "aborted";
+};
+
+export type WorldVoicePlaybackOptions = {
+  synthesize: WorldVoiceSynthesize;
+  createAudio: WorldVoiceAudioFactory;
+};
+
+type NormalizedVoiceProfile = {
+  version: string | number;
+  voiceId: string;
+  speed: number;
+  emotion: string;
+};
+
+type QueueEntry = {
+  cue: WorldVoiceCue;
+  text: string;
+  profile: NormalizedVoiceProfile;
+  cacheKey: string;
+  resolve: (outcome: WorldVoicePlaybackOutcome) => void;
+};
+
+type ActiveEntry = QueueEntry & {
+  controller: AbortController;
+  audio: WorldVoiceAudio | null;
+  cancelStatus: "skipped" | "cancelled" | null;
+  settled: boolean;
+  resumePlayback: (() => void) | null;
+  finishPlayback: (() => void) | null;
+  generation: number;
+};
+
+/** Plays optional world dialogue voice audio without making speech a cue dependency. */
+export class WorldVoicePlayback {
+  private readonly cache = new Map<string, WorldVoiceSynthesis>();
+  private readonly queue: QueueEntry[] = [];
+  private readonly resumeWaiters = new Set<() => void>();
+  private active: ActiveEntry | null = null;
+  private paused = false;
+  private pumping = false;
+  private disposed = false;
+  private generation = 0;
+
+  constructor(private readonly options: WorldVoicePlaybackOptions) {}
+
+  /** Queues one dialogue cue and resolves when audio or text fallback finishes. */
+  playCue(cue: WorldVoiceCue): Promise<WorldVoicePlaybackOutcome> {
+    if (this.disposed) return Promise.resolve({ cueId: cue.cueId, status: "cancelled", reason: "aborted" });
+
+    const text = normalizeText(cue.text);
+    const profile = normalizeVoiceProfile(cue.voiceProfile);
+    if (!text || !profile) {
+      return Promise.resolve({
+        cueId: cue.cueId,
+        status: "no_voice",
+        reason: "no_voice_profile",
+      });
+    }
+
+    return new Promise<WorldVoicePlaybackOutcome>((resolve) => {
+      this.queue.push({
+        cue,
+        text,
+        profile,
+        cacheKey: createCacheKey(cue.worldId, profile, text),
+        resolve,
+      });
+      void this.pump();
+    });
+  }
+
+  /** Alias kept terse for callers that model playback as a normal queue. */
+  enqueue(cue: WorldVoiceCue): Promise<WorldVoicePlaybackOutcome> {
+    return this.playCue(cue);
+  }
+
+  /** Pauses the current audio and prevents the next queued cue from starting. */
+  pause(): void {
+    if (this.disposed || this.paused) return;
+    this.paused = true;
+    this.active?.audio?.pause();
+  }
+
+  /** Resumes the current audio or releases a queue paused before synthesis began. */
+  resume(): void {
+    if (this.disposed || !this.paused) return;
+    this.paused = false;
+    const waiters = [...this.resumeWaiters];
+    this.resumeWaiters.clear();
+    for (const resolve of waiters) resolve();
+    this.active?.resumePlayback?.();
+  }
+
+  /** Skips only the current cue and continues with the remaining queue. */
+  skip(): void {
+    const active = this.active;
+    if (!active) return;
+    active.cancelStatus = "skipped";
+    active.controller.abort();
+    active.finishPlayback?.();
+    this.destroyAudio(active.audio);
+    this.settle(active, { cueId: active.cue.cueId, status: "skipped", reason: "aborted" });
+  }
+
+  /** Cancels the active cue and every queued cue. */
+  cancel(): void {
+    const active = this.active;
+    for (const entry of this.queue.splice(0)) {
+      entry.resolve({ cueId: entry.cue.cueId, status: "cancelled", reason: "aborted" });
+    }
+    if (!active) return;
+    active.cancelStatus = "cancelled";
+    active.controller.abort();
+    active.finishPlayback?.();
+    this.destroyAudio(active.audio);
+    this.settle(active, { cueId: active.cue.cueId, status: "cancelled", reason: "aborted" });
+  }
+
+  /** Aborts outstanding synthesis, destroys audio, clears cache, and retires the player. */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.cancel();
+    this.cache.clear();
+    this.paused = false;
+    for (const resolve of this.resumeWaiters) resolve();
+    this.resumeWaiters.clear();
+  }
+
+  /** Clears synthesized audio so tests and callers can control cache lifetime explicitly. */
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  get cacheSize(): number {
+    return this.cache.size;
+  }
+
+  get isDisposed(): boolean {
+    return this.disposed;
+  }
+
+  private async pump(): Promise<void> {
+    if (this.pumping || this.disposed || this.paused || this.active || this.queue.length === 0) return;
+    this.pumping = true;
+    try {
+      while (!this.disposed && !this.paused && !this.active && this.queue.length > 0) {
+        const entry = this.queue.shift();
+        if (!entry) return;
+        await this.process(entry);
+      }
+    } finally {
+      this.pumping = false;
+      if (!this.disposed && !this.paused && !this.active && this.queue.length > 0) void this.pump();
+    }
+  }
+
+  private async process(entry: QueueEntry): Promise<void> {
+    const active: ActiveEntry = {
+      ...entry,
+      controller: new AbortController(),
+      audio: null,
+      cancelStatus: null,
+      settled: false,
+      resumePlayback: null,
+      finishPlayback: null,
+      generation: ++this.generation,
+    };
+    this.active = active;
+
+    try {
+      const synthesized = this.cache.get(entry.cacheKey) ?? await this.synthesize(active);
+      if (active.cancelStatus) return;
+      if (!isValidSynthesis(synthesized)) {
+        this.settle(active, { cueId: entry.cue.cueId, status: "fallback", reason: "invalid_audio" });
+        return;
+      }
+      this.cache.set(entry.cacheKey, synthesized);
+      await this.waitUntilResumed(active.controller.signal);
+      if (active.cancelStatus || this.disposed) return;
+      await this.playAudio(active, synthesized);
+    } catch (error) {
+      if (active.cancelStatus || active.controller.signal.aborted || this.disposed) return;
+      this.settle(active, {
+        cueId: entry.cue.cueId,
+        status: "fallback",
+        reason: error instanceof Error && error.name === "AbortError" ? "aborted" : "synthesis_failed",
+      });
+    } finally {
+      active.resumePlayback = null;
+      active.finishPlayback = null;
+      this.destroyAudio(active.audio);
+      if (this.active === active) this.active = null;
+    }
+  }
+
+  private async synthesize(active: ActiveEntry): Promise<WorldVoiceSynthesis> {
+    try {
+      const synthesized = await this.options.synthesize(active.text, active.cue.voiceProfile as WorldVoiceProfile, active.controller.signal);
+      if (active.cancelStatus || active.controller.signal.aborted) throw createAbortError();
+      return synthesized;
+    } catch (error) {
+      if (active.cancelStatus || active.controller.signal.aborted) throw createAbortError();
+      throw error;
+    }
+  }
+
+  private async waitUntilResumed(signal: AbortSignal): Promise<void> {
+    if (!this.paused) return;
+    await new Promise<void>((resolve, reject) => {
+      const onAbort = () => {
+        this.resumeWaiters.delete(resolve);
+        reject(createAbortError());
+      };
+      signal.addEventListener("abort", onAbort, { once: true });
+      this.resumeWaiters.add(() => {
+        signal.removeEventListener("abort", onAbort);
+        this.resumeWaiters.delete(resolve);
+        resolve();
+      });
+    });
+  }
+
+  private async playAudio(active: ActiveEntry, synthesized: WorldVoiceSynthesis): Promise<void> {
+    const audio = this.options.createAudio(synthesized.audioBase64, synthesized.format);
+    active.audio = audio;
+    const generation = active.generation;
+    await new Promise<void>((resolve) => {
+      let finished = false;
+      const finish = (outcome: WorldVoicePlaybackOutcome): void => {
+        if (finished || this.active !== active || active.generation !== generation) return;
+        finished = true;
+        active.resumePlayback = null;
+        this.settle(active, outcome);
+        resolve();
+      };
+      active.finishPlayback = () => finish({
+        cueId: active.cue.cueId,
+        status: active.cancelStatus ?? "cancelled",
+        reason: "aborted",
+      });
+      audio.onended = () => finish({ cueId: active.cue.cueId, status: "played" });
+      audio.onerror = () => finish({ cueId: active.cue.cueId, status: "fallback", reason: "playback_failed" });
+      const start = (): void => {
+        if (finished || active.cancelStatus || this.disposed) return;
+        try {
+          Promise.resolve(audio.play()).catch(() => finish({ cueId: active.cue.cueId, status: "fallback", reason: "playback_failed" }));
+        } catch {
+          finish({ cueId: active.cue.cueId, status: "fallback", reason: "playback_failed" });
+        }
+      };
+      active.resumePlayback = start;
+      start();
+    });
+  }
+
+  private settle(active: ActiveEntry, outcome: WorldVoicePlaybackOutcome): void {
+    if (active.settled) return;
+    active.settled = true;
+    active.resolve(outcome);
+  }
+
+  private destroyAudio(audio: WorldVoiceAudio | null): void {
+    if (!audio) return;
+    audio.onended = null;
+    audio.onerror = null;
+    try {
+      audio.pause();
+    } catch {
+      // Cleanup must not turn a text fallback into a playback exception.
+    }
+    if ("src" in audio) audio.src = "";
+    try {
+      audio.load?.();
+    } catch {
+      // Some test doubles and browsers reject load after an interrupted play.
+    }
+  }
+}
+
+function normalizeText(value: string): string {
+  return String(value ?? "").trim().replace(/\s+/g, " ");
+}
+
+function normalizeVoiceProfile(profile: WorldVoiceProfile | null | undefined): NormalizedVoiceProfile | null {
+  if (!profile || typeof profile !== "object" || profile.enabled === false) return null;
+  const version = profile.configVersion ?? profile.config_version;
+  const voiceId = String(profile.voiceId ?? profile.voice_id ?? "").trim();
+  const speed = Number(profile.speed);
+  const emotion = String(profile.emotion ?? "").trim();
+  if ((typeof version !== "string" && typeof version !== "number") || String(version).trim() === "") return null;
+  if (!voiceId || !Number.isFinite(speed) || speed < 0.5 || speed > 2) return null;
+  return { version, voiceId, speed, emotion };
+}
+
+function createCacheKey(worldId: string, profile: NormalizedVoiceProfile, text: string): string {
+  return JSON.stringify([worldId, profile.version, profile.voiceId, text, profile.speed, profile.emotion]);
+}
+
+function isValidSynthesis(value: WorldVoiceSynthesis): boolean {
+  return Boolean(value)
+    && value.format === "mp3"
+    && typeof value.audioBase64 === "string"
+    && value.audioBase64.length > 0;
+}
+
+function createAbortError(): Error {
+  const error = new Error("voice playback aborted");
+  error.name = "AbortError";
+  return error;
+}

--- a/desktop_bridge/world_presentation_assets.py
+++ b/desktop_bridge/world_presentation_assets.py
@@ -28,17 +28,70 @@ class WorldPresentationAssetResolver:
         self._visuals = WorldVisualResolver()
 
     def to_bridge_dict(self, plan: PerformancePlan) -> dict[str, Any]:
-        """Return one plan with trusted snapshot paths attached to sprite cues."""
+        """Return one plan enriched with trusted snapshot presentation data."""
 
         value = plan.to_bridge_dict()
         for cue in value["cues"]:
-            if cue["kind"] != "sprites":
-                continue
-            payload = cue["payload"]
-            items = payload.get("items") if isinstance(payload, dict) else None
-            if isinstance(items, list):
-                payload["items"] = [self._sprite(item) for item in items]
+            if cue["kind"] == "sprites":
+                payload = cue["payload"]
+                items = payload.get("items") if isinstance(payload, dict) else None
+                if isinstance(items, list):
+                    payload["items"] = [self._sprite(item) for item in items]
+            elif cue["kind"] == "dialogue":
+                payload = cue["payload"]
+                cue["payload"] = self._dialogue(payload)
         return value
+
+    def _dialogue(self, value: Any) -> Any:
+        if not isinstance(value, dict):
+            return value
+        item = dict(value)
+        item.pop("voiceProfile", None)
+        item.pop("voice_profile", None)
+        actor_id = str(item.get("actor_id") or item.get("actorId") or "").strip()
+        snapshot = self._snapshots_by_actor.get(actor_id)
+        if snapshot is None:
+            return item
+        voice_profile = self._voice_profile(snapshot, str(item.get("mood") or "").strip())
+        if voice_profile is not None:
+            item["voiceProfile"] = voice_profile
+        return item
+
+    @staticmethod
+    def _voice_profile(snapshot: RoleTemplateSnapshot, mood: str) -> dict[str, Any] | None:
+        profile = snapshot.voice_profile
+        if not isinstance(profile, dict):
+            return None
+        voice_id = str(profile.get("voice_id") or "").strip()
+        if not voice_id or profile.get("enabled") is False:
+            return None
+
+        raw_speed = profile.get("speed", 1.0)
+        speed = float(raw_speed) if isinstance(raw_speed, (int, float)) else 1.0
+        if not 0.5 <= speed <= 2.0:
+            speed = 1.0
+        raw_config_version = profile.get("config_version", 1)
+        config_version = (
+            raw_config_version
+            if isinstance(raw_config_version, int) and not isinstance(raw_config_version, bool)
+            else 1
+        )
+        raw_emotions = profile.get("mood_tts_emotions")
+        emotions = raw_emotions if isinstance(raw_emotions, dict) else {}
+        mood_emotions = {
+            str(name).strip(): str(emotion).strip()
+            for name, emotion in emotions.items()
+            if str(name).strip() and str(emotion).strip()
+        }
+        return {
+            "configVersion": config_version,
+            "enabled": True,
+            "provider": str(profile.get("provider") or "minimax").strip() or "minimax",
+            "voiceId": voice_id,
+            "speed": speed,
+            "moodEmotions": mood_emotions,
+            "emotion": mood_emotions.get(mood, ""),
+        }
 
     def _sprite(self, value: Any) -> Any:
         if not isinstance(value, dict):

--- a/docs/knowledge/modules/persistent-world-and-presentation.md
+++ b/docs/knowledge/modules/persistent-world-and-presentation.md
@@ -2,7 +2,7 @@
 title: 持久世界与演出
 kind: 领域说明
 status: 当前有效
-last_verified_commit: 9896f304
+last_verified_commit: f9a11714
 source_paths:
   - world_simulation/
   - desktop_bridge/world_simulation_handler.py

--- a/tests/desktop_bridge/test_world_presentation_assets.py
+++ b/tests/desktop_bridge/test_world_presentation_assets.py
@@ -51,3 +51,100 @@ def test_resolver_enriches_semantic_mood_with_avatar_fallback():
             "image_path": "C:/world-assets/avatar.png",
         }
     ]
+
+
+def _dialogue_plan(payload: dict[str, object]):
+    return compile_performance_plan(
+        TimelineEvent(
+            id="event-dialogue",
+            world_id="world-1",
+            event_type="scene.dialogue.committed",
+            effective_at="2026-07-29T10:00:00+00:00",
+            sequence=1,
+            changes={"presentation": {"dialogue": payload}},
+        )
+    )
+
+
+def _voice_snapshot(**voice_profile: object) -> RoleTemplateSnapshot:
+    return RoleTemplateSnapshot(
+        id="snapshot-voice",
+        source_role_id="role-voice",
+        source_version="v1",
+        persona={},
+        voice_profile=voice_profile,
+    )
+
+
+def test_resolver_projects_safe_voice_profile_and_mood_emotion():
+    plan = _dialogue_plan(
+        {
+            "actor_id": "resident-voice",
+            "mood": "开心",
+            "content": "你好。",
+            "voiceProfile": {"secret_key": "must-not-pass"},
+        }
+    )
+    resolver = WorldPresentationAssetResolver(
+        snapshots=[
+            _voice_snapshot(
+                config_version=1,
+                enabled=True,
+                provider="minimax",
+                voice_id="rin-voice",
+                speed=1.2,
+                mood_tts_emotions={"开心": "happy", "悲伤": "sad"},
+                secret_key="must-not-pass",
+            )
+        ],
+        residents=[
+            NativeResident(id="resident-voice", snapshot_id="snapshot-voice", name="凛")
+        ],
+    )
+
+    dialogue = resolver.to_bridge_dict(plan)["cues"][0]["payload"]
+
+    assert dialogue["voiceProfile"] == {
+        "configVersion": 1,
+        "enabled": True,
+        "provider": "minimax",
+        "voiceId": "rin-voice",
+        "speed": 1.2,
+        "moodEmotions": {"开心": "happy", "悲伤": "sad"},
+        "emotion": "happy",
+    }
+    assert "secret_key" not in str(dialogue)
+
+
+def test_resolver_does_not_project_voice_profile_without_actor_or_voice_id():
+    resolver = WorldPresentationAssetResolver(
+        snapshots=[_voice_snapshot(enabled=True, voice_id="")],
+        residents=[
+            NativeResident(id="resident-voice", snapshot_id="snapshot-voice", name="凛")
+        ],
+    )
+
+    without_actor = resolver.to_bridge_dict(_dialogue_plan({"content": "无声线。"}))
+    without_voice_id = resolver.to_bridge_dict(
+        _dialogue_plan({"actorId": "resident-voice", "content": "无声线。"})
+    )
+
+    assert "voiceProfile" not in without_actor["cues"][0]["payload"]
+    assert "voiceProfile" not in without_voice_id["cues"][0]["payload"]
+
+
+def test_resolver_does_not_project_disabled_voice_profile():
+    plan = _dialogue_plan({"actorId": "resident-voice", "mood": "平静"})
+    resolver = WorldPresentationAssetResolver(
+        snapshots=[
+            _voice_snapshot(enabled=False, voice_id="rin-voice", secret_key="must-not-pass")
+        ],
+        residents=[
+            NativeResident(id="resident-voice", snapshot_id="snapshot-voice", name="凛")
+        ],
+    )
+
+    dialogue = resolver.to_bridge_dict(plan)["cues"][0]["payload"]
+
+    assert "voiceProfile" not in dialogue
+    assert "secret_key" not in str(dialogue)


### PR DESCRIPTION
## Summary
- add optional MiniMax dialogue voice synthesis to World presentation cues
- project frozen role voice profiles into bridge-safe dialogue payloads
- add cached serial playback with pause, resume, skip, cancel, dispose, and text fallback behavior
- keep voice playback failures independent from visual cue checkpoints

Closes #45
Related to #39

## Verification
- `npm run typecheck`
- focused World renderer tests: 19 passed
- `pytest tests/desktop_bridge/test_world_presentation_assets.py tests/desktop_bridge/test_world_simulation_handler.py`: 9 passed
- `pytest tests/desktop_bridge/test_voice_service.py tests/desktop_bridge/test_service.py -k voice`: 20 passed
- `graphify update .`

## Known blockers
- MiniMax voice playback requires valid voice settings and API credentials at runtime.
- The branch is stacked on `codex/issue-44-world-game-surface`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optional dialogue voice playback to World. Voices are synthesized via the bridge MiniMax endpoint and play when cues render, without blocking visual checkpoints.

- **New Features**
  - Added `synthesizeVoice` to the bridge client, mapping to `voice.synthesize` and returning base64 `mp3`.
  - Introduced a queued voice player with cache, pause/resume/skip/cancel/dispose, and text fallback. Playback errors don’t affect visual cue checkpoints.
  - Renderer now calls `onCueRendered` to start voice per cue; `WorldStage` wires voice playback into the game surface.
  - Asset resolver injects a safe `voiceProfile` into dialogue cues from role snapshots (configVersion, voiceId, speed, mood→emotion), removing secrets and invalid configs.
  - Added unit tests for playback behavior, bridge mapping, and resolver projection.

- **Migration**
  - Requires valid voice settings and API credentials at runtime.
  - Branch is stacked on `codex/issue-44-world-game-surface`.

<sup>Written for commit 2b57c383b131c932510316d4e949b86d380d7239. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

