### PR TITLE
refactor(world): restore Day chronicle and scene-only Galgame flow

### DIFF
--- a/desktop/renderer/src/app/WorldWorkspacePresentationView.tsx
+++ b/desktop/renderer/src/app/WorldWorkspacePresentationView.tsx
@@ -2,12 +2,13 @@ import type { RoleRecord } from "../shared/types";
 import { toFileUrl } from "../shared/format";
 import {
   WorldCreateFlow,
+  GalgameFocusMode,
+  WorldDaySurface,
   WorldGameSettings,
   WorldGameSurface,
   WorldLauncher,
   WorldLoadingScreen,
   WorldTimelineView,
-  WorldWorkspace,
 } from "../world";
 import type { useWorldWorkspaceController } from "../world/useWorldWorkspaceController";
 import type { WorldPresentationRuntime } from "../world/worldPresentationRuntime";
@@ -15,6 +16,7 @@ import type { useWorldCreationFlowController } from "./useWorldCreationFlowContr
 import type { useWorldPresentationOperation } from "./useWorldPresentationOperation";
 import type { useWorldTimelineController } from "./useWorldTimelineController";
 import type { WorldPresentationMode } from "./worldPresentationModes";
+import { selectWorldScene } from "../world/worldDayPresentation";
 
 type Props = {
   roles: RoleRecord[];
@@ -26,14 +28,20 @@ type Props = {
   creation: ReturnType<typeof useWorldCreationFlowController>;
   timeline: ReturnType<typeof useWorldTimelineController>;
   runtime: WorldPresentationRuntime;
+  activeSceneId: string;
+  sceneMode: "live" | "replay";
   setMode: (mode: WorldPresentationMode) => void;
   loadWorldForPlay: (worldId: string) => Promise<void>;
-  openGame: () => void;
+  openScene: (sceneId: string) => void;
+  onReturnToDay: (dismissLiveScene: boolean) => void;
+  onSceneComplete: () => void;
+  onOpenSettings: (returnMode: "launcher" | "day") => void;
+  onCloseSettings: () => void;
   onExit: () => void;
 };
 
 /** Dispatches World routes without owning bridge or workflow state. */
-export function WorldWorkspacePresentationView({ roles, mode, loadingWorldId, loadingElapsedMs, controller, operation, creation, timeline, runtime, setMode, loadWorldForPlay, openGame, onExit }: Props) {
+export function WorldWorkspacePresentationView({ roles, mode, loadingWorldId, loadingElapsedMs, controller, operation, creation, timeline, runtime, activeSceneId, sceneMode, setMode, loadWorldForPlay, openScene, onReturnToDay, onSceneComplete, onOpenSettings, onCloseSettings, onExit }: Props) {
   const world = controller.world;
   const error = operation.error || controller.error;
   const busy = operation.busy || controller.busy;
@@ -48,13 +56,13 @@ export function WorldWorkspacePresentationView({ roles, mode, loadingWorldId, lo
     return <WorldLoadingScreen mode="listing" error={error} onRetry={() => void controller.reloadWorlds()} onBack={onExit} />;
   }
   if (mode === "launcher") {
-    return <WorldLauncher worlds={controller.worlds} busy={busy} error={error} onCreateWorld={() => { operation.clearError(); creation.resetDraft(); setMode("create"); }} onLoadWorld={(worldId) => void loadWorldForPlay(worldId)} onOpenSettings={() => { operation.clearError(); setMode("settings"); }} onExit={onExit} />;
+    return <WorldLauncher worlds={controller.worlds} busy={busy} error={error} onCreateWorld={() => { operation.clearError(); creation.resetDraft(); setMode("create"); }} onLoadWorld={(worldId) => void loadWorldForPlay(worldId)} onOpenSettings={() => { operation.clearError(); onOpenSettings("launcher"); }} onExit={onExit} />;
   }
   if (mode === "loading") {
     return <WorldLoadingScreen mode="world" busy={busy} error={error} elapsedMs={loadingElapsedMs} loaded={0} total={1} onRetry={loadingWorldId ? () => void loadWorldForPlay(loadingWorldId) : undefined} onBack={() => setMode("launcher")} />;
   }
   if (mode === "settings") {
-    return <WorldGameSettings onBack={() => { runtime.refreshSettings(); setMode("launcher"); }} />;
+    return <WorldGameSettings onBack={onCloseSettings} />;
   }
   if (mode === "create" || !world) {
     return <WorldCreateFlow roles={worldRoles} initialSeed={creation.seed} busy={operation.busy} draft={creation.draft} onBack={() => setMode("launcher")} onRerollSeed={creation.rerollSeed} onPreview={creation.previewDraft} onConfirm={creation.confirmDraft} />;
@@ -62,8 +70,12 @@ export function WorldWorkspacePresentationView({ roles, mode, loadingWorldId, lo
   if (mode === "timeline") {
     return <WorldTimelineView worldName={world.name} activeOcName={controller.activeOc?.name ?? "当前 OC"} entries={timeline.timeline} perspective={timeline.perspective} backfillPreview={timeline.backfillPreview} onBack={() => setMode(timeline.returnMode)} onPerspectiveChange={timeline.changePerspective} onCopyWorld={timeline.copyWorld} onPreviewBackfill={timeline.previewBackfill} onCommitBackfill={timeline.commitBackfill} />;
   }
-  if (mode === "game") {
-    return <WorldGameSurface world={world} runtime={runtime} busy={busy} onOpenTimeline={() => timeline.open("game")} onExitWorkspace={() => setMode("workspace")} onSubmitAction={controller.submitAction} onAdvance={controller.advance} onResolveBarrier={controller.resolveBarrier} onRedrawShot={controller.redrawShot} onPause={controller.pausePresentation} onResume={controller.resumePresentation} onCheckpoint={controller.checkpointPresentation} />;
+  if (mode === "scene") {
+    const scene = selectWorldScene(world, activeSceneId);
+    if (sceneMode === "replay" && scene) {
+      return <GalgameFocusMode worldName={world.name} beat={scene} onExit={() => onReturnToDay(false)} onRedrawShot={controller.redrawShot} />;
+    }
+    return <WorldGameSurface world={world} runtime={runtime} busy={busy} onOpenTimeline={() => timeline.open("scene")} onExitWorkspace={() => onReturnToDay(true)} onSceneComplete={onSceneComplete} onResolveBarrier={controller.resolveBarrier} onRedrawShot={controller.redrawShot} onPause={controller.pausePresentation} onResume={controller.resumePresentation} onCheckpoint={controller.checkpointPresentation} />;
   }
-  return <WorldWorkspace worlds={controller.worlds} world={world} busy={busy} error={error} onSelectWorld={controller.loadWorld} onSwitchOc={controller.switchOc} onCreateWorld={() => { creation.resetDraft(); setMode("create"); }} onOpenTimeline={() => timeline.open("workspace")} onOpenFocus={openGame} onSubmitAction={controller.submitAction} onAdvance={controller.advance} onResolveBarrier={controller.resolveBarrier} onCancel={controller.cancelRun} onRedrawShot={controller.redrawShot} />;
+  return <WorldDaySurface world={world} busy={busy} error={error} onCompleteDay={controller.completeDay} onReplayScene={openScene} onOpenTimeline={() => timeline.open("day")} onOpenSettings={() => onOpenSettings("day")} onSwitchOc={controller.switchOc} onExit={() => setMode("launcher")} />;
 }

--- a/desktop/renderer/src/app/useWorldSceneNavigation.ts
+++ b/desktop/renderer/src/app/useWorldSceneNavigation.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from "react";
+import { selectPendingWorldScene } from "../world/worldDayPresentation";
+import type { WorldDetails } from "../world/types";
+import type { WorldPresentationMode } from "./worldPresentationModes";
+
+type Args = {
+  world: WorldDetails | null;
+  mode: WorldPresentationMode;
+  setMode: (mode: WorldPresentationMode) => void;
+};
+
+/** Owns automatic live-scene entry, replay selection, and Day return semantics. */
+export function useWorldSceneNavigation({ world, mode, setMode }: Args) {
+  const [activeSceneId, setActiveSceneId] = useState("");
+  const [sceneMode, setSceneMode] = useState<"live" | "replay">("live");
+  const [dismissedPlanId, setDismissedPlanId] = useState("");
+  const pendingScene = selectPendingWorldScene(world);
+  const pendingSceneId = pendingScene?.id ?? "";
+  const pendingPlanId = world?.presentation?.plans[0]?.planId ?? "";
+
+  useEffect(() => {
+    if (mode !== "day" || !pendingSceneId || pendingPlanId === dismissedPlanId) return;
+    setActiveSceneId(pendingSceneId);
+    setSceneMode("live");
+    setMode("scene");
+  }, [dismissedPlanId, mode, pendingPlanId, pendingSceneId, setMode]);
+
+  const prepareLoadedWorld = useCallback(() => {
+    setDismissedPlanId("");
+    setMode("day");
+  }, [setMode]);
+
+  const openScene = useCallback((sceneId: string) => {
+    const liveScene = selectPendingWorldScene(world);
+    setActiveSceneId(sceneId);
+    setSceneMode(liveScene?.id === sceneId ? "live" : "replay");
+    setMode("scene");
+  }, [setMode, world]);
+
+  const returnToDay = useCallback((dismissLiveScene: boolean) => {
+    if (dismissLiveScene && pendingPlanId) setDismissedPlanId(pendingPlanId);
+    setMode("day");
+  }, [pendingPlanId, setMode]);
+
+  const completeLiveScene = useCallback(() => {
+    setDismissedPlanId("");
+    setMode("day");
+  }, [setMode]);
+
+  return {
+    activeSceneId,
+    sceneMode,
+    prepareLoadedWorld,
+    openScene,
+    returnToDay,
+    completeLiveScene,
+  };
+}

--- a/desktop/renderer/src/app/useWorldTimelineController.ts
+++ b/desktop/renderer/src/app/useWorldTimelineController.ts
@@ -16,7 +16,7 @@ type Args = {
 
 /** Owns timeline perspective, copy, and historical-backfill operations. */
 export function useWorldTimelineController({ client, controller, world, loadWorldForPlay, run, setMode }: Args) {
-  const [returnMode, setReturnMode] = useState<TimelineReturnMode>("game");
+  const [returnMode, setReturnMode] = useState<TimelineReturnMode>("day");
   const [timeline, setTimeline] = useState<Awaited<ReturnType<WorldBridgeClient["getTimeline"]>>>([]);
   const [perspective, setPerspective] = useState<"known" | "omniscient">("known");
   const [backfillPreview, setBackfillPreview] = useState<BackfillPreview | null>(null);

--- a/desktop/renderer/src/app/useWorldWorkspacePresentation.tsx
+++ b/desktop/renderer/src/app/useWorldWorkspacePresentation.tsx
@@ -8,6 +8,7 @@ import { useWorldPresentationOperation } from "./useWorldPresentationOperation";
 import { useWorldTimelineController } from "./useWorldTimelineController";
 import { WorldWorkspacePresentationView } from "./WorldWorkspacePresentationView";
 import type { WorldPresentationMode } from "./worldPresentationModes";
+import { useWorldSceneNavigation } from "./useWorldSceneNavigation";
 
 type UseWorldWorkspacePresentationArgs = {
   roles: RoleRecord[];
@@ -21,13 +22,24 @@ export function useWorldWorkspacePresentation({ roles, client, controller, onExi
   const [mode, setMode] = useState<WorldPresentationMode>("launcher");
   const [loadingWorldId, setLoadingWorldId] = useState("");
   const [loadingElapsedMs, setLoadingElapsedMs] = useState(0);
+  const [settingsReturnMode, setSettingsReturnMode] = useState<"launcher" | "day">("launcher");
   const runtime = useMemo(() => new WorldPresentationRuntime({
     synthesizeVoice: (text, profile, signal) => client.synthesizeVoice(text, profile, signal),
   }), [client]);
   const operation = useWorldPresentationOperation();
   const { clearError, reportError, run } = operation;
+  const { loadWorld } = controller;
 
   useEffect(() => () => runtime.dispose(), [runtime]);
+
+  const {
+    activeSceneId,
+    sceneMode,
+    prepareLoadedWorld,
+    openScene,
+    returnToDay,
+    completeLiveScene,
+  } = useWorldSceneNavigation({ world: controller.world, mode, setMode });
 
   const loadWorldForPlay = useCallback(async (worldId: string) => {
     setLoadingWorldId(worldId);
@@ -39,8 +51,8 @@ export function useWorldWorkspacePresentation({ roles, client, controller, onExi
     }, 250);
     const progressTimer = setTimeout(() => setLoadingElapsedMs(2_000), 2_000);
     try {
-      if (await controller.loadWorld(worldId)) {
-        setMode("game");
+      if (await loadWorld(worldId)) {
+        prepareLoadedWorld();
         return;
       }
       reportError("无法加载这个世界，请稍后重试。");
@@ -49,7 +61,7 @@ export function useWorldWorkspacePresentation({ roles, client, controller, onExi
       clearTimeout(transitionTimer);
       clearTimeout(progressTimer);
     }
-  }, [clearError, controller, reportError]);
+  }, [clearError, loadWorld, prepareLoadedWorld, reportError]);
 
   const creation = useWorldCreationFlowController({
     client,
@@ -65,13 +77,15 @@ export function useWorldWorkspacePresentation({ roles, client, controller, onExi
     run,
     setMode,
   });
-  const openGame = useCallback(() => {
-    if (!controller.world?.scene.beats.length) {
-      reportError("当前场景尚无可播放的剧情。");
-      return;
-    }
-    setMode("game");
-  }, [controller.world, reportError]);
+  const openSettings = useCallback((returnMode: "launcher" | "day") => {
+    setSettingsReturnMode(returnMode);
+    setMode("settings");
+  }, []);
+
+  const closeSettings = useCallback(() => {
+    runtime.refreshSettings();
+    setMode(settingsReturnMode);
+  }, [runtime, settingsReturnMode]);
 
   return {
     content: (
@@ -85,9 +99,15 @@ export function useWorldWorkspacePresentation({ roles, client, controller, onExi
         creation={creation}
         timeline={timeline}
         runtime={runtime}
+        activeSceneId={activeSceneId}
+        sceneMode={sceneMode}
         setMode={setMode}
         loadWorldForPlay={loadWorldForPlay}
-        openGame={openGame}
+        openScene={openScene}
+        onReturnToDay={returnToDay}
+        onSceneComplete={completeLiveScene}
+        onOpenSettings={openSettings}
+        onCloseSettings={closeSettings}
         onExit={onExit}
       />
     ),

--- a/desktop/renderer/src/app/worldPresentationModes.ts
+++ b/desktop/renderer/src/app/worldPresentationModes.ts
@@ -1,2 +1,2 @@
-export type WorldPresentationMode = "launcher" | "game" | "workspace" | "create" | "timeline" | "settings" | "loading";
-export type TimelineReturnMode = "game" | "workspace";
+export type WorldPresentationMode = "launcher" | "day" | "scene" | "create" | "timeline" | "settings" | "loading";
+export type TimelineReturnMode = "day" | "scene";

--- a/desktop/renderer/src/world/GalgameFocusMode.test.tsx
+++ b/desktop/renderer/src/world/GalgameFocusMode.test.tsx
@@ -14,6 +14,6 @@ describe("GalgameFocusMode", () => {
     assert.match(markup, /aria-label="暂停演出"/);
     assert.match(markup, /aria-label="跳过当前演出"/);
     assert.match(markup, /aria-label="退出焦点模式"/);
-    assert.match(markup, />返回工作台</);
+    assert.match(markup, />返回当前 Day</);
   });
 });

--- a/desktop/renderer/src/world/GalgameFocusMode.tsx
+++ b/desktop/renderer/src/world/GalgameFocusMode.tsx
@@ -95,7 +95,7 @@ export function GalgameFocusMode({ worldName, beat, plan, preloadPlan, startCueI
           <button className="pointer-events-auto grid h-10 w-10 place-items-center rounded-md bg-black/35 text-white backdrop-blur-sm hover:bg-black/55" type="button" aria-label="退出焦点模式" title="退出焦点模式" onClick={onExit}><X /></button>
         </div>
       </header>
-      <div className="absolute inset-x-0 bottom-0 z-10 px-[clamp(24px,8vw,120px)] pb-[clamp(28px,7vh,72px)]"><div className="max-w-4xl border-l-2 border-[#E59A70] bg-black/45 px-6 py-5 backdrop-blur-md">{beat.speakerName ? <h1 className="m-0 mb-2 font-serif text-lg font-semibold text-[#F3B18B]">{beat.speakerName}</h1> : null}<p className="m-0 whitespace-pre-wrap font-serif text-lg leading-8 text-white">{beat.content}</p></div><button className="pointer-events-auto mt-3 inline-flex h-9 items-center gap-2 rounded-md bg-black/35 px-3 text-xs text-white/80 hover:bg-black/55" type="button" onClick={onExit}><ArrowLeft />返回工作台</button></div>
+      <div className="absolute inset-x-0 bottom-0 z-10 px-[clamp(24px,8vw,120px)] pb-[clamp(28px,7vh,72px)]"><div className="max-w-4xl border-l-2 border-[#E59A70] bg-black/45 px-6 py-5 backdrop-blur-md">{beat.speakerName ? <h1 className="m-0 mb-2 font-serif text-lg font-semibold text-[#F3B18B]">{beat.speakerName}</h1> : null}<p className="m-0 whitespace-pre-wrap font-serif text-lg leading-8 text-white">{beat.content}</p></div><button className="pointer-events-auto mt-3 inline-flex h-9 items-center gap-2 rounded-md bg-black/35 px-3 text-xs text-white/80 hover:bg-black/55" type="button" onClick={onExit}><ArrowLeft />返回当前 Day</button></div>
     </section>
   );
 }

--- a/desktop/renderer/src/world/WorldDaySurface.test.tsx
+++ b/desktop/renderer/src/world/WorldDaySurface.test.tsx
@@ -1,0 +1,63 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { renderToStaticMarkup } from "react-dom/server";
+import { describe, it } from "node:test";
+import { createSceneBeat, createWorldDetails } from "./testFixtures";
+import { WorldDaySurface } from "./WorldDaySurface";
+
+function render(overrides: Parameters<typeof createWorldDetails>[0] = {}) {
+  return renderToStaticMarkup(
+    <WorldDaySurface
+      world={createWorldDetails(overrides)}
+      busy={false}
+      error=""
+      onCompleteDay={async () => true}
+      onReplayScene={() => undefined}
+      onOpenTimeline={() => undefined}
+      onOpenSettings={() => undefined}
+      onSwitchOc={() => undefined}
+      onExit={() => undefined}
+    />,
+  );
+}
+
+describe("WorldDaySurface", () => {
+  it("renders a plot-first day chronicle without attributes or workspace columns", () => {
+    const markup = render();
+
+    assert.match(markup, /data-testid="world-day-surface"/);
+    assert.match(markup, />Day 3</);
+    assert.match(markup, /你终于来了。/);
+    assert.match(markup, /aria-label="结束当前 Day"/);
+    assert.match(markup, /data-current-day="true"/);
+    assert.doesNotMatch(markup, /属性|好感度|world-workspace/);
+  });
+
+  it("keeps completed days read-only and exposes completed scenes for replay", () => {
+    const markup = render({
+      days: [
+        { dayIndex: 2, title: "Day 2", status: "completed", events: [createSceneBeat({ id: "old-scene", presentationMode: "scene" })] },
+        { dayIndex: 3, title: "Day 3", status: "current", events: [createSceneBeat({ id: "today", presentationMode: "narrative" })] },
+      ],
+    });
+
+    assert.match(markup, /aria-label="回看场景：你终于来了。"/);
+    assert.equal((markup.match(/aria-label="结束当前 Day"/g) ?? []).length, 1);
+  });
+
+  it("requires a pending concrete scene to finish before the Day can advance", () => {
+    const base = createWorldDetails();
+    const scene = createSceneBeat({ id: "pending-scene", presentationMode: "scene" });
+    const markup = render({
+      days: [{ dayIndex: 3, title: "Day 3", status: "current", events: [scene] }],
+      presentation: {
+        session: { worldId: base.id, lastPresentedEventSequence: 0, activePlanId: null, activeCueIndex: 0, status: "playing", updatedAt: "2026-07-31T00:00:00+00:00" },
+        plans: [{ schemaVersion: 1, planId: "plan-pending", worldId: base.id, eventId: scene.id, sourceSequence: 1, cues: [] }],
+      },
+    });
+
+    assert.match(markup, /aria-label="继续场景：你终于来了。"/);
+    assert.match(markup, /aria-label="结束当前 Day" disabled=""/);
+  });
+});

--- a/desktop/renderer/src/world/WorldDaySurface.tsx
+++ b/desktop/renderer/src/world/WorldDaySurface.tsx
@@ -1,0 +1,93 @@
+import { ArrowRight, BookOpenText, Gear, PlayCircle, SignOut, UserSwitch } from "@phosphor-icons/react";
+import { useLayoutEffect, useRef, useState } from "react";
+import { AutosizeTextarea } from "../shared/AutosizeTextarea";
+import type { WorldDetails } from "./types";
+
+type WorldDaySurfaceProps = {
+  world: WorldDetails;
+  busy: boolean;
+  error: string;
+  onCompleteDay: (content: string) => Promise<boolean>;
+  onReplayScene: (sceneId: string) => void;
+  onOpenTimeline: () => void;
+  onOpenSettings: () => void;
+  onSwitchOc: (ocId: string) => void;
+  onExit: () => void;
+};
+
+/** Renders the plot-first Day chronicle and its single end-of-day command. */
+export function WorldDaySurface({ world, busy, error, onCompleteDay, onReplayScene, onOpenTimeline, onOpenSettings, onSwitchOc, onExit }: WorldDaySurfaceProps) {
+  const [action, setAction] = useState("");
+  const currentDayRef = useRef<HTMLElement | null>(null);
+  const pendingSceneId = world.presentation?.plans[0]?.eventId ?? "";
+  const canCompleteDay = !pendingSceneId && world.status !== "barrier" && !busy && Boolean(action.trim());
+
+  useLayoutEffect(() => {
+    currentDayRef.current?.scrollIntoView({ block: "start" });
+  }, [world.currentDayIndex, world.id]);
+
+  async function completeDay() {
+    if (!canCompleteDay) return;
+    if (await onCompleteDay(action.trim())) setAction("");
+  }
+
+  return (
+    <section className="grid h-full min-h-0 grid-rows-[auto_minmax(0,1fr)] bg-[#F1F4F2] text-[#252A27]" data-testid="world-day-surface">
+      <header className="flex min-h-16 items-center justify-between gap-4 border-b border-[#D9DEDA] bg-white px-5">
+        <div className="min-w-0">
+          <h1 className="m-0 truncate font-serif text-lg font-semibold">{world.name}</h1>
+          <p className="m-0 truncate text-xs text-[#707873]">Day {world.currentDayIndex} · {world.premise}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2">
+          {world.ocs.length > 1 ? <label className="relative flex h-9 items-center rounded-md border border-[#D6DDD8] bg-[#F7F9F8] pl-8 pr-2 text-xs"><UserSwitch className="absolute left-2.5" /><select className="max-w-36 bg-transparent pr-1 focus:outline-none" aria-label="切换 OC" value={world.activeOcId ?? ""} onChange={(event) => onSwitchOc(event.target.value)}>{world.ocs.map((oc) => <option key={oc.id} value={oc.id}>{oc.name}</option>)}</select></label> : null}
+          <button className="grid h-9 w-9 place-items-center rounded-md hover:bg-[#EEF1EF]" type="button" aria-label="打开完整时间线" title="打开完整时间线" onClick={onOpenTimeline}><BookOpenText /></button>
+          <button className="grid h-9 w-9 place-items-center rounded-md hover:bg-[#EEF1EF]" type="button" aria-label="世界设置" title="世界设置" onClick={onOpenSettings}><Gear /></button>
+          <button className="grid h-9 w-9 place-items-center rounded-md hover:bg-[#EEF1EF]" type="button" aria-label="返回世界列表" title="返回世界列表" onClick={onExit}><SignOut /></button>
+        </div>
+      </header>
+      <div className="min-h-0 overflow-y-auto px-5 py-8">
+        <main className="mx-auto grid max-w-3xl gap-12">
+          {world.days.map((day) => (
+            <section
+              key={day.dayIndex}
+              ref={day.status === "current" ? currentDayRef : undefined}
+              aria-labelledby={`world-day-${day.dayIndex}`}
+              className={day.status === "completed" ? "opacity-75" : "scroll-mt-8"}
+              data-current-day={day.status === "current" ? "true" : undefined}
+            >
+              <div className="mb-6 flex items-baseline justify-between gap-4 border-b border-[#CCD3CE] pb-3">
+                <h2 id={`world-day-${day.dayIndex}`} className="m-0 font-serif text-2xl font-semibold">{day.title}</h2>
+                <span className="text-xs text-[#727A75]">{day.status === "current" ? "进行中" : "已结束"}</span>
+              </div>
+              <ol className="m-0 grid list-none gap-0 border-l border-[#B9C3BC] pl-7">
+                {day.events.map((event) => (
+                  <li key={event.id} className="relative pb-7">
+                    <span className={`absolute -left-[33px] top-1 h-3 w-3 rounded-full border-2 border-[#F1F4F2] ${event.presentationMode === "scene" ? "bg-[#A75F41]" : "bg-[#66766C]"}`} />
+                    <div className="flex items-start justify-between gap-5">
+                      <div className="min-w-0">
+                        {event.speakerName ? <p className="m-0 mb-1 text-xs font-medium text-[#A75F41]">{event.speakerName}</p> : null}
+                        <p className="m-0 whitespace-pre-wrap font-serif text-base leading-7 text-[#3B423E]">{event.content}</p>
+                      </div>
+                      {event.presentationMode === "scene" ? <button className="inline-flex h-9 shrink-0 items-center gap-2 rounded-md border border-[#D4DAD5] bg-white px-3 text-xs hover:border-[#A75F41] hover:text-[#8D4C34]" type="button" aria-label={`${event.id === pendingSceneId ? "继续" : "回看"}场景：${event.content}`} onClick={() => onReplayScene(event.id)}><PlayCircle />{event.id === pendingSceneId ? "继续" : "回看"}</button> : null}
+                    </div>
+                  </li>
+                ))}
+              </ol>
+              {day.status === "current" ? (
+                <div className="ml-7 border-t border-[#CDD4CF] pt-5">
+                  <div className="flex items-end gap-2 rounded-md border border-[#CCD4CE] bg-white p-2 transition focus-within:border-[#7C8D82] focus-within:ring-2 focus-within:ring-[#7C8D82]/20">
+                    <AutosizeTextarea className="min-h-11 w-full bg-transparent px-2 py-2 text-sm leading-6 focus:outline-none" containerClassName="min-h-11 flex-1" mirrorClassName="px-2 py-2 text-sm leading-6" value={action} placeholder={world.scene.actionPrompt} onChange={(event) => setAction(event.target.value)} onKeyDown={(event) => { if (event.key === "Enter" && !event.shiftKey) { event.preventDefault(); void completeDay(); } }} />
+                    <button className="inline-flex h-10 shrink-0 items-center gap-2 rounded-md bg-[#53675B] px-4 text-sm text-white hover:bg-[#43564B] disabled:opacity-40" type="button" aria-label="结束当前 Day" disabled={!canCompleteDay} onClick={() => void completeDay()}>进入下一天<ArrowRight /></button>
+                  </div>
+                  {world.status === "barrier" ? <p className="m-0 mt-2 text-xs text-[#8C513D]">当前剧情尚有待决选择。</p> : null}
+                  {pendingSceneId ? <p className="m-0 mt-2 text-xs text-[#8C513D]">请先完成当前场景。</p> : null}
+                </div>
+              ) : null}
+            </section>
+          ))}
+        </main>
+        {error ? <div className="fixed bottom-5 left-1/2 -translate-x-1/2 rounded-md bg-[#793F36] px-4 py-2 text-sm text-white shadow-lg" role="alert">{error}</div> : null}
+      </div>
+    </section>
+  );
+}

--- a/desktop/renderer/src/world/WorldGameControls.tsx
+++ b/desktop/renderer/src/world/WorldGameControls.tsx
@@ -43,7 +43,7 @@ export function WorldGameControls({ paused, onPause, onResume, onSkip, onRedraw,
         <aside className="absolute right-5 top-20 z-30 grid w-64 gap-2 rounded-md border border-white/15 bg-[#171A18]/95 p-3 text-white shadow-2xl backdrop-blur-md" role="dialog" aria-label="演出菜单">
           <div className="flex items-center justify-between px-1 pb-1"><strong className="font-serif text-base">演出菜单</strong><button className="grid h-8 w-8 place-items-center rounded-md text-white/70 hover:bg-white/10" type="button" aria-label="关闭演出菜单" title="关闭演出菜单" onClick={closeMenu}><X /></button></div>
           <button className="flex h-10 items-center rounded-md px-3 text-left text-sm hover:bg-white/10" type="button" onClick={() => { setMenuOpen(false); onOpenTimeline(); }}>打开时间线</button>
-          <button className="flex h-10 items-center rounded-md px-3 text-left text-sm hover:bg-white/10" type="button" onClick={onExitWorkspace}>返回世界管理</button>
+          <button className="flex h-10 items-center rounded-md px-3 text-left text-sm hover:bg-white/10" type="button" onClick={onExitWorkspace}>返回当前 Day</button>
           <button className="flex h-10 items-center rounded-md px-3 text-left text-sm hover:bg-white/10" type="button" onClick={resumeFromMenu}>继续演出</button>
         </aside>
       ) : null}

--- a/desktop/renderer/src/world/WorldGameInteraction.tsx
+++ b/desktop/renderer/src/world/WorldGameInteraction.tsx
@@ -12,6 +12,7 @@ type WorldGameInteractionProps = {
   performing: boolean;
   busy: boolean;
   dialogue: WorldDialogueSnapshot;
+  allowFreeAction?: boolean;
   onContinueDialogue: () => void;
   onSubmitAction: (content: string) => Promise<boolean>;
   onAdvance: () => void;
@@ -19,10 +20,10 @@ type WorldGameInteractionProps = {
 };
 
 /** Renders dialogue and swaps the bottom area to action or barrier input. */
-export function WorldGameInteraction({ world, beat, paused, performing, busy, dialogue, onContinueDialogue, onSubmitAction, onAdvance, onResolveBarrier }: WorldGameInteractionProps) {
+export function WorldGameInteraction({ world, beat, paused, performing, busy, dialogue, allowFreeAction = true, onContinueDialogue, onSubmitAction, onAdvance, onResolveBarrier }: WorldGameInteractionProps) {
   const [action, setAction] = useState("");
   const barrier = world.scene.barriers[0] ?? null;
-  const canAct = !paused && !performing && canSubmitWorldAction(world);
+  const canAct = allowFreeAction && !paused && !performing && canSubmitWorldAction(world);
   const hasDialogue = dialogue.cueId !== null;
   const speakerName = hasDialogue ? dialogue.speakerName : beat?.speakerName ?? "";
   const visibleText = hasDialogue ? dialogue.visibleText : performing ? "" : beat?.content ?? "";
@@ -53,7 +54,7 @@ export function WorldGameInteraction({ world, beat, paused, performing, busy, di
             <button className="grid h-10 w-10 shrink-0 place-items-center rounded-md bg-[#A75F41] text-white disabled:opacity-40" type="button" aria-label="提交行动" disabled={busy || !action.trim()} onClick={() => void submit()}><PaperPlaneTilt weight="fill" /></button>
           </div>
         ) : null}
-        {!paused && !performing && !barrier && !canAct ? <button className="mt-5 inline-flex h-10 items-center gap-2 rounded-md bg-white/15 px-4 text-sm text-white hover:bg-white/20 disabled:opacity-50" type="button" disabled={busy} onClick={onAdvance}><Play weight="fill" />继续世界</button> : null}
+        {allowFreeAction && !paused && !performing && !barrier && !canAct ? <button className="mt-5 inline-flex h-10 items-center gap-2 rounded-md bg-white/15 px-4 text-sm text-white hover:bg-white/20 disabled:opacity-50" type="button" disabled={busy} onClick={onAdvance}><Play weight="fill" />继续世界</button> : null}
       </div>
     </section>
   );

--- a/desktop/renderer/src/world/WorldGameSurface.test.tsx
+++ b/desktop/renderer/src/world/WorldGameSurface.test.tsx
@@ -1,9 +1,11 @@
 /// <reference types="node" />
 
 import assert from "node:assert/strict";
+import { useState } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { describe, it } from "node:test";
-import { WorldGameSurface } from "./WorldGameSurface";
+import type { PerformancePlan } from "./presentationProtocol";
+import { useHydratedWorldPlans, WorldGameSurface } from "./WorldGameSurface";
 import { createWorldDetails } from "./testFixtures";
 import { selectWorldGamePresentation } from "./worldGamePresentation";
 import { WorldPresentationRuntime } from "./worldPresentationRuntime";
@@ -16,13 +18,12 @@ function render(world = createWorldDetails()) {
       runtime={runtime}
       onOpenTimeline={() => undefined}
       onExitWorkspace={() => undefined}
-      onSubmitAction={async () => true}
-      onAdvance={() => undefined}
+      onSceneComplete={() => undefined}
       onResolveBarrier={() => undefined}
       onRedrawShot={() => undefined}
       onPause={() => undefined}
       onResume={() => undefined}
-      onCheckpoint={() => undefined}
+      onCheckpoint={() => false}
     />,
   );
   runtime.dispose();
@@ -30,6 +31,32 @@ function render(world = createWorldDetails()) {
 }
 
 describe("WorldGameSurface", () => {
+  it("keeps hydrated plan identity stable when presentation state refreshes the same plan", () => {
+    const plan: PerformancePlan = {
+      schemaVersion: 1,
+      planId: "plan-stable",
+      worldId: "world-1",
+      eventId: "beat-1",
+      sourceSequence: 1,
+      cues: [],
+    };
+    const seen: Array<PerformancePlan | null> = [];
+
+    function Probe() {
+      const [renderCount, setRenderCount] = useState(0);
+      const refreshedPlan = renderCount === 0 ? plan : { ...plan, cues: [...plan.cues] };
+      const hydrated = useHydratedWorldPlans(refreshedPlan);
+      seen.push(hydrated.plan);
+      if (renderCount === 0) setRenderCount(1);
+      return null;
+    }
+
+    renderToStaticMarkup(<Probe />);
+
+    assert.equal(seen.length, 2);
+    assert.equal(seen[0], seen[1]);
+  });
+
   it("renders the stage and performance controls for a queued plan", () => {
     const base = createWorldDetails();
     const markup = render({
@@ -76,12 +103,12 @@ describe("WorldGameSurface", () => {
     assert.doesNotMatch(markup, /aria-label="提交行动"/);
   });
 
-  it("shows action input after the presentation queue is empty", () => {
+  it("does not expose Day actions after the presentation queue is empty", () => {
     const markup = render(createWorldDetails({ presentation: undefined }));
 
     assert.doesNotMatch(markup, /data-testid="world-stage"/);
-    assert.match(markup, /aria-label="提交行动"/);
-    assert.match(markup, /岚准备怎么做？/);
+    assert.doesNotMatch(markup, /aria-label="提交行动"/);
+    assert.doesNotMatch(markup, /进入下一天|继续世界/);
   });
 
   it("shows a decision barrier instead of the action composer", () => {

--- a/desktop/renderer/src/world/WorldGameSurface.tsx
+++ b/desktop/renderer/src/world/WorldGameSurface.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState, useSyncExternalStore } from "react";
 import { WorldGameControls } from "./WorldGameControls";
 import { WorldGameInteraction } from "./WorldGameInteraction";
+import type { PerformancePlan } from "./presentationProtocol";
 import type { DecisionBarrier, SceneBeat, WorldDetails } from "./types";
 import { hydrateWorldPresentationAssets } from "./worldPresentationAssets";
 import { WorldStage } from "./WorldStage";
@@ -13,13 +14,12 @@ type WorldGameSurfaceProps = {
   busy?: boolean;
   onOpenTimeline: () => void;
   onExitWorkspace: () => void;
-  onSubmitAction: (content: string) => Promise<boolean>;
-  onAdvance: () => void;
+  onSceneComplete: () => void;
   onResolveBarrier: (barrier: DecisionBarrier, choiceId: string) => void;
   onRedrawShot: (shotId: string) => void;
   onPause: () => Promise<void> | void;
   onResume: () => Promise<void> | void;
-  onCheckpoint: (planId: string, cueIndex: number) => Promise<void> | void;
+  onCheckpoint: (planId: string, cueIndex: number) => Promise<boolean> | boolean;
 };
 
 function initialVisual(beat: SceneBeat | null) {
@@ -29,15 +29,39 @@ function initialVisual(beat: SceneBeat | null) {
   return asset ? { id: `shot-${asset.id}`, url: asset.imageUrl } : undefined;
 }
 
+function createWorldPlanHydrator() {
+  const cache = new Map<string, PerformancePlan>();
+  return (plan: PerformancePlan | null | undefined) => {
+    if (!plan) return null;
+    const cached = cache.get(plan.planId);
+    if (cached) return cached;
+    const hydrated = hydrateWorldPresentationAssets(plan);
+    cache.set(plan.planId, hydrated);
+    if (cache.size > 4) cache.delete(cache.keys().next().value!);
+    return hydrated;
+  };
+}
+
+/** Hydrates immutable scene plans while preserving playback identity across bridge refreshes. */
+export function useHydratedWorldPlans(plan: PerformancePlan | null, preloadPlan?: PerformancePlan) {
+  const [hydratePlan] = useState(createWorldPlanHydrator);
+  const hydratedPlan = hydratePlan(plan);
+  const hydratedPreloadPlan = hydratePlan(preloadPlan);
+
+  return {
+    plan: hydratedPlan,
+    preloadPlan: hydratedPreloadPlan ?? undefined,
+  };
+}
+
 /** Owns the World visual-novel lifecycle while management views remain separate. */
-export function WorldGameSurface({ world, runtime, busy = false, onOpenTimeline, onExitWorkspace, onSubmitAction, onAdvance, onResolveBarrier, onRedrawShot, onPause, onResume, onCheckpoint }: WorldGameSurfaceProps) {
+export function WorldGameSurface({ world, runtime, busy = false, onOpenTimeline, onExitWorkspace, onSceneComplete, onResolveBarrier, onRedrawShot, onPause, onResume, onCheckpoint }: WorldGameSurfaceProps) {
   const { plan, preloadPlan, beat, session, startCueIndex, canPlay } = selectWorldGamePresentation(world);
   const [paused, setPaused] = useState(session?.status === "paused");
   const [skipVersion, setSkipVersion] = useState(0);
   const isPaused = paused || session?.status === "paused";
   const performing = canPlay && !isPaused;
-  const hydratedPlan = plan ? hydrateWorldPresentationAssets(plan) : null;
-  const hydratedPreloadPlan = preloadPlan ? hydrateWorldPresentationAssets(preloadPlan) : undefined;
+  const { plan: hydratedPlan, preloadPlan: hydratedPreloadPlan } = useHydratedWorldPlans(plan, preloadPlan);
   const subscribeDialogue = useCallback((listener: () => void) => runtime.subscribeDialogue(listener), [runtime]);
   const readDialogue = useCallback(() => runtime.dialogueSnapshot(), [runtime]);
   const dialogue = useSyncExternalStore(subscribeDialogue, readDialogue, readDialogue);
@@ -63,10 +87,10 @@ export function WorldGameSurface({ world, runtime, busy = false, onOpenTimeline,
 
   return (
     <section className="relative h-full min-h-0 overflow-hidden bg-[#151816] text-white" data-testid="world-game-surface">
-      {hydratedPlan ? <WorldStage plan={hydratedPlan} preloadPlan={hydratedPreloadPlan} fallbackText={beat?.content ?? ""} runtime={runtime} initialVisual={initialVisual(beat)} startCueIndex={startCueIndex} paused={isPaused} skipVersion={skipVersion} onCueComplete={(cue) => onCheckpoint(cue.planId, cue.sequence)} /> : beat?.shot?.assets[0] ? <img className="absolute inset-0 h-full w-full object-cover" src={beat.shot.assets[0].imageUrl} alt={beat.shot.prompt} /> : <div className="absolute inset-0 bg-[#252C28]" />}
+      {hydratedPlan ? <WorldStage plan={hydratedPlan} preloadPlan={hydratedPreloadPlan} fallbackText={beat?.content ?? ""} runtime={runtime} initialVisual={initialVisual(beat)} startCueIndex={startCueIndex} paused={isPaused} skipVersion={skipVersion} onCueComplete={async (cue) => { if (await onCheckpoint(cue.planId, cue.sequence)) onSceneComplete(); }} /> : beat?.shot?.assets[0] ? <img className="absolute inset-0 h-full w-full object-cover" src={beat.shot.assets[0].imageUrl} alt={beat.shot.prompt} /> : <div className="absolute inset-0 bg-[#252C28]" />}
       <div className="pointer-events-none absolute inset-0 bg-black/35" />
       <WorldGameControls paused={isPaused} onPause={pause} onResume={resume} onSkip={() => setSkipVersion((value) => value + 1)} onRedraw={beat?.shot ? () => onRedrawShot(beat.shot!.id) : undefined} onOpenTimeline={onOpenTimeline} onExitWorkspace={exitWorkspace} />
-      <WorldGameInteraction world={world} beat={beat} paused={isPaused} performing={performing} busy={busy} dialogue={dialogue} onContinueDialogue={() => { runtime.continueDialogue(); }} onSubmitAction={onSubmitAction} onAdvance={onAdvance} onResolveBarrier={onResolveBarrier} />
+      <WorldGameInteraction world={world} beat={beat} paused={isPaused} performing={performing} busy={busy} dialogue={dialogue} allowFreeAction={false} onContinueDialogue={() => { runtime.continueDialogue(); }} onSubmitAction={async () => false} onAdvance={() => undefined} onResolveBarrier={onResolveBarrier} />
     </section>
   );
 }

--- a/desktop/renderer/src/world/WorldLauncher.test.tsx
+++ b/desktop/renderer/src/world/WorldLauncher.test.tsx
@@ -23,8 +23,9 @@ describe("WorldLauncher", () => {
     assert.ok(markup.includes("退出"));
     // Check logo
     assert.ok(markup.includes("Shiori"));
-    // Check background
-    assert.ok(markup.includes("default-galgame-bg.png"));
+    // The relative URL must resolve beside renderer-dist/index.html under Electron loadFile().
+    assert.ok(markup.includes("url(./assets/backgrounds/default-galgame-bg.png)"));
+    assert.doesNotMatch(markup, /url\(['\"]?\/assets\//);
     // Check no old "继续世界" text
     assert.doesNotMatch(markup, /继续世界/);
   });

--- a/desktop/renderer/src/world/WorldLauncher.tsx
+++ b/desktop/renderer/src/world/WorldLauncher.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, FolderOpen, GearSix, Plus, SignOut } from "@phosphor-icons/react";
 import { useState } from "react";
 import type { WorldSummary } from "./types";
+import { WORLD_MENU_BACKGROUND_URL } from "./worldStaticAssets";
 
 type WorldLauncherProps = {
   worlds: WorldSummary[];
@@ -20,7 +21,7 @@ export function WorldLauncher({ worlds, busy = false, error = "", onCreateWorld,
 
   return (
     <section className="relative h-full min-h-0 overflow-hidden" data-testid="world-launcher">
-      <div className="absolute inset-0 bg-cover bg-center bg-no-repeat" style={{ backgroundImage: "url('/assets/backgrounds/default-galgame-bg.png')" }} />
+      <div className="absolute inset-0 bg-cover bg-center bg-no-repeat" style={{ backgroundImage: `url(${WORLD_MENU_BACKGROUND_URL})` }} />
       <div className="absolute inset-0 bg-gradient-to-r from-white/20 via-transparent to-black/25" />
 
       <div className="absolute left-[clamp(16px,4vw,32px)] top-[clamp(16px,4vh,32px)] z-10">

--- a/desktop/renderer/src/world/WorldLoadingScreen.test.tsx
+++ b/desktop/renderer/src/world/WorldLoadingScreen.test.tsx
@@ -8,6 +8,8 @@ describe("WorldLoadingScreen", () => {
   it("renders staged progress for initial World entry", () => {
     const markup = renderToStaticMarkup(<WorldLoadingScreen mode="listing" />);
     assert.match(markup, /data-testid="world-loading-screen"/);
+    assert.match(markup, /url\(\.\/assets\/backgrounds\/default-galgame-bg\.png\)/);
+    assert.doesNotMatch(markup, /url\(['\"]?\/assets\//);
     assert.match(markup, />读取世界</);
     assert.match(markup, />恢复演出</);
     assert.match(markup, />准备舞台</);

--- a/desktop/renderer/src/world/WorldLoadingScreen.tsx
+++ b/desktop/renderer/src/world/WorldLoadingScreen.tsx
@@ -1,5 +1,6 @@
 import { ArrowLeft, ArrowClockwise, GlobeHemisphereEast } from "@phosphor-icons/react";
 import { resolveWorldLoadingPresentation } from "./worldLoadingPolicy";
+import { WORLD_MENU_BACKGROUND_URL } from "./worldStaticAssets";
 
 type WorldLoadingScreenProps = {
   mode: "listing" | "world";
@@ -21,7 +22,7 @@ export function WorldLoadingScreen({ mode, busy = true, error = "", elapsedMs = 
   return (
     <section className="relative grid h-full min-h-0 place-items-center overflow-hidden text-[#F6F0E8]" data-testid="world-loading-screen" aria-busy={busy}>
       {/* Full-screen background */}
-      <div className="absolute inset-0 bg-cover bg-center bg-no-repeat" style={{ backgroundImage: "url('/assets/backgrounds/default-galgame-bg.png')" }} />
+      <div className="absolute inset-0 bg-cover bg-center bg-no-repeat" style={{ backgroundImage: `url(${WORLD_MENU_BACKGROUND_URL})` }} />
       <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" />
       <div className="relative z-10 w-[min(520px,calc(100%-48px))]">
         <div className="flex items-center gap-2 text-xs uppercase tracking-[0.28em] text-[#D49A76]"><GlobeHemisphereEast weight="duotone" />World</div>

--- a/desktop/renderer/src/world/WorldTimelineView.test.tsx
+++ b/desktop/renderer/src/world/WorldTimelineView.test.tsx
@@ -4,7 +4,7 @@ import { describe, it } from "node:test";
 import { renderToStaticMarkup } from "react-dom/server";
 import { WorldTimelineView } from "./WorldTimelineView";
 
-const entries = [{ id: "anchor-1", timeLabel: "第一日", title: "潮水退去", summary: "旧港露出了石阶。", visibility: "known" as const, involvedNames: ["澪"], canCopy: true, canEnter: true }];
+const entries = [{ id: "anchor-1", dayIndex: 1, timeLabel: "第一日", title: "潮水退去", summary: "旧港露出了石阶。", visibility: "known" as const, involvedNames: ["澪"], canCopy: true, canEnter: true }];
 
 describe("WorldTimelineView", () => {
   it("renders a full history with cognitive and omniscient controls", () => {

--- a/desktop/renderer/src/world/bridgeClient.test.ts
+++ b/desktop/renderer/src/world/bridgeClient.test.ts
@@ -55,6 +55,21 @@ describe("createWorldBridgeClient", () => {
     }]);
   });
 
+  it("completes one Day through one atomic bridge command", async () => {
+    const requests: Array<{ method: string; payload: Record<string, unknown> }> = [];
+    const client = createWorldBridgeClient(async (request): Promise<BridgeResponse> => {
+      requests.push(request);
+      return { id: "response", type: "response", method: request.method, payload: { run_id: "run-day-1" }, error: null };
+    });
+
+    await client.completeDay("world-1", "去旧港寻找失踪者。");
+
+    assert.deepEqual(requests, [{
+      method: "worlds.days.complete",
+      payload: { world_id: "world-1", content: "去旧港寻找失踪者。" },
+    }]);
+  });
+
   it("maps dialogue voice synthesis to the MiniMax voice bridge contract", async () => {
     const requests: Array<{ method: string; payload: Record<string, unknown> }> = [];
     const invoke = async (request: { method: string; payload: Record<string, unknown> }): Promise<BridgeResponse> => {

--- a/desktop/renderer/src/world/bridgeClient.ts
+++ b/desktop/renderer/src/world/bridgeClient.ts
@@ -42,6 +42,7 @@ export interface WorldBridgeClient {
   addOc(worldId: string, oc: WorldCreationInput["firstOc"], anchorId?: string): Promise<WorldDetails>;
   switchOc(worldId: string, ocId: string): Promise<WorldDetails>;
   submitAction(worldId: string, content: string): Promise<void>;
+  completeDay(worldId: string, content: string): Promise<void>;
   advance(worldId: string): Promise<void>;
   resolveBarrier(worldId: string, barrier: DecisionBarrier, choiceId: string): Promise<WorldDetails>;
   getTimeline(worldId: string, perspective: "known" | "omniscient", ocId?: string): Promise<WorldTimelineEntry[]>;
@@ -91,6 +92,9 @@ export function createWorldBridgeClient(invoke: DesktopInvoke = window.miraDeskt
     },
     async submitAction(worldId, content) {
       await invokePayload(invoke, "worlds.actions.submit", { world_id: worldId, content });
+    },
+    async completeDay(worldId, content) {
+      await invokePayload(invoke, "worlds.days.complete", { world_id: worldId, content });
     },
     async advance(worldId) {
       await invokePayload(invoke, "worlds.advance", { world_id: worldId });

--- a/desktop/renderer/src/world/index.ts
+++ b/desktop/renderer/src/world/index.ts
@@ -2,6 +2,7 @@ export { createWorldBridgeClient } from "./bridgeClient";
 export type { WorldBridgeClient } from "./bridgeClient";
 export { GalgameFocusMode } from "./GalgameFocusMode";
 export { WorldGameSurface } from "./WorldGameSurface";
+export { WorldDaySurface } from "./WorldDaySurface";
 export { WorldStage } from "./WorldStage";
 export { WorldAppSurface } from "./WorldAppSurface";
 export { SceneShot } from "./SceneShot";

--- a/desktop/renderer/src/world/presentationProtocol.ts
+++ b/desktop/renderer/src/world/presentationProtocol.ts
@@ -137,12 +137,16 @@ export function parsePresentationState(value: unknown): WorldPresentationState {
 
 /** Validate presentation plans embedded in a world detail response. */
 export function parseWorldDetailsPerformance(world: WorldDetails): WorldDetails {
+  const parseBeat = (beat: SceneBeat) => beat.performancePlan
+    ? { ...beat, performancePlan: parsePerformancePlan(beat.performancePlan) }
+    : beat;
   return {
     ...world,
     presentation: world.presentation ? parsePresentationState(world.presentation) : undefined,
+    days: world.days.map((day) => ({ ...day, events: day.events.map(parseBeat) })),
     scene: {
       ...world.scene,
-      beats: world.scene.beats.map((beat: SceneBeat) => beat.performancePlan ? { ...beat, performancePlan: parsePerformancePlan(beat.performancePlan) } : beat),
+      beats: world.scene.beats.map(parseBeat),
     },
   };
 }

--- a/desktop/renderer/src/world/selectors.test.ts
+++ b/desktop/renderer/src/world/selectors.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { canSubmitWorldAction, mergeCommittedBeats, selectActiveOc, selectTimelineEntries } from "./selectors";
+import { canSubmitWorldAction, mergeCommittedBeats, replaceWorldSummary, selectActiveOc, selectTimelineEntries } from "./selectors";
 import { createSceneBeat, createWorldDetails } from "./testFixtures";
 
 describe("world selectors", () => {
@@ -20,9 +20,17 @@ describe("world selectors", () => {
   it("selects the controlled OC and filters private history in cognitive view", () => {
     assert.equal(selectActiveOc(createWorldDetails())?.name, "岚");
     const entries = [
-      { id: "known", timeLabel: "清晨", title: "抵达", summary: "看见港口", visibility: "known" as const, involvedNames: [], canCopy: true, canEnter: true },
-      { id: "hidden", timeLabel: "清晨", title: "密谈", summary: "未被看见", visibility: "omniscient" as const, involvedNames: [], canCopy: true, canEnter: false },
+      { id: "known", dayIndex: 1, timeLabel: "清晨", title: "抵达", summary: "看见港口", visibility: "known" as const, involvedNames: [], canCopy: true, canEnter: true },
+      { id: "hidden", dayIndex: 1, timeLabel: "清晨", title: "密谈", summary: "未被看见", visibility: "omniscient" as const, involvedNames: [], canCopy: true, canEnter: false },
     ];
     assert.deepEqual(selectTimelineEntries(entries, "known").map((entry) => entry.id), ["known"]);
+  });
+
+  it("refreshes the launcher summary after a Day changes", () => {
+    const current = createWorldDetails({ currentDayIndex: 4, status: "barrier" });
+    const updated = replaceWorldSummary([{ ...createWorldDetails(), currentDayIndex: 3 }], current);
+
+    assert.equal(updated[0].currentDayIndex, 4);
+    assert.equal(updated[0].status, "barrier");
   });
 });

--- a/desktop/renderer/src/world/selectors.ts
+++ b/desktop/renderer/src/world/selectors.ts
@@ -5,6 +5,23 @@ export function selectWorld(worlds: WorldSummary[], worldId: string) {
   return worlds.find((world) => world.id === worldId) ?? worlds[0] ?? null;
 }
 
+/** Replace one cached launcher summary from the latest complete read model. */
+export function replaceWorldSummary(worlds: WorldSummary[], world: WorldDetails) {
+  const summary: WorldSummary = {
+    id: world.id,
+    name: world.name,
+    premise: world.premise,
+    currentTimeLabel: world.currentTimeLabel,
+    currentDayIndex: world.currentDayIndex,
+    activeOcId: world.activeOcId,
+    status: world.status,
+  };
+  const index = worlds.findIndex((candidate) => candidate.id === world.id);
+  if (index < 0) return [...worlds, summary];
+  if (worlds[index].currentDayIndex === summary.currentDayIndex && worlds[index].status === summary.status && worlds[index].activeOcId === summary.activeOcId) return worlds;
+  return worlds.map((candidate, candidateIndex) => candidateIndex === index ? summary : candidate);
+}
+
 /** Selects the currently controlled OC. */
 export function selectActiveOc(world: WorldDetails | null): WorldOc | null {
   if (!world) return null;

--- a/desktop/renderer/src/world/testFixtures.ts
+++ b/desktop/renderer/src/world/testFixtures.ts
@@ -5,10 +5,12 @@ export function createSceneBeat(overrides: Partial<SceneBeat> = {}): SceneBeat {
   return {
     id: overrides.id ?? "beat-1",
     order: overrides.order ?? 1,
+    dayIndex: overrides.dayIndex ?? 3,
     timeLabel: overrides.timeLabel ?? "雨夜",
     speakerName: overrides.speakerName ?? "澪",
     kind: overrides.kind ?? "dialogue",
     content: overrides.content ?? "你终于来了。",
+    presentationMode: overrides.presentationMode ?? "narrative",
     shot: overrides.shot,
     isCritical: overrides.isCritical,
   };
@@ -16,21 +18,25 @@ export function createSceneBeat(overrides: Partial<SceneBeat> = {}): SceneBeat {
 
 /** Creates a complete world read model for renderer tests. */
 export function createWorldDetails(overrides: Partial<WorldDetails> = {}): WorldDetails {
+  const scene = overrides.scene ?? { title: "灯塔下", location: "旧港灯塔", timeLabel: "暴雨将至", participants: [{ id: "oc-1", name: "岚", role: "controlled_oc" as const }], beats: [createSceneBeat()], actionPrompt: "岚准备怎么做？", opportunities: ["灯塔门没有上锁"], barriers: [] };
   return {
     id: overrides.id ?? "world-1",
     name: overrides.name ?? "雨港",
     premise: overrides.premise ?? "潮汐会带回被遗忘的名字。",
     currentTimeLabel: overrides.currentTimeLabel ?? "第三日 · 深夜",
+    currentDayIndex: overrides.currentDayIndex ?? 3,
     activeOcId: overrides.activeOcId ?? "oc-1",
     status: overrides.status ?? "action_required",
     ocs: overrides.ocs ?? [{ id: "oc-1", name: "岚", identity: "从北方来的抄写员", location: "旧港", primaryGoal: "找到失踪的姐姐", constraints: [], autonomy: "guided", isActive: true }],
-    scene: overrides.scene ?? { title: "灯塔下", location: "旧港灯塔", timeLabel: "暴雨将至", participants: [{ id: "oc-1", name: "岚", role: "controlled_oc" }], beats: [createSceneBeat()], actionPrompt: "岚准备怎么做？", opportunities: ["灯塔门没有上锁"], barriers: [] },
+    days: overrides.days ?? [{ dayIndex: 3, title: "Day 3", status: "current", events: scene.beats }],
+    scene,
     relatedCharacters: overrides.relatedCharacters ?? [{ id: "native-1", name: "澪", relationship: "刚刚相识" }],
     performance: overrides.performance ?? { active: true, label: "观看现场演出", canCancel: true },
+    presentation: overrides.presentation,
   };
 }
 
 /** Creates the summary form of the world fixture. */
 export function createWorldSummary(world = createWorldDetails()): WorldSummary {
-  return { id: world.id, name: world.name, premise: world.premise, currentTimeLabel: world.currentTimeLabel, activeOcId: world.activeOcId, status: world.status };
+  return { id: world.id, name: world.name, premise: world.premise, currentTimeLabel: world.currentTimeLabel, currentDayIndex: world.currentDayIndex, activeOcId: world.activeOcId, status: world.status };
 }

--- a/desktop/renderer/src/world/types.ts
+++ b/desktop/renderer/src/world/types.ts
@@ -4,6 +4,7 @@ export type WorldSummary = {
   name: string;
   premise: string;
   currentTimeLabel: string;
+  currentDayIndex: number;
   activeOcId: string | null;
   status: WorldRunStatus;
 };
@@ -39,13 +40,23 @@ export type SceneParticipant = {
 export type SceneBeat = {
   id: string;
   order: number;
+  dayIndex: number;
   timeLabel: string;
   speakerName?: string;
   kind: "dialogue" | "action" | "environment";
   content: string;
+  presentationMode: "narrative" | "scene";
   shot?: SceneShot;
   performancePlan?: import("./presentationProtocol").PerformancePlan;
   isCritical?: boolean;
+};
+
+/** One Day chapter projected from committed timeline events. */
+export type WorldDay = {
+  dayIndex: number;
+  title: string;
+  status: "completed" | "current";
+  events: SceneBeat[];
 };
 
 /** One visual shot and all retained presentation alternatives. */
@@ -87,6 +98,7 @@ export type WorldScene = {
 
 /** Complete renderer read model for a world. */
 export type WorldDetails = WorldSummary & {
+  days: WorldDay[];
   ocs: WorldOc[];
   scene: WorldScene;
   relatedCharacters: Array<{ id: string; name: string; relationship: string; avatarUrl?: string }>;
@@ -140,6 +152,7 @@ export type WorldCreationDraft = {
 /** An immutable world-history entry. */
 export type WorldTimelineEntry = {
   id: string;
+  dayIndex: number;
   timeLabel: string;
   title: string;
   summary: string;

--- a/desktop/renderer/src/world/useWorldWorkspaceController.ts
+++ b/desktop/renderer/src/world/useWorldWorkspaceController.ts
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { createWorldBridgeClient, type WorldBridgeClient } from "./bridgeClient";
-import { mergeCommittedBeats, selectActiveOc } from "./selectors";
+import { mergeCommittedBeats, replaceWorldSummary, selectActiveOc } from "./selectors";
 import type { DecisionBarrier, SceneShot, WorldDetails, WorldSummary } from "./types";
 
 type ControllerState = {
@@ -61,7 +61,7 @@ export function useWorldWorkspaceController(client: WorldBridgeClient = createWo
 
   useEffect(() => {
     void reloadWorlds();
-  }, []); // The client is stable for the lifetime of the workspace.
+  }, [reloadWorlds]);
 
   const catchUp = useCallback(async () => {
     if (!state.world) return;
@@ -73,6 +73,7 @@ export function useWorldWorkspaceController(client: WorldBridgeClient = createWo
       return {
         ...current,
         cursor: update.cursor,
+        worlds: replaceWorldSummary(current.worlds, baseWorld),
         world: {
           ...baseWorld,
           scene: {
@@ -101,6 +102,14 @@ export function useWorldWorkspaceController(client: WorldBridgeClient = createWo
     if (!state.world) return;
     const result = await run(() => client.advance(state.world!.id));
     if (result !== null) await catchUp();
+  }, [catchUp, client, run, state.world]);
+
+  const completeDay = useCallback(async (content: string) => {
+    if (!state.world || !content.trim()) return false;
+    const result = await run(() => client.completeDay(state.world!.id, content.trim()));
+    if (result === null) return false;
+    await catchUp();
+    return true;
   }, [catchUp, client, run, state.world]);
 
   const resolveBarrier = useCallback(async (barrier: DecisionBarrier, choiceId: string) => {
@@ -155,14 +164,15 @@ export function useWorldWorkspaceController(client: WorldBridgeClient = createWo
   }, [client, run, state.world]);
 
   const checkpointPresentation = useCallback(async (planId: string, cueIndex: number) => {
-    if (!state.world) return;
-    await run(
+    if (!state.world) return false;
+    const result = await run(
       () => client.checkpointPresentation(state.world!.id, planId, cueIndex),
       (presentation) => setState((current) => current.world ? ({
         ...current,
         world: { ...current.world, presentation },
       }) : current),
     );
+    return Boolean(result && result.plans.length === 0);
   }, [client, run, state.world]);
 
   return useMemo(() => ({
@@ -173,6 +183,7 @@ export function useWorldWorkspaceController(client: WorldBridgeClient = createWo
     switchOc,
     submitAction,
     advance,
+    completeDay,
     resolveBarrier,
     cancelRun,
     catchUp,
@@ -180,5 +191,5 @@ export function useWorldWorkspaceController(client: WorldBridgeClient = createWo
     pausePresentation,
     resumePresentation,
     checkpointPresentation,
-  }), [advance, cancelRun, catchUp, checkpointPresentation, loadWorld, pausePresentation, redrawShot, reloadWorlds, resolveBarrier, resumePresentation, state, submitAction, switchOc]);
+  }), [advance, cancelRun, catchUp, checkpointPresentation, completeDay, loadWorld, pausePresentation, redrawShot, reloadWorlds, resolveBarrier, resumePresentation, state, submitAction, switchOc]);
 }

--- a/desktop/renderer/src/world/worldDayPresentation.test.ts
+++ b/desktop/renderer/src/world/worldDayPresentation.test.ts
@@ -1,0 +1,46 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createSceneBeat, createWorldDetails } from "./testFixtures";
+import { selectCurrentWorldDay, selectPendingWorldScene } from "./worldDayPresentation";
+
+describe("worldDayPresentation", () => {
+  it("selects the current day independently from historical days", () => {
+    const world = createWorldDetails();
+
+    assert.equal(selectCurrentWorldDay(world)?.dayIndex, 3);
+    assert.equal(selectCurrentWorldDay(world)?.status, "current");
+  });
+
+  it("only selects an unconsumed scene event for automatic presentation", () => {
+    const scene = createSceneBeat({ id: "scene-1", presentationMode: "scene" });
+    const world = createWorldDetails({
+      days: [{ dayIndex: 3, title: "Day 3", status: "current", events: [
+        createSceneBeat({ id: "narrative-1", presentationMode: "narrative" }),
+        scene,
+      ] }],
+      presentation: {
+        session: {
+          worldId: "world-1",
+          lastPresentedEventSequence: 1,
+          activePlanId: null,
+          activeCueIndex: 0,
+          status: "playing",
+          updatedAt: "2026-07-31T00:00:00+00:00",
+        },
+        plans: [{
+          schemaVersion: 1,
+          planId: "plan-scene-1",
+          worldId: "world-1",
+          eventId: "scene-1",
+          sourceSequence: 2,
+          cues: [],
+        }],
+      },
+    });
+
+    assert.equal(selectPendingWorldScene(world)?.id, "scene-1");
+    assert.equal(selectPendingWorldScene({ ...world, presentation: undefined }), null);
+  });
+});

--- a/desktop/renderer/src/world/worldDayPresentation.ts
+++ b/desktop/renderer/src/world/worldDayPresentation.ts
@@ -1,0 +1,28 @@
+import type { SceneBeat, WorldDay, WorldDetails } from "./types";
+
+/** Return the mutable Day chapter from the immutable renderer read model. */
+export function selectCurrentWorldDay(world: WorldDetails | null): WorldDay | null {
+  if (!world) return null;
+  return world.days.find((day) => day.dayIndex === world.currentDayIndex) ?? null;
+}
+
+/** Resolve the next durable scene plan to its Day event. */
+export function selectPendingWorldScene(world: WorldDetails | null): SceneBeat | null {
+  const plan = world?.presentation?.plans[0];
+  if (!world || !plan) return null;
+  for (const day of world.days) {
+    const event = day.events.find((candidate) => candidate.id === plan.eventId);
+    if (event?.presentationMode === "scene") return event;
+  }
+  return null;
+}
+
+/** Resolve any committed scene for replay or live presentation. */
+export function selectWorldScene(world: WorldDetails | null, sceneId: string): SceneBeat | null {
+  if (!world || !sceneId) return null;
+  for (const day of world.days) {
+    const event = day.events.find((candidate) => candidate.id === sceneId);
+    if (event?.presentationMode === "scene") return event;
+  }
+  return null;
+}

--- a/desktop/renderer/src/world/worldStaticAssets.ts
+++ b/desktop/renderer/src/world/worldStaticAssets.ts
@@ -1,0 +1,2 @@
+/** Relative URL for the bundled World launcher and loading backdrop. */
+export const WORLD_MENU_BACKGROUND_URL = "./assets/backgrounds/default-galgame-bg.png";

--- a/desktop_bridge/request_dispatcher.py
+++ b/desktop_bridge/request_dispatcher.py
@@ -35,6 +35,7 @@ _INTEGRATION_METHODS = frozenset(
 _BACKGROUND_WORLD_METHODS = frozenset(
     {
         "worlds.actions.submit",
+        "worlds.days.complete",
         "worlds.advance",
         "worlds.barriers.resolve",
         "worlds.runs.cancel",

--- a/desktop_bridge/world_day_handler.py
+++ b/desktop_bridge/world_day_handler.py
@@ -1,0 +1,158 @@
+"""Desktop bridge adapter for atomic Day progression."""
+
+from __future__ import annotations
+
+from world_simulation.days import current_day_index, next_day_time
+from world_simulation.dependencies import DependencySet
+from world_simulation.proposals import BeatProposal, ProposedEvent
+from world_simulation.repository import WorldRepository
+from world_simulation.service import WorldSimulationService
+
+
+class WorldDayHandler:
+    """Own Day advancement while leaving settlement as the only fact writer."""
+
+    def __init__(
+        self,
+        repository: WorldRepository,
+        service: WorldSimulationService,
+    ) -> None:
+        self._repository = repository
+        self._service = service
+
+    def current_index(self, world_id: str) -> int:
+        """Return the current Day for one world."""
+
+        return current_day_index(self._repository.list_events(world_id))
+
+    def advance(self, world_id: str, *, request_id: str) -> dict[str, str]:
+        """Commit a compatibility Day advance without a closing player action."""
+
+        world = self._repository.require_world(world_id)
+        active_oc = self._active_oc(world_id, world.active_oc_id)
+        current_day = self.current_index(world_id)
+        run = self._service.start_run(
+            world_id,
+            kind="advance",
+            request_id=f"{request_id}:run",
+            expected_revision=world.revision,
+            random_seed=f"{world.random_state}:{request_id}",
+        )
+        event = ProposedEvent(
+            event_type="world.day.advanced",
+            effective_at=next_day_time(world.current_time),
+            day_index=current_day + 1,
+            participants=(active_oc.id,),
+            location=active_oc.location,
+            changes={"presentation": self._next_day_presentation()},
+            dependencies=DependencySet(write_facts=frozenset({"world.day.advanced"})),
+        )
+        proposal = self._proposal(world, run.id, run.random_seed, (event,))
+        self._service.advance(proposal, request_id=request_id)
+        return {"run_id": run.id}
+
+    def complete(
+        self,
+        world_id: str,
+        content: str,
+        *,
+        request_id: str,
+    ) -> dict[str, str]:
+        """Commit a player's closing action and the next Day atomically."""
+
+        action = content.strip()
+        if not action:
+            raise ValueError("content 不能为空")
+        existing = self._repository.get_idempotency_result(request_id)
+        if existing is not None:
+            return {"run_id": str(existing.get("run_id") or "")}
+        world = self._repository.require_world(world_id)
+        active_oc = self._active_oc(world_id, world.active_oc_id)
+        current_day = self.current_index(world_id)
+        run = self._service.start_run(
+            world_id,
+            kind="complete_day",
+            request_id=f"{request_id}:run",
+            expected_revision=world.revision,
+            random_seed=f"{world.random_state}:{request_id}",
+        )
+        events = (
+            ProposedEvent(
+                event_type="scene.action.committed",
+                effective_at=world.current_time,
+                day_index=current_day,
+                participants=(active_oc.id,),
+                location=active_oc.location,
+                changes={
+                    "presentation": {
+                        "mode": "narrative",
+                        "kind": "action",
+                        "content": action,
+                        "speaker_name": active_oc.name,
+                    }
+                },
+                dependencies=DependencySet(
+                    write_facts=frozenset({"scene.action.committed"})
+                ),
+            ),
+            ProposedEvent(
+                event_type="world.day.advanced",
+                effective_at=next_day_time(world.current_time),
+                day_index=current_day + 1,
+                participants=(active_oc.id,),
+                location=active_oc.location,
+                changes={"presentation": self._next_day_presentation()},
+                dependencies=DependencySet(
+                    write_facts=frozenset({"world.day.advanced"})
+                ),
+            ),
+        )
+        proposal = self._proposal(
+            world,
+            run.id,
+            run.random_seed,
+            events,
+            projection_patch={"last_action": {"oc": active_oc.id, "content": action}},
+        )
+        result = self._service.submit_action(proposal, request_id=request_id)
+        return {"run_id": str(result.get("run_id") or run.id)}
+
+    def _active_oc(self, world_id: str, active_oc_id: str | None):
+        ocs = self._repository.list_ocs(world_id)
+        active = next((oc for oc in ocs if oc.id == active_oc_id), None)
+        if active is None:
+            raise ValueError("世界还没有可操控的 OC")
+        return active
+
+    def _proposal(
+        self,
+        world,
+        run_id: str,
+        random_seed: str,
+        events: tuple[ProposedEvent, ...],
+        projection_patch=None,
+    ) -> BeatProposal:
+        return BeatProposal(
+            schema_version=1,
+            proposal_id=f"proposal-{run_id}",
+            proposal_type="scene_beat",
+            world_id=world.id,
+            world_revision=world.revision,
+            run_id=run_id,
+            beat_sequence=self._repository.next_event_sequence(world.id),
+            provider="deterministic-world-adapter",
+            model="deterministic",
+            prompt_version="desktop-v1",
+            random_seed=random_seed,
+            source="desktop_bridge",
+            events=events,
+            projection_patch=projection_patch or {},
+        )
+
+    @staticmethod
+    def _next_day_presentation() -> dict[str, str]:
+        return {
+            "mode": "narrative",
+            "kind": "environment",
+            "content": "新的一天开始了。",
+        }

--- a/desktop_bridge/world_presentation_handler.py
+++ b/desktop_bridge/world_presentation_handler.py
@@ -1,0 +1,205 @@
+"""Derived World presentation queue and checkpoint adapter."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from desktop_bridge.world_presentation_assets import WorldPresentationAssetResolver
+from world_simulation.performance import (
+    compile_performance_plan,
+    presentation_mode_for_event,
+)
+from world_simulation.presentation_session import WorldPresentationSession
+from world_simulation.repository import WorldRepository
+from world_simulation.scenes import DecisionBarrier
+from world_simulation.timeline import TimelineEvent
+from world_simulation.world import utc_now
+
+
+class WorldPresentationHandler:
+    """Own the derived scene queue without writing authoritative world facts."""
+
+    def __init__(self, repository: WorldRepository) -> None:
+        self._repository = repository
+
+    def pause(self, world_id: str) -> dict[str, Any]:
+        """Pause queue consumption while retaining the current cue cursor."""
+
+        session = self._session(world_id)
+        if session.status != "paused":
+            session = replace(session, status="paused", updated_at=utc_now())
+            self._repository.save_presentation_session(session)
+        return self.state(world_id)
+
+    def resume(self, world_id: str) -> dict[str, Any]:
+        """Resume queue consumption without replaying completed plans."""
+
+        state = self.state(world_id)
+        if state["session"]["status"] == "paused":
+            status = "playing" if state["plans"] else self._waiting_status(world_id)
+            session = replace(
+                self._session(world_id), status=status, updated_at=utc_now()
+            )
+            self._repository.save_presentation_session(session)
+        return self.state(world_id)
+
+    def checkpoint(self, world_id: str, plan_id: str, cue_index: int) -> dict[str, Any]:
+        """Persist one completed cue and advance only the derived playback cursor."""
+
+        if cue_index < 0:
+            raise ValueError("cue_index 必须是非负整数")
+        events = self._repository.list_events(world_id)
+        scene_events = [
+            event for event in events if presentation_mode_for_event(event) == "scene"
+        ]
+        target = next(
+            (
+                event
+                for event in scene_events
+                if compile_performance_plan(event).id == plan_id
+            ),
+            None,
+        )
+        if target is None:
+            raise ValueError("找不到对应的演出计划")
+        plan = compile_performance_plan(target)
+        if cue_index >= len(plan.cues):
+            raise ValueError("cue_index 超出演出计划范围")
+        session = self._normalize_session(self._session(world_id), events)
+        if target.sequence <= session.last_presented_event_sequence:
+            return self.state(world_id)
+        if session.status == "paused":
+            raise ValueError("演出已暂停")
+        next_scene = next(
+            (
+                event
+                for event in scene_events
+                if event.sequence > session.last_presented_event_sequence
+            ),
+            None,
+        )
+        if next_scene is None or target.sequence != next_scene.sequence:
+            raise ValueError("演出计划必须按世界事件顺序完成")
+        if session.active_plan_id not in (None, plan.id):
+            raise ValueError("另一演出计划正在等待完成")
+        cue = plan.cues[cue_index]
+        if not cue.checkpoint and cue_index != len(plan.cues) - 1:
+            raise ValueError("只能提交阻塞 cue 或计划末尾 checkpoint")
+        if session.active_plan_id == plan.id and cue_index < session.active_cue_index:
+            return self.state(world_id)
+        if session.active_plan_id == plan.id and cue_index > session.active_cue_index:
+            raise ValueError("不能跳过当前演出 cue")
+        next_index = cue_index + 1
+        next_session = replace(
+            session,
+            last_presented_event_sequence=(
+                target.sequence
+                if next_index >= len(plan.cues)
+                else session.last_presented_event_sequence
+            ),
+            active_plan_id=plan.id if next_index < len(plan.cues) else None,
+            active_cue_index=next_index if next_index < len(plan.cues) else 0,
+            status="playing",
+            updated_at=utc_now(),
+        )
+        self._repository.save_presentation_session(next_session)
+        return self.state(world_id)
+
+    def state(self, world_id: str) -> dict[str, Any]:
+        """Derive idempotent scene plans from facts and expose the persisted cursor."""
+
+        events = self._repository.list_events(world_id)
+        barriers = self._repository.list_pending_barriers(world_id)
+        session = self._normalize_session(self._session(world_id), events)
+        plans = [
+            compile_performance_plan(event)
+            for event in events
+            if event.sequence > session.last_presented_event_sequence
+            and presentation_mode_for_event(event) == "scene"
+        ]
+        if session.active_plan_id and all(
+            plan.id != session.active_plan_id for plan in plans
+        ):
+            session = replace(
+                session,
+                active_plan_id=None,
+                active_cue_index=0,
+                status=(
+                    "playing"
+                    if plans and session.status != "paused"
+                    else session.status
+                ),
+                updated_at=utc_now(),
+            )
+            self._repository.save_presentation_session(session)
+        elif session.status != "paused":
+            desired = (
+                "playing"
+                if plans
+                else self._waiting_status(world_id, barriers=barriers)
+            )
+            if session.status != desired:
+                session = replace(session, status=desired, updated_at=utc_now())
+                self._repository.save_presentation_session(session)
+        resolver = WorldPresentationAssetResolver(
+            snapshots=self._repository.list_role_snapshots(world_id),
+            residents=self._repository.list_residents(world_id),
+        )
+        return {
+            "session": session.to_bridge_dict(),
+            "plans": [resolver.to_bridge_dict(plan) for plan in plans],
+        }
+
+    def _session(self, world_id: str) -> WorldPresentationSession:
+        session = self._repository.get_presentation_session(world_id)
+        if session is not None:
+            return session
+        events = self._repository.list_events(world_id)
+        session = WorldPresentationSession(
+            world_id=world_id,
+            status="playing" if events else self._waiting_status(world_id),
+        )
+        self._repository.save_presentation_session(session)
+        return session
+
+    def _normalize_session(
+        self,
+        session: WorldPresentationSession,
+        events: list[TimelineEvent],
+    ) -> WorldPresentationSession:
+        if session.active_plan_id or not events:
+            return session
+        next_scene = next(
+            (
+                event
+                for event in events
+                if event.sequence > session.last_presented_event_sequence
+                and presentation_mode_for_event(event) == "scene"
+            ),
+            None,
+        )
+        target_sequence = next_scene.sequence - 1 if next_scene else events[-1].sequence
+        if target_sequence <= session.last_presented_event_sequence:
+            return session
+        normalized = replace(
+            session,
+            last_presented_event_sequence=target_sequence,
+            updated_at=utc_now(),
+        )
+        self._repository.save_presentation_session(normalized)
+        return normalized
+
+    def _waiting_status(
+        self,
+        world_id: str,
+        *,
+        barriers: list[DecisionBarrier] | None = None,
+    ) -> str:
+        if barriers is not None:
+            return "awaiting_barrier" if barriers else "awaiting_action"
+        return (
+            "awaiting_barrier"
+            if self._repository.list_pending_barriers(world_id)
+            else "awaiting_action"
+        )

--- a/desktop_bridge/world_simulation_handler.py
+++ b/desktop_bridge/world_simulation_handler.py
@@ -3,33 +3,33 @@
 from __future__ import annotations
 
 from dataclasses import replace
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timezone
 from pathlib import Path
-import shutil
 from typing import Any
 from uuid import uuid4
 
-from PIL import Image, ImageOps, UnidentifiedImageError
-
 from core.roles import RoleStore
-from desktop_bridge.world_presentation_assets import WorldPresentationAssetResolver
+from desktop_bridge.world_day_handler import WorldDayHandler
+from desktop_bridge.world_presentation_handler import WorldPresentationHandler
+from desktop_bridge.world_snapshot_builder import WorldSnapshotBuilder
 from world_simulation.actors import AutonomyPolicy, PlayerOC
 from world_simulation.dependencies import DependencySet
+from world_simulation.days import group_world_days
 from world_simulation.errors import HistoricalConflictError
-from world_simulation.performance import compile_performance_plan
-from world_simulation.presentation_session import WorldPresentationSession
+from world_simulation.performance import (
+    compile_performance_plan,
+    presentation_mode_for_event,
+)
 from world_simulation.proposals import BeatProposal, ProposedEvent
 from world_simulation.repository import WorldRepository
 from world_simulation.scenes import DecisionBarrier
 from world_simulation.service import WorldSimulationService
 from world_simulation.timeline import TimelineEvent
-from world_simulation.world import NativeResident, RoleTemplateSnapshot, WorldDraft, WorldTemplate
-from world_simulation.world import utc_now
-
-
-_SNAPSHOT_CHARACTER_CANVAS = (1200, 1600)
-_SNAPSHOT_CHARACTER_BASELINE = 1520
-_SNAPSHOT_CHARACTER_MARGIN = 60
+from world_simulation.world import (
+    NativeResident,
+    WorldDraft,
+    WorldTemplate,
+)
 
 
 class WorldSimulationHandler:
@@ -39,7 +39,9 @@ class WorldSimulationHandler:
         self._roles = role_store
         self._repository = WorldRepository(workspace / "worlds.db")
         self._service = WorldSimulationService(self._repository)
-        self._world_assets_dir = workspace / "world_assets"
+        self._days = WorldDayHandler(self._repository, self._service)
+        self._presentation = WorldPresentationHandler(self._repository)
+        self._snapshots = WorldSnapshotBuilder(role_store, workspace / "world_assets")
         self._shots: dict[tuple[str, str], dict[str, Any]] = {}
 
     def close(self) -> None:
@@ -47,13 +49,19 @@ class WorldSimulationHandler:
 
         self._repository.close()
 
-    def handle(self, method: str, payload: dict[str, Any], *, request_id: str) -> dict[str, Any] | None:
+    def handle(
+        self, method: str, payload: dict[str, Any], *, request_id: str
+    ) -> dict[str, Any] | None:
         """Handle a worlds.* request, returning None for unrelated bridge methods."""
 
         if not method.startswith("worlds."):
             return None
         if method == "worlds.list":
-            return {"worlds": [self._summary(world) for world in self._repository.list_worlds()]}
+            return {
+                "worlds": [
+                    self._summary(world) for world in self._repository.list_worlds()
+                ]
+            }
         if method == "worlds.get":
             return {"world": self._world_details(self._world_id(payload))}
         if method == "worlds.drafts.preview":
@@ -66,8 +74,14 @@ class WorldSimulationHandler:
             return {"world": self._switch_oc(payload)}
         if method == "worlds.actions.submit":
             return self._submit_action(payload, request_id=request_id)
+        if method == "worlds.days.complete":
+            return self._days.complete(
+                self._world_id(payload),
+                self._required(payload, "content"),
+                request_id=request_id,
+            )
         if method == "worlds.advance":
-            return self._advance(payload, request_id=request_id)
+            return self._days.advance(self._world_id(payload), request_id=request_id)
         if method == "worlds.barriers.resolve":
             return {"world": self._resolve_barrier(payload, request_id=request_id)}
         if method == "worlds.timeline":
@@ -83,19 +97,32 @@ class WorldSimulationHandler:
         if method == "worlds.events.catch_up":
             return self._catch_up(payload)
         if method == "worlds.presentation.pause":
-            return {"presentation": self._pause_presentation(payload)}
+            return {"presentation": self._presentation.pause(self._world_id(payload))}
         if method == "worlds.presentation.resume":
-            return {"presentation": self._resume_presentation(payload)}
+            return {"presentation": self._presentation.resume(self._world_id(payload))}
         if method == "worlds.presentation.checkpoint":
-            return {"presentation": self._checkpoint_presentation(payload)}
+            raw_index = payload.get("cue_index")
+            try:
+                cue_index = int(str(raw_index).strip()) if raw_index is not None else -1
+            except ValueError as exc:
+                raise ValueError("cue_index 必须是非负整数") from exc
+            return {
+                "presentation": self._presentation.checkpoint(
+                    self._world_id(payload),
+                    self._required(payload, "plan_id"),
+                    cue_index,
+                )
+            }
         if method == "worlds.shots.redraw":
             return {"shot": self._redraw_shot(payload)}
         raise ValueError(f"unknown world method: {method}")
 
     def _preview_draft(self, payload: dict[str, Any]) -> dict[str, Any]:
         input_data = self._creation_input(payload)
-        selected_roles = [self._require_role(role_id) for role_id in input_data["selectedRoleIds"]]
-        snapshots = tuple(self._snapshot_for(role) for role in selected_roles)
+        selected_roles = [
+            self._require_role(role_id) for role_id in input_data["selectedRoleIds"]
+        ]
+        snapshots = tuple(self._snapshots.snapshot_for(role) for role in selected_roles)
         residents = tuple(
             NativeResident(
                 id=f"resident-{snapshot.source_role_id}",
@@ -104,7 +131,9 @@ class WorldSimulationHandler:
                 occupation=role.description or "世界原住民",
                 residence=input_data["firstOc"]["entryLocation"],
                 core_persona_facts=(role.system_prompt,),
-                visual_identity={"avatar_path": self._asset_path(role.avatar)},
+                visual_identity={
+                    "avatar_path": self._snapshots.source_asset_path(role.avatar)
+                },
             )
             for snapshot, role in zip(snapshots, selected_roles, strict=True)
         )
@@ -131,10 +160,15 @@ class WorldSimulationHandler:
         return {
             "id": draft.id,
             "input": input_data,
-            "nativeIdentities": [self._native_identity(resident, role) for resident, role in zip(residents, selected_roles, strict=True)],
+            "nativeIdentities": [
+                self._native_identity(resident, role)
+                for resident, role in zip(residents, selected_roles, strict=True)
+            ],
         }
 
-    def _confirm_draft(self, payload: dict[str, Any], *, request_id: str) -> dict[str, Any]:
+    def _confirm_draft(
+        self, payload: dict[str, Any], *, request_id: str
+    ) -> dict[str, Any]:
         draft_id = self._required(payload, "draft_id")
         draft = self._repository.get_draft(draft_id)
         if draft is None:
@@ -169,10 +203,14 @@ class WorldSimulationHandler:
     def _switch_oc(self, payload: dict[str, Any]) -> dict[str, Any]:
         world_id = self._world_id(payload)
         world = self._repository.require_world(world_id)
-        self._service.switch_oc(world_id, self._required(payload, "oc_id"), expected_revision=world.revision)
+        self._service.switch_oc(
+            world_id, self._required(payload, "oc_id"), expected_revision=world.revision
+        )
         return self._world_details(world_id)
 
-    def _submit_action(self, payload: dict[str, Any], *, request_id: str) -> dict[str, Any]:
+    def _submit_action(
+        self, payload: dict[str, Any], *, request_id: str
+    ) -> dict[str, Any]:
         world_id = self._world_id(payload)
         content = self._required(payload, "content")
         world = self._repository.require_world(world_id)
@@ -190,47 +228,34 @@ class WorldSimulationHandler:
             random_seed=run.random_seed,
             event_type="scene.action.committed",
             effective_at=world.current_time,
+            day_index=self._days.current_index(world_id),
             participants=(active_oc.id,),
             location=active_oc.location,
-            presentation={"kind": "action", "content": content, "speaker_name": active_oc.name},
+            presentation={
+                "mode": "narrative",
+                "kind": "action",
+                "content": content,
+                "speaker_name": active_oc.name,
+            },
             projection_patch={"last_action": {"oc": active_oc.id, "content": content}},
         )
         self._service.submit_action(proposal, request_id=request_id)
         return {"run_id": run.id}
 
-    def _advance(self, payload: dict[str, Any], *, request_id: str) -> dict[str, Any]:
+    def _resolve_barrier(
+        self, payload: dict[str, Any], *, request_id: str
+    ) -> dict[str, Any]:
         world_id = self._world_id(payload)
         world = self._repository.require_world(world_id)
-        active_oc = self._active_oc(world_id, world.active_oc_id)
-        run = self._service.start_run(
-            world_id,
-            kind="advance",
-            request_id=f"{request_id}:run",
-            expected_revision=world.revision,
-            random_seed=f"{world.random_state}:{request_id}",
+        barrier = self._repository.get_barrier(
+            world_id, self._required(payload, "barrier_id")
         )
-        next_time = self._next_time(world.current_time)
-        proposal = self._proposal(
-            world=world,
-            run_id=run.id,
-            random_seed=run.random_seed,
-            event_type="world.time.advanced",
-            effective_at=next_time,
-            participants=(active_oc.id,),
-            location=active_oc.location,
-            presentation={"kind": "environment", "content": "时间向前流去，新的机会正在靠近。"},
-        )
-        self._service.advance(proposal, request_id=request_id)
-        return {"run_id": run.id}
-
-    def _resolve_barrier(self, payload: dict[str, Any], *, request_id: str) -> dict[str, Any]:
-        world_id = self._world_id(payload)
-        world = self._repository.require_world(world_id)
-        barrier = self._repository.get_barrier(world_id, self._required(payload, "barrier_id"))
         if barrier is None:
             raise ValueError("待决事件已经不存在")
         choice_id = self._required(payload, "choice_id")
-        option = next((item for item in barrier.options if str(item.get("id")) == choice_id), None)
+        option = next(
+            (item for item in barrier.options if str(item.get("id")) == choice_id), None
+        )
         if option is None:
             raise ValueError("不是这个待决事件的选择")
         run = self._service.start_run(
@@ -247,7 +272,10 @@ class WorldSimulationHandler:
             event_type="decision.resolved",
             effective_at=barrier.effective_at,
             participants=(barrier.oc_id,),
-            presentation={"kind": "action", "content": str(option.get("label") or "作出了决定")},
+            presentation={
+                "kind": "action",
+                "content": str(option.get("label") or "作出了决定"),
+            },
         )
         self._service.resolve_barrier(
             world_id,
@@ -264,14 +292,28 @@ class WorldSimulationHandler:
         oc_id = str(payload.get("oc_id") or "")
         entries = []
         for event in self._repository.list_events(world_id):
-            known_to = set(event.visibility.get("known_to", ())) if isinstance(event.visibility, dict) else set()
+            known_to = (
+                set(event.visibility.get("known_to", ()))
+                if isinstance(event.visibility, dict)
+                else set()
+            )
             if perspective == "known" and oc_id and known_to and oc_id not in known_to:
                 continue
-            entries.append(self._timeline_entry(event, visibility="known" if known_to else "omniscient"))
+            entries.append(
+                self._timeline_entry(
+                    event, visibility="known" if known_to else "omniscient"
+                )
+            )
         return entries
 
-    def _copy_world(self, payload: dict[str, Any], *, request_id: str) -> dict[str, Any]:
-        world = self._service.copy_world(self._world_id(payload), self._required(payload, "anchor_id"), request_id=request_id)
+    def _copy_world(
+        self, payload: dict[str, Any], *, request_id: str
+    ) -> dict[str, Any]:
+        world = self._service.copy_world(
+            self._world_id(payload),
+            self._required(payload, "anchor_id"),
+            request_id=request_id,
+        )
         return self._world_details(world.id)
 
     def _preview_backfill(self, payload: dict[str, Any]) -> dict[str, Any]:
@@ -286,14 +328,24 @@ class WorldSimulationHandler:
             "anchorId": anchor.id,
             "oc": oc,
             "stages": [
-                {"title": "过去经历", "summary": "日常经历将作为私有历史补入。", "playable": False},
-                {"title": "入场时刻", "summary": "重要转折会在共享世界中成为可玩场景。", "playable": True},
+                {
+                    "title": "过去经历",
+                    "summary": "日常经历将作为私有历史补入。",
+                    "playable": False,
+                },
+                {
+                    "title": "入场时刻",
+                    "summary": "重要转折会在共享世界中成为可玩场景。",
+                    "playable": True,
+                },
             ],
             "conflicts": conflicts,
             "allowed": not conflicts,
         }
 
-    def _commit_backfill(self, payload: dict[str, Any], *, request_id: str) -> dict[str, Any]:
+    def _commit_backfill(
+        self, payload: dict[str, Any], *, request_id: str
+    ) -> dict[str, Any]:
         world_id = self._world_id(payload)
         preview = payload.get("preview")
         if not isinstance(preview, dict):
@@ -315,7 +367,14 @@ class WorldSimulationHandler:
     def _cancel_run(self, payload: dict[str, Any]) -> dict[str, Any]:
         world_id = self._world_id(payload)
         # A run that already committed is intentionally not rolled back.
-        run = next((item for item in self._repository.list_runs(world_id) if item.status not in {"completed", "failed", "cancelled"}), None)
+        run = next(
+            (
+                item
+                for item in self._repository.list_runs(world_id)
+                if item.status not in {"completed", "failed", "cancelled"}
+            ),
+            None,
+        )
         if run is not None:
             self._service.cancel_run(run.id)
         return self._world_details(world_id)
@@ -324,7 +383,10 @@ class WorldSimulationHandler:
         world_id = self._world_id(payload)
         cursor = int(str(payload.get("cursor") or "0").strip() or 0)
         messages = self._repository.list_outbox(world_id, after_sequence=cursor)
-        beats = [self._beat(message["payload"].get("event", {}), int(message["sequence"])) for message in messages]
+        beats = [
+            self._beat(message["payload"].get("event", {}), int(message["sequence"]))
+            for message in messages
+        ]
         next_cursor = str(messages[-1]["sequence"] if messages else cursor)
         world = self._world_details(world_id)
         return {
@@ -334,156 +396,12 @@ class WorldSimulationHandler:
             "presentation": world["presentation"],
         }
 
-    def _pause_presentation(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Pause queue consumption while retaining the current cue cursor."""
-
-        world_id = self._world_id(payload)
-        session = self._presentation_session(world_id)
-        if session.status != "paused":
-            session = replace(session, status="paused", updated_at=utc_now())
-            self._repository.save_presentation_session(session)
-        return self._presentation_state(world_id)
-
-    def _resume_presentation(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Resume queue consumption without replaying completed plans."""
-
-        world_id = self._world_id(payload)
-        state = self._presentation_state(world_id)
-        session = state["session"]
-        if session["status"] == "paused":
-            status = "playing" if state["plans"] else self._waiting_status(world_id)
-            session = replace(
-                self._presentation_session(world_id),
-                status=status,
-                updated_at=utc_now(),
-            )
-            self._repository.save_presentation_session(session)
-        return self._presentation_state(world_id)
-
-    def _checkpoint_presentation(self, payload: dict[str, Any]) -> dict[str, Any]:
-        """Persist one completed cue and advance only the derived playback cursor."""
-
-        world_id = self._world_id(payload)
-        plan_id = self._required(payload, "plan_id")
-        raw_cue_index = payload.get("cue_index")
-        try:
-            cue_index = int(str(raw_cue_index).strip()) if raw_cue_index is not None else -1
-        except ValueError as exc:
-            raise ValueError("cue_index 必须是非负整数") from exc
-        if cue_index < 0:
-            raise ValueError("cue_index 必须是非负整数")
-        events = self._repository.list_events(world_id)
-        target = next(
-            (
-                event
-                for event in events
-                if compile_performance_plan(event).id == plan_id
-            ),
-            None,
-        )
-        if target is None:
-            raise ValueError("找不到对应的演出计划")
-        plan = compile_performance_plan(target)
-        if cue_index >= len(plan.cues):
-            raise ValueError("cue_index 超出演出计划范围")
-        session = self._presentation_session(world_id)
-        if target.sequence <= session.last_presented_event_sequence:
-            return self._presentation_state(world_id)
-        if session.status == "paused":
-            raise ValueError("演出已暂停")
-        if target.sequence != session.last_presented_event_sequence + 1:
-            raise ValueError("演出计划必须按世界事件顺序完成")
-        if session.active_plan_id not in (None, plan.id):
-            raise ValueError("另一演出计划正在等待完成")
-        cue = plan.cues[cue_index]
-        if not cue.checkpoint and cue_index != len(plan.cues) - 1:
-            raise ValueError("只能提交阻塞 cue 或计划末尾 checkpoint")
-        if session.active_plan_id == plan.id and cue_index < session.active_cue_index:
-            return self._presentation_state(world_id)
-        if session.active_plan_id == plan.id and cue_index > session.active_cue_index:
-            raise ValueError("不能跳过当前演出 cue")
-        next_index = cue_index + 1
-        if next_index < len(plan.cues):
-            next_session = replace(
-                session,
-                active_plan_id=plan.id,
-                active_cue_index=next_index,
-                status="playing",
-                updated_at=utc_now(),
-            )
-        else:
-            next_session = replace(
-                session,
-                last_presented_event_sequence=target.sequence,
-                active_plan_id=None,
-                active_cue_index=0,
-                status="playing",
-                updated_at=utc_now(),
-            )
-        self._repository.save_presentation_session(next_session)
-        return self._presentation_state(world_id)
-
-    def _presentation_session(self, world_id: str) -> WorldPresentationSession:
-        """Load a session, rebuilding an empty cursor when its derived row is gone."""
-
-        session = self._repository.get_presentation_session(world_id)
-        if session is not None:
-            return session
-        events = self._repository.list_events(world_id)
-        session = WorldPresentationSession(
-            world_id=world_id,
-            status="playing" if events else self._waiting_status(world_id),
-        )
-        self._repository.save_presentation_session(session)
-        return session
-
-    def _presentation_state(self, world_id: str) -> dict[str, Any]:
-        """Derive idempotent plans from facts and expose the persisted cursor."""
-
-        events = self._repository.list_events(world_id)
-        barriers = self._repository.list_pending_barriers(world_id)
-        session = self._presentation_session(world_id)
-        plans = [
-            compile_performance_plan(event)
-            for event in events
-            if event.sequence > session.last_presented_event_sequence
-        ]
-        if session.active_plan_id and all(plan.id != session.active_plan_id for plan in plans):
-            session = replace(
-                session,
-                active_plan_id=None,
-                active_cue_index=0,
-                status="playing" if plans and session.status != "paused" else session.status,
-                updated_at=utc_now(),
-            )
-            self._repository.save_presentation_session(session)
-        elif session.status != "paused":
-            desired = "playing" if plans else self._waiting_status(world_id, barriers=barriers)
-            if session.status != desired:
-                session = replace(session, status=desired, updated_at=utc_now())
-                self._repository.save_presentation_session(session)
-        asset_resolver = WorldPresentationAssetResolver(
-            snapshots=self._repository.list_role_snapshots(world_id),
-            residents=self._repository.list_residents(world_id),
-        )
-        return {
-            "session": session.to_bridge_dict(),
-            "plans": [asset_resolver.to_bridge_dict(plan) for plan in plans],
-        }
-
-    def _waiting_status(
-        self, world_id: str, *, barriers: list[DecisionBarrier] | None = None
-    ) -> str:
-        return "awaiting_barrier" if barriers is not None and barriers else (
-            "awaiting_barrier"
-            if self._repository.list_pending_barriers(world_id)
-            else "awaiting_action"
-        )
-
     def _redraw_shot(self, payload: dict[str, Any]) -> dict[str, Any]:
         world_id = self._world_id(payload)
         shot_id = self._required(payload, "shot_id")
-        existing = self._shots.get((world_id, shot_id), {"id": shot_id, "prompt": "当前场景", "assets": []})
+        existing = self._shots.get(
+            (world_id, shot_id), {"id": shot_id, "prompt": "当前场景", "assets": []}
+        )
         shot = {**existing, "status": "developing"}
         self._shots[(world_id, shot_id)] = shot
         return shot
@@ -494,24 +412,71 @@ class WorldSimulationHandler:
         residents = self._repository.list_residents(world_id)
         barriers = self._repository.list_pending_barriers(world_id)
         events = self._repository.list_events(world_id)
-        active_oc = next((oc for oc in ocs if oc.id == world.active_oc_id), ocs[0] if ocs else None)
-        beats = [self._beat(event.to_dict(), index + 1) for index, event in enumerate(events)]
+        active_oc = next(
+            (oc for oc in ocs if oc.id == world.active_oc_id), ocs[0] if ocs else None
+        )
+        beats = [
+            self._beat(event.to_dict(), index + 1) for index, event in enumerate(events)
+        ]
+        current_day_index = self._days.current_index(world_id)
+        days = [
+            {
+                "dayIndex": group.day_index,
+                "title": f"Day {group.day_index}",
+                "status": group.status,
+                "events": [
+                    beat
+                    for beat, event in zip(beats, events, strict=True)
+                    if event in group.events
+                ],
+            }
+            for group in group_world_days(events)
+        ]
         return {
             **self._summary(world),
-            "ocs": [self._oc_view(oc, active=oc.id == world.active_oc_id) for oc in ocs],
+            "currentDayIndex": current_day_index,
+            "days": days,
+            "ocs": [
+                self._oc_view(oc, active=oc.id == world.active_oc_id) for oc in ocs
+            ],
             "scene": {
                 "title": f"{world.template_snapshot.get('name', '世界')}的此刻",
                 "location": active_oc.location if active_oc else "未知地点",
                 "timeLabel": world.current_time,
-                "participants": [{"id": oc.id, "name": oc.name, "role": "controlled_oc" if oc.id == world.active_oc_id else "observer"} for oc in ocs],
+                "participants": [
+                    {
+                        "id": oc.id,
+                        "name": oc.name,
+                        "role": (
+                            "controlled_oc"
+                            if oc.id == world.active_oc_id
+                            else "observer"
+                        ),
+                    }
+                    for oc in ocs
+                ],
                 "beats": beats,
-                "actionPrompt": f"{active_oc.name}准备怎么做？" if active_oc else "先创建一位 OC。",
+                "actionPrompt": (
+                    f"{active_oc.name}准备怎么做？" if active_oc else "先创建一位 OC。"
+                ),
                 "opportunities": [],
                 "barriers": [self._barrier_view(item, ocs) for item in barriers],
             },
-            "relatedCharacters": [{"id": resident.id, "name": resident.name, "relationship": resident.occupation or "世界原住民", "avatarUrl": resident.visual_identity.get("avatar_path")} for resident in residents],
-            "performance": {"active": bool(beats), "label": "观看现场演出", "canCancel": False},
-            "presentation": self._presentation_state(world_id),
+            "relatedCharacters": [
+                {
+                    "id": resident.id,
+                    "name": resident.name,
+                    "relationship": resident.occupation or "世界原住民",
+                    "avatarUrl": resident.visual_identity.get("avatar_path"),
+                }
+                for resident in residents
+            ],
+            "performance": {
+                "active": bool(beats),
+                "label": "观看现场演出",
+                "canCancel": False,
+            },
+            "presentation": self._presentation.state(world_id),
         }
 
     def _summary(self, world: Any) -> dict[str, Any]:
@@ -521,11 +486,57 @@ class WorldSimulationHandler:
             "name": world.template_snapshot.get("name", "未命名世界"),
             "premise": environment.get("premise", ""),
             "currentTimeLabel": world.current_time,
+            "currentDayIndex": self._days.current_index(world.id),
             "activeOcId": world.active_oc_id,
-            "status": "barrier" if self._repository.list_pending_barriers(world.id) else "action_required",
+            "status": (
+                "barrier"
+                if self._repository.list_pending_barriers(world.id)
+                else "action_required"
+            ),
         }
 
-    def _proposal(self, *, world: Any, run_id: str, random_seed: str, event_type: str, effective_at: str, participants: tuple[str, ...], location: str = "", presentation: dict[str, Any], projection_patch: dict[str, Any] | None = None) -> BeatProposal:
+    def _proposal(
+        self,
+        *,
+        world: Any,
+        run_id: str,
+        random_seed: str,
+        event_type: str,
+        effective_at: str,
+        participants: tuple[str, ...],
+        location: str = "",
+        presentation: dict[str, Any],
+        projection_patch: dict[str, Any] | None = None,
+        day_index: int | None = None,
+    ) -> BeatProposal:
+        event = ProposedEvent(
+            event_type=event_type,
+            effective_at=effective_at,
+            day_index=day_index or self._days.current_index(world.id),
+            participants=participants,
+            location=location,
+            changes={"presentation": presentation},
+            dependencies=DependencySet(write_facts=frozenset({event_type})),
+        )
+        return self._proposal_from_events(
+            world=world,
+            run_id=run_id,
+            random_seed=random_seed,
+            events=(event,),
+            projection_patch=projection_patch,
+        )
+
+    def _proposal_from_events(
+        self,
+        *,
+        world: Any,
+        run_id: str,
+        random_seed: str,
+        events: tuple[ProposedEvent, ...],
+        projection_patch: dict[str, Any] | None = None,
+    ) -> BeatProposal:
+        """Build one settlement envelope for one or more Day events."""
+
         return BeatProposal(
             schema_version=1,
             proposal_id=f"proposal-{uuid4().hex}",
@@ -539,195 +550,191 @@ class WorldSimulationHandler:
             prompt_version="desktop-v1",
             random_seed=random_seed,
             source="desktop_bridge",
-            events=(ProposedEvent(event_type=event_type, effective_at=effective_at, participants=participants, location=location, changes={"presentation": presentation}, dependencies=DependencySet(write_facts=frozenset({event_type}))),),
+            events=events,
             projection_patch=projection_patch or {},
         )
 
     def _beat(self, event: dict[str, Any], order: int) -> dict[str, Any]:
-        changes = event.get("changes", {}) if isinstance(event.get("changes"), dict) else {}
-        presentation = changes.get("presentation", {}) if isinstance(changes.get("presentation"), dict) else {}
+        changes = (
+            event.get("changes", {}) if isinstance(event.get("changes"), dict) else {}
+        )
+        presentation = (
+            changes.get("presentation", {})
+            if isinstance(changes.get("presentation"), dict)
+            else {}
+        )
         event_type = str(event.get("event_type") or "world.event")
-        return {"id": str(event.get("id") or f"beat-{order}"), "order": order, "timeLabel": str(event.get("effective_at") or ""), "speakerName": presentation.get("speaker_name"), "kind": presentation.get("kind", "environment"), "content": presentation.get("content", self._event_summary(event_type)), "isCritical": event_type.startswith("decision."), "performancePlan": compile_performance_plan(event).to_bridge_dict()}
+        mode = presentation_mode_for_event(event)
+        beat = {
+            "id": str(event.get("id") or f"beat-{order}"),
+            "order": order,
+            "dayIndex": int(event.get("day_index") or 1),
+            "timeLabel": str(event.get("effective_at") or ""),
+            "speakerName": presentation.get("speaker_name"),
+            "kind": presentation.get("kind", "environment"),
+            "content": presentation.get("content", self._event_summary(event_type)),
+            "presentationMode": mode,
+            "isCritical": event_type.startswith("decision."),
+        }
+        if mode == "scene":
+            beat["performancePlan"] = compile_performance_plan(event).to_bridge_dict()
+        return beat
 
-    def _timeline_entry(self, event: TimelineEvent, *, visibility: str) -> dict[str, Any]:
-        return {"id": event.id, "timeLabel": event.effective_at, "title": self._event_title(event.event_type), "summary": self._beat(event.to_dict(), event.sequence)["content"], "visibility": visibility, "involvedNames": self._participant_names(event.world_id, event.participants), "canCopy": True, "canEnter": True}
+    def _timeline_entry(
+        self, event: TimelineEvent, *, visibility: str
+    ) -> dict[str, Any]:
+        return {
+            "id": event.id,
+            "dayIndex": event.day_index,
+            "timeLabel": event.effective_at,
+            "title": self._event_title(event.event_type),
+            "summary": self._beat(event.to_dict(), event.sequence)["content"],
+            "visibility": visibility,
+            "involvedNames": self._participant_names(
+                event.world_id, event.participants
+            ),
+            "canCopy": True,
+            "canEnter": True,
+        }
 
     @staticmethod
     def _event_title(event_type: str) -> str:
-        return {"world.created": "世界开启", "player_oc.joined": "新的入场", "player_oc.backfilled": "补入过去", "scene.action.committed": "行动", "world.time.advanced": "世界继续流动", "decision.resolved": "做出了决定"}.get(event_type, "世界事件")
+        return {
+            "world.created": "世界开启",
+            "player_oc.joined": "新的入场",
+            "player_oc.backfilled": "补入过去",
+            "scene.action.committed": "行动",
+            "world.time.advanced": "世界继续流动",
+            "world.day.advanced": "新的一天",
+            "decision.resolved": "做出了决定",
+        }.get(event_type, "世界事件")
 
     @staticmethod
     def _event_summary(event_type: str) -> str:
-        return {"world.created": "世界的既定事实从这一刻开始。", "player_oc.joined": "一位新的 OC 来到世界。", "player_oc.backfilled": "新的经历被安全地补入过去。"}.get(event_type, "世界发生了新的变化。")
+        return {
+            "world.created": "世界的既定事实从这一刻开始。",
+            "player_oc.joined": "一位新的 OC 来到世界。",
+            "player_oc.backfilled": "新的经历被安全地补入过去。",
+        }.get(event_type, "世界发生了新的变化。")
 
     def _native_identity(self, resident: NativeResident, role: Any) -> dict[str, Any]:
-        return {"roleId": role.id, "roleName": role.name, "nativeName": resident.name, "identity": resident.occupation, "history": "在世界开始前已经拥有自己的生活。", "relationships": "", "accepted": True}
+        return {
+            "roleId": role.id,
+            "roleName": role.name,
+            "nativeName": resident.name,
+            "identity": resident.occupation,
+            "history": "在世界开始前已经拥有自己的生活。",
+            "relationships": "",
+            "accepted": True,
+        }
 
-    def _apply_native_identity_edits(self, draft: WorldDraft, identities: list[Any]) -> WorldDraft:
-        edits = {str(item.get("roleId")): item for item in identities if isinstance(item, dict) and bool(item.get("accepted"))}
+    def _apply_native_identity_edits(
+        self, draft: WorldDraft, identities: list[Any]
+    ) -> WorldDraft:
+        edits = {
+            str(item.get("roleId")): item
+            for item in identities
+            if isinstance(item, dict) and bool(item.get("accepted"))
+        }
         if len(edits) != len(draft.residents):
             raise ValueError("请确认所有原住民草案")
         residents = []
         for resident in draft.residents:
-            source_role_id = next(snapshot.source_role_id for snapshot in draft.role_snapshots if snapshot.id == resident.snapshot_id)
+            source_role_id = next(
+                snapshot.source_role_id
+                for snapshot in draft.role_snapshots
+                if snapshot.id == resident.snapshot_id
+            )
             edit = edits.get(source_role_id)
             if edit is None:
                 raise ValueError("原住民草案与世界不一致")
-            residents.append(replace(resident, name=self._required(edit, "nativeName"), occupation=self._required(edit, "identity"), prior_experiences=({"summary": self._required(edit, "history")},)))
+            residents.append(
+                replace(
+                    resident,
+                    name=self._required(edit, "nativeName"),
+                    occupation=self._required(edit, "identity"),
+                    prior_experiences=({"summary": self._required(edit, "history")},),
+                )
+            )
         return replace(draft, residents=tuple(residents))
 
     def _backfill_conflicts(self, world_id: str, entry_time: str) -> list[str]:
         try:
-            self._service._validate_backfill(world_id, entry_time, DependencySet(write_facts=frozenset({"oc:private_history"})))
+            self._service._validate_backfill(
+                world_id,
+                entry_time,
+                DependencySet(write_facts=frozenset({"oc:private_history"})),
+            )
         except HistoricalConflictError:
             return ["这段经历会改变已经结算的公共因果。请从更早的节点创建世界副本。"]
         return []
 
     def _oc_from_input(self, value: dict[str, str]) -> PlayerOC:
-        return PlayerOC(id=f"oc-{uuid4().hex}", name=value["name"], persona={"identity": value["identity"]}, identity={"description": value["identity"], "entry_time": value["entryTime"]}, primary_goal=value["primaryGoal"], location=value["entryLocation"], autonomy=AutonomyPolicy(allow_optional_scenes=True))
+        return PlayerOC(
+            id=f"oc-{uuid4().hex}",
+            name=value["name"],
+            persona={"identity": value["identity"]},
+            identity={
+                "description": value["identity"],
+                "entry_time": value["entryTime"],
+            },
+            primary_goal=value["primaryGoal"],
+            location=value["entryLocation"],
+            autonomy=AutonomyPolicy(allow_optional_scenes=True),
+        )
 
     def _oc_view(self, oc: PlayerOC, *, active: bool) -> dict[str, Any]:
-        return {"id": oc.id, "name": oc.name, "identity": str(oc.identity.get("description") or ""), "location": oc.location, "primaryGoal": oc.primary_goal, "constraints": list(oc.behavior_constraints), "autonomy": "guided" if oc.autonomy.allow_optional_scenes else "manual", "isActive": active}
+        return {
+            "id": oc.id,
+            "name": oc.name,
+            "identity": str(oc.identity.get("description") or ""),
+            "location": oc.location,
+            "primaryGoal": oc.primary_goal,
+            "constraints": list(oc.behavior_constraints),
+            "autonomy": "guided" if oc.autonomy.allow_optional_scenes else "manual",
+            "isActive": active,
+        }
 
-    def _barrier_view(self, barrier: DecisionBarrier, ocs: list[PlayerOC]) -> dict[str, Any]:
-        return {"id": barrier.id, "title": barrier.reason, "context": barrier.reason, "affectedOcNames": self._participant_names(barrier.world_id, (barrier.oc_id,)), "choices": [{"id": str(item.get("id", "")), "label": str(item.get("label", "")), "consequence": item.get("consequence")} for item in barrier.options]}
+    def _barrier_view(
+        self, barrier: DecisionBarrier, ocs: list[PlayerOC]
+    ) -> dict[str, Any]:
+        return {
+            "id": barrier.id,
+            "title": barrier.reason,
+            "context": barrier.reason,
+            "affectedOcNames": self._participant_names(
+                barrier.world_id, (barrier.oc_id,)
+            ),
+            "choices": [
+                {
+                    "id": str(item.get("id", "")),
+                    "label": str(item.get("label", "")),
+                    "consequence": item.get("consequence"),
+                }
+                for item in barrier.options
+            ],
+        }
 
-    def _participant_names(self, world_id: str, participants: tuple[str, ...]) -> list[str]:
+    def _participant_names(
+        self, world_id: str, participants: tuple[str, ...]
+    ) -> list[str]:
         names = {oc.id: oc.name for oc in self._repository.list_ocs(world_id)}
-        names.update({resident.id: resident.name for resident in self._repository.list_residents(world_id)})
+        names.update(
+            {
+                resident.id: resident.name
+                for resident in self._repository.list_residents(world_id)
+            }
+        )
         return [names[item] for item in participants if item in names]
 
     def _active_oc(self, world_id: str, oc_id: str | None) -> PlayerOC:
-        oc = next((item for item in self._repository.list_ocs(world_id) if item.id == oc_id), None)
+        oc = next(
+            (item for item in self._repository.list_ocs(world_id) if item.id == oc_id),
+            None,
+        )
         if oc is None:
             raise ValueError("请先选择一位当前 OC")
         return oc
-
-    def _snapshot_for(self, role: Any) -> RoleTemplateSnapshot:
-        snapshot_id = f"snapshot-{uuid4().hex}"
-        asset_ids: dict[str, str] = {}
-        assets = []
-        for source in [role.avatar, *role.illustrations]:
-            if not source or source in asset_ids:
-                continue
-            copied = self._copy_snapshot_asset(snapshot_id, source)
-            if copied is None:
-                continue
-            asset_id = f"asset-{uuid4().hex}"
-            asset_ids[source] = asset_id
-            assets.append({"id": asset_id, "path": copied})
-        runtime = role.runtime_config if isinstance(role.runtime_config, dict) else {}
-        raw_bindings = runtime.get("mood_illustration_bindings", {})
-        bindings = raw_bindings if isinstance(raw_bindings, dict) else {}
-        mood_bindings = {
-            str(mood).strip(): asset_ids[str(path).strip()]
-            for mood, path in bindings.items()
-            if str(mood).strip() and str(path).strip() in asset_ids
-        }
-        raw_catalog = runtime.get("mood_catalog", [])
-        catalog = raw_catalog if isinstance(raw_catalog, list) else []
-        mood_catalog = [
-            str(mood).strip()
-            for mood in catalog
-            if str(mood).strip() in mood_bindings
-        ]
-        default_mood = str(runtime.get("default_mood") or "").strip()
-        if default_mood not in mood_bindings:
-            default_mood = mood_catalog[0] if mood_catalog else next(iter(mood_bindings), "")
-        return RoleTemplateSnapshot(
-            id=snapshot_id,
-            source_role_id=role.id,
-            source_version=role.updated_at,
-            persona={"name": role.name, "description": role.description},
-            system_constraints=(role.system_prompt,),
-            visual_profile={
-                "default_mood": default_mood,
-                "mood_catalog": mood_catalog,
-                "mood_illustration_bindings": mood_bindings,
-                "avatar_asset_id": asset_ids.get(role.avatar),
-            },
-            voice_profile=self._voice_profile(runtime),
-            assets=tuple(assets),
-        )
-
-    def _copy_snapshot_asset(self, snapshot_id: str, relative_path: str) -> str | None:
-        """Copy a role-owned asset before the source role can change or disappear."""
-
-        source = (self._roles.roles_dir / relative_path).resolve()
-        try:
-            source.relative_to(self._roles.assets_dir.resolve())
-        except ValueError:
-            return None
-        if not source.is_file():
-            return None
-        destination_dir = self._world_assets_dir / snapshot_id
-        destination = destination_dir / f"{uuid4().hex}.png"
-        destination.parent.mkdir(parents=True, exist_ok=True)
-        try:
-            self._normalize_snapshot_character(source, destination)
-        except (UnidentifiedImageError, OSError):
-            destination = destination_dir / f"{uuid4().hex}{source.suffix}"
-            shutil.copy2(source, destination)
-        return str(destination.resolve())
-
-    @staticmethod
-    def _normalize_snapshot_character(source: Path, destination: Path) -> None:
-        """Place visible character pixels on one transparent canvas and foot baseline."""
-
-        with Image.open(source) as opened:
-            image = ImageOps.exif_transpose(opened).convert("RGBA")
-            bounds = image.getchannel("A").getbbox()
-            canvas = Image.new("RGBA", _SNAPSHOT_CHARACTER_CANVAS, (0, 0, 0, 0))
-            if bounds is None:
-                canvas.save(destination, format="PNG")
-                return
-            character = image.crop(bounds)
-            max_width = _SNAPSHOT_CHARACTER_CANVAS[0] - 2 * _SNAPSHOT_CHARACTER_MARGIN
-            max_height = _SNAPSHOT_CHARACTER_BASELINE - _SNAPSHOT_CHARACTER_MARGIN
-            scale = min(1.0, max_width / character.width, max_height / character.height)
-            if scale < 1.0:
-                character = character.resize(
-                    (
-                        max(1, round(character.width * scale)),
-                        max(1, round(character.height * scale)),
-                    ),
-                    Image.Resampling.LANCZOS,
-                )
-            x = (_SNAPSHOT_CHARACTER_CANVAS[0] - character.width) // 2
-            y = _SNAPSHOT_CHARACTER_BASELINE - character.height
-            canvas.alpha_composite(character, (x, y))
-            canvas.save(destination, format="PNG")
-
-    @staticmethod
-    def _voice_profile(runtime: dict[str, Any]) -> dict[str, Any]:
-        """Freeze only non-secret voice fields required by later presentation work."""
-
-        raw_tts = runtime.get("tts", {})
-        tts = raw_tts if isinstance(raw_tts, dict) else {}
-        voice_id = str(tts.get("voice_id") or "").strip()
-        if not voice_id:
-            return {}
-        speed = tts.get("speed", 1.0)
-        normalized_speed = float(speed) if isinstance(speed, (int, float)) else 1.0
-        if not 0.5 <= normalized_speed <= 2.0:
-            normalized_speed = 1.0
-        raw_emotions = tts.get("mood_tts_emotions", {})
-        emotions = raw_emotions if isinstance(raw_emotions, dict) else {}
-        return {
-            "config_version": 1,
-            "enabled": tts.get("enabled", True) is not False,
-            "provider": str(tts.get("provider") or "minimax").strip() or "minimax",
-            "voice_id": voice_id,
-            "speed": normalized_speed,
-            "mood_tts_emotions": {
-                str(mood).strip(): str(emotion).strip()
-                for mood, emotion in emotions.items()
-                if str(mood).strip() and str(emotion).strip()
-            },
-        }
-
-    def _asset_path(self, relative_path: str | None) -> str | None:
-        return str((self._roles.roles_dir / relative_path).resolve()) if relative_path else None
 
     def _require_role(self, role_id: str) -> Any:
         role = self._roles.get_role(role_id)
@@ -748,7 +755,15 @@ class WorldSimulationHandler:
         selected = payload.get("selectedRoleIds")
         if not isinstance(selected, list):
             raise ValueError("原住民选择格式无效")
-        return {"name": self._required(payload, "name"), "premise": self._required(payload, "premise"), "rules": str(payload.get("rules") or ""), "tone": str(payload.get("tone") or ""), "selectedRoleIds": [str(item) for item in selected if str(item).strip()], "seed": self._required(payload, "seed"), "firstOc": oc}
+        return {
+            "name": self._required(payload, "name"),
+            "premise": self._required(payload, "premise"),
+            "rules": str(payload.get("rules") or ""),
+            "tone": str(payload.get("tone") or ""),
+            "selectedRoleIds": [str(item) for item in selected if str(item).strip()],
+            "seed": self._required(payload, "seed"),
+            "firstOc": oc,
+        }
 
     def _oc_input(self, payload: Any) -> dict[str, str]:
         if not isinstance(payload, dict):
@@ -760,15 +775,13 @@ class WorldSimulationHandler:
             raise ValueError("入场时间无效") from exc
         if parsed.tzinfo is None:
             parsed = parsed.replace(tzinfo=timezone.utc)
-        return {"name": self._required(payload, "name"), "identity": self._required(payload, "identity"), "entryTime": parsed.astimezone(timezone.utc).isoformat(), "entryLocation": self._required(payload, "entryLocation"), "primaryGoal": str(payload.get("primaryGoal") or "")}
-
-    @staticmethod
-    def _next_time(value: str) -> str:
-        try:
-            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
-        except ValueError:
-            return value
-        return (parsed + timedelta(hours=1)).astimezone(timezone.utc).isoformat()
+        return {
+            "name": self._required(payload, "name"),
+            "identity": self._required(payload, "identity"),
+            "entryTime": parsed.astimezone(timezone.utc).isoformat(),
+            "entryLocation": self._required(payload, "entryLocation"),
+            "primaryGoal": str(payload.get("primaryGoal") or ""),
+        }
 
     @staticmethod
     def _required(payload: dict[str, Any], field: str) -> str:

--- a/desktop_bridge/world_snapshot_builder.py
+++ b/desktop_bridge/world_snapshot_builder.py
@@ -1,0 +1,159 @@
+"""World-owned role snapshot construction for the desktop bridge."""
+
+from __future__ import annotations
+
+from pathlib import Path
+import shutil
+from typing import Any
+from uuid import uuid4
+
+from PIL import Image, ImageOps, UnidentifiedImageError
+
+from core.roles import RoleStore
+from world_simulation.world import RoleTemplateSnapshot
+
+_SNAPSHOT_CHARACTER_CANVAS = (1200, 1600)
+_SNAPSHOT_CHARACTER_BASELINE = 1520
+_SNAPSHOT_CHARACTER_MARGIN = 60
+
+
+class WorldSnapshotBuilder:
+    """Freeze role-owned visuals and voice metadata into world-owned assets."""
+
+    def __init__(self, role_store: RoleStore, world_assets_dir: Path) -> None:
+        self._roles = role_store
+        self._world_assets_dir = world_assets_dir
+
+    def snapshot_for(self, role: Any) -> RoleTemplateSnapshot:
+        """Build one immutable role snapshot for a new world draft."""
+
+        snapshot_id = f"snapshot-{uuid4().hex}"
+        asset_ids: dict[str, str] = {}
+        assets = []
+        for source in [role.avatar, *role.illustrations]:
+            if not source or source in asset_ids:
+                continue
+            copied = self._copy_snapshot_asset(snapshot_id, source)
+            if copied is None:
+                continue
+            asset_id = f"asset-{uuid4().hex}"
+            asset_ids[source] = asset_id
+            assets.append({"id": asset_id, "path": copied})
+        runtime = role.runtime_config if isinstance(role.runtime_config, dict) else {}
+        raw_bindings = runtime.get("mood_illustration_bindings", {})
+        bindings = raw_bindings if isinstance(raw_bindings, dict) else {}
+        mood_bindings = {
+            str(mood).strip(): asset_ids[str(path).strip()]
+            for mood, path in bindings.items()
+            if str(mood).strip() and str(path).strip() in asset_ids
+        }
+        raw_catalog = runtime.get("mood_catalog", [])
+        catalog = raw_catalog if isinstance(raw_catalog, list) else []
+        mood_catalog = [
+            str(mood).strip() for mood in catalog if str(mood).strip() in mood_bindings
+        ]
+        default_mood = str(runtime.get("default_mood") or "").strip()
+        if default_mood not in mood_bindings:
+            default_mood = (
+                mood_catalog[0] if mood_catalog else next(iter(mood_bindings), "")
+            )
+        return RoleTemplateSnapshot(
+            id=snapshot_id,
+            source_role_id=role.id,
+            source_version=role.updated_at,
+            persona={"name": role.name, "description": role.description},
+            system_constraints=(role.system_prompt,),
+            visual_profile={
+                "default_mood": default_mood,
+                "mood_catalog": mood_catalog,
+                "mood_illustration_bindings": mood_bindings,
+                "avatar_asset_id": asset_ids.get(role.avatar),
+            },
+            voice_profile=self._voice_profile(runtime),
+            assets=tuple(assets),
+        )
+
+    def source_asset_path(self, relative_path: str | None) -> str | None:
+        """Resolve a role-owned source asset for draft-only identity metadata."""
+
+        return (
+            str((self._roles.roles_dir / relative_path).resolve())
+            if relative_path
+            else None
+        )
+
+    def _copy_snapshot_asset(self, snapshot_id: str, relative_path: str) -> str | None:
+        """Copy a role-owned asset before the source role can change or disappear."""
+
+        source = (self._roles.roles_dir / relative_path).resolve()
+        try:
+            source.relative_to(self._roles.assets_dir.resolve())
+        except ValueError:
+            return None
+        if not source.is_file():
+            return None
+        destination_dir = self._world_assets_dir / snapshot_id
+        destination = destination_dir / f"{uuid4().hex}.png"
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        try:
+            self._normalize_snapshot_character(source, destination)
+        except (UnidentifiedImageError, OSError):
+            destination = destination_dir / f"{uuid4().hex}{source.suffix}"
+            shutil.copy2(source, destination)
+        return str(destination.resolve())
+
+    @staticmethod
+    def _normalize_snapshot_character(source: Path, destination: Path) -> None:
+        """Place visible character pixels on one transparent canvas and foot baseline."""
+
+        with Image.open(source) as opened:
+            image = ImageOps.exif_transpose(opened).convert("RGBA")
+            bounds = image.getchannel("A").getbbox()
+            canvas = Image.new("RGBA", _SNAPSHOT_CHARACTER_CANVAS, (0, 0, 0, 0))
+            if bounds is None:
+                canvas.save(destination, format="PNG")
+                return
+            character = image.crop(bounds)
+            max_width = _SNAPSHOT_CHARACTER_CANVAS[0] - 2 * _SNAPSHOT_CHARACTER_MARGIN
+            max_height = _SNAPSHOT_CHARACTER_BASELINE - _SNAPSHOT_CHARACTER_MARGIN
+            scale = min(1.0, max_width / character.width, max_height / character.height)
+            if scale < 1.0:
+                character = character.resize(
+                    (
+                        max(1, round(character.width * scale)),
+                        max(1, round(character.height * scale)),
+                    ),
+                    Image.Resampling.LANCZOS,
+                )
+            x = (_SNAPSHOT_CHARACTER_CANVAS[0] - character.width) // 2
+            y = _SNAPSHOT_CHARACTER_BASELINE - character.height
+            canvas.alpha_composite(character, (x, y))
+            canvas.save(destination, format="PNG")
+
+    @staticmethod
+    def _voice_profile(runtime: dict[str, Any]) -> dict[str, Any]:
+        """Freeze only non-secret voice fields required by later presentation work."""
+
+        raw_tts = runtime.get("tts", {})
+        tts = raw_tts if isinstance(raw_tts, dict) else {}
+        voice_id = str(tts.get("voice_id") or "").strip()
+        if not voice_id:
+            return {}
+        speed = tts.get("speed", 1.0)
+        normalized_speed = float(speed) if isinstance(speed, (int, float)) else 1.0
+        if not 0.5 <= normalized_speed <= 2.0:
+            normalized_speed = 1.0
+        raw_emotions = tts.get("mood_tts_emotions", {})
+        emotions = raw_emotions if isinstance(raw_emotions, dict) else {}
+        return {
+            "config_version": 1,
+            "enabled": tts.get("enabled", True) is not False,
+            "provider": str(tts.get("provider") or "minimax").strip() or "minimax",
+            "voice_id": voice_id,
+            "speed": normalized_speed,
+            "mood_tts_emotions": {
+                str(mood).strip(): str(emotion).strip()
+                for mood, emotion in emotions.items()
+                if str(mood).strip() and str(emotion).strip()
+            },
+        }

--- a/tests/desktop_bridge/test_world_simulation_handler.py
+++ b/tests/desktop_bridge/test_world_simulation_handler.py
@@ -105,12 +105,11 @@ def test_action_catch_up_only_returns_committed_beats(tmp_path):
     assert repeated is not None
     assert [beat["content"] for beat in replay["beats"]][-1] == "推开灯塔的门。"
     assert replay["world"]["scene"]["beats"][-1]["content"] == "推开灯塔的门。"
-    assert [plan["planId"] for plan in replay["presentation"]["plans"]] == [
-        plan["planId"] for plan in repeated["presentation"]["plans"]
-    ]
-    performance_plan = replay["beats"][-1]["performancePlan"]
-    assert performance_plan["schemaVersion"] == 1
-    assert performance_plan["cues"][0]["kind"] == "dialogue"
+    assert replay["world"]["currentDayIndex"] == 1
+    assert replay["world"]["days"][0]["status"] == "current"
+    assert replay["world"]["days"][0]["events"][-1]["presentationMode"] == "narrative"
+    assert "performancePlan" not in replay["beats"][-1]
+    assert replay["presentation"]["plans"] == repeated["presentation"]["plans"] == []
     handler.close()
 
 
@@ -134,9 +133,36 @@ def test_presentation_session_checkpoints_pause_and_rebuilds_from_facts(tmp_path
     )
     assert confirmed is not None
     world = confirmed["world"]
-    initial = world["presentation"]
+    stored_world = handler._repository.require_world(world["id"])
+    run = handler._service.start_run(
+        world["id"],
+        kind="scene",
+        request_id="scene-presentation:run",
+        expected_revision=stored_world.revision,
+        random_seed="scene-presentation",
+    )
+    proposal = handler._proposal(
+        world=stored_world,
+        run_id=run.id,
+        random_seed=run.random_seed,
+        event_type="scene.encounter.committed",
+        effective_at=stored_world.current_time,
+        participants=(world["activeOcId"],),
+        presentation={
+            "mode": "scene",
+            "kind": "dialogue",
+            "content": "潮声里有人叫住了岚。",
+        },
+    )
+    handler._service.submit_action(proposal, request_id="scene-presentation")
+    refreshed = handler.handle(
+        "worlds.get", {"world_id": world["id"]}, request_id="refresh-scene"
+    )
+    assert refreshed is not None
+    initial = refreshed["world"]["presentation"]
     assert initial["session"]["status"] == "playing"
     assert len(initial["plans"]) == 1
+    assert refreshed["world"]["days"][0]["events"][-1]["presentationMode"] == "scene"
     plan_id = initial["plans"][0]["planId"]
 
     paused = handler.handle(
@@ -160,7 +186,7 @@ def test_presentation_session_checkpoints_pause_and_rebuilds_from_facts(tmp_path
         request_id="checkpoint-presentation",
     )
     assert checkpoint is not None
-    assert checkpoint["presentation"]["session"]["lastPresentedEventSequence"] == 1
+    assert checkpoint["presentation"]["session"]["lastPresentedEventSequence"] == 2
     assert checkpoint["presentation"]["plans"] == []
     duplicate = handler.handle(
         "worlds.presentation.checkpoint",
@@ -176,9 +202,59 @@ def test_presentation_session_checkpoints_pause_and_rebuilds_from_facts(tmp_path
         "worlds.get", {"world_id": world["id"]}, request_id="rebuild-session"
     )
     assert rebuilt is not None
-    assert rebuilt["world"]["presentation"]["session"]["lastPresentedEventSequence"] == 0
+    assert (
+        rebuilt["world"]["presentation"]["session"]["lastPresentedEventSequence"] == 1
+    )
     assert rebuilt["world"]["presentation"]["plans"]
     restarted.close()
+
+
+def test_completing_a_day_commits_action_and_advances_one_day_atomically(tmp_path):
+    role_store = RoleStore(tmp_path)
+    role = role_store.create_role(name="凛", system_prompt="保持冷静")
+    handler = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    draft = handler.handle(
+        "worlds.drafts.preview",
+        _creation_input(role.id),
+        request_id="preview-day-world",
+    )
+    assert draft is not None
+    confirmed = handler.handle(
+        "worlds.drafts.confirm",
+        {
+            "draft_id": draft["draft"]["id"],
+            "native_identities": draft["draft"]["nativeIdentities"],
+        },
+        request_id="confirm-day-world",
+    )
+    assert confirmed is not None
+    world_id = confirmed["world"]["id"]
+
+    first = handler.handle(
+        "worlds.days.complete",
+        {"world_id": world_id, "content": "去旧港寻找失踪者。"},
+        request_id="complete-day-1",
+    )
+    repeated = handler.handle(
+        "worlds.days.complete",
+        {"world_id": world_id, "content": "去旧港寻找失踪者。"},
+        request_id="complete-day-1",
+    )
+    result = handler.handle(
+        "worlds.get", {"world_id": world_id}, request_id="get-day-2"
+    )
+
+    assert first == repeated
+    assert result is not None
+    world = result["world"]
+    assert world["currentDayIndex"] == 2
+    assert [day["status"] for day in world["days"]] == ["completed", "current"]
+    assert [event["content"] for event in world["days"][0]["events"]][
+        -1
+    ] == "去旧港寻找失踪者。"
+    assert world["days"][1]["events"][0]["content"] == "新的一天开始了。"
+    assert len(handler._repository.list_events(world_id)) == 3
+    handler.close()
 
 
 def test_world_draft_freezes_role_visual_and_voice_snapshots(tmp_path):

--- a/tests/world_simulation/test_days.py
+++ b/tests/world_simulation/test_days.py
@@ -1,0 +1,28 @@
+from world_simulation.days import current_day_index, group_world_days, next_day_time
+from world_simulation.timeline import TimelineEvent
+
+
+def _event(event_id: str, sequence: int, day_index: int) -> TimelineEvent:
+    return TimelineEvent(
+        id=event_id,
+        world_id="world-1",
+        event_type="story.event",
+        effective_at=f"2026-07-{day_index:02d}T00:00:00+00:00",
+        sequence=sequence,
+        day_index=day_index,
+    )
+
+
+def test_groups_committed_events_into_ordered_day_chapters() -> None:
+    events = (_event("day-1", 1, 1), _event("day-2-a", 2, 2), _event("day-2-b", 3, 2))
+
+    days = group_world_days(events)
+
+    assert current_day_index(events) == 2
+    assert [day.status for day in days] == ["completed", "current"]
+    assert [event.id for event in days[1].events] == ["day-2-a", "day-2-b"]
+
+
+def test_advances_iso_world_time_by_one_day_without_parsing_display_labels() -> None:
+    assert next_day_time("2026-07-31T08:00:00+00:00") == "2026-08-01T08:00:00+00:00"
+    assert next_day_time("序章") == "序章"

--- a/world_simulation/days.py
+++ b/world_simulation/days.py
@@ -1,0 +1,50 @@
+"""Day-level narrative grouping and progression for persistent worlds."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from typing import Iterable
+
+from world_simulation.timeline import TimelineEvent
+
+
+@dataclass(frozen=True)
+class WorldDayGroup:
+    """One ordered Day chapter derived from committed timeline events."""
+
+    day_index: int
+    status: str
+    events: tuple[TimelineEvent, ...]
+
+
+def current_day_index(events: Iterable[TimelineEvent]) -> int:
+    """Return the latest structured Day without parsing display labels."""
+
+    return max((event.day_index for event in events), default=1)
+
+
+def group_world_days(events: Iterable[TimelineEvent]) -> tuple[WorldDayGroup, ...]:
+    """Group committed facts into ordered completed/current Day chapters."""
+
+    ordered = tuple(events)
+    current = current_day_index(ordered)
+    indexes = sorted({event.day_index for event in ordered} or {1})
+    return tuple(
+        WorldDayGroup(
+            day_index=index,
+            status="current" if index == current else "completed",
+            events=tuple(event for event in ordered if event.day_index == index),
+        )
+        for index in indexes
+    )
+
+
+def next_day_time(value: str) -> str:
+    """Advance an ISO world clock by one Day while preserving timezone semantics."""
+
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return value
+    return (parsed + timedelta(days=1)).astimezone(timezone.utc).isoformat()

--- a/world_simulation/performance.py
+++ b/world_simulation/performance.py
@@ -167,6 +167,27 @@ def _as_mapping_tuple(value: Any) -> tuple[dict[str, Any], ...]:
     return tuple(dict(item) for item in value if isinstance(item, Mapping))
 
 
+def presentation_mode_for_event(
+    event: TimelineEvent | Mapping[str, Any],
+) -> Literal["narrative", "scene"]:
+    """Classify a committed event without turning ordinary prose into a scene."""
+
+    value = event.to_dict() if isinstance(event, TimelineEvent) else dict(event)
+    changes = _as_mapping(value.get("changes"))
+    presentation = _as_mapping(changes.get("presentation"))
+    explicit = str(presentation.get("mode") or "").strip()
+    if explicit == "scene":
+        return "scene"
+    if explicit == "narrative":
+        return "narrative"
+    staged_fields = ("dialogue", "sprites", "background", "camera", "audio", "cg_tasks")
+    return (
+        "scene"
+        if any(presentation.get(field) for field in staged_fields)
+        else "narrative"
+    )
+
+
 def _cue(
     *,
     plan_id: str,

--- a/world_simulation/proposals.py
+++ b/world_simulation/proposals.py
@@ -15,6 +15,7 @@ class ProposedEvent:
 
     event_type: str
     effective_at: str
+    day_index: int = 1
     participants: tuple[str, ...] = ()
     location: str = ""
     scope: str = "world"
@@ -23,6 +24,12 @@ class ProposedEvent:
     changes: dict[str, Any] = field(default_factory=dict)
     dependencies: DependencySet = field(default_factory=DependencySet)
     is_backfill: bool = False
+
+    def __post_init__(self) -> None:
+        """Reject invalid Day placement before deterministic settlement."""
+
+        if self.day_index < 1:
+            raise InvalidWorldProposalError("event day_index must be positive")
 
 
 @dataclass(frozen=True)

--- a/world_simulation/service.py
+++ b/world_simulation/service.py
@@ -94,12 +94,17 @@ class WorldSimulationService:
             effective_at=draft.initial_time,
             sequence=1,
             participants=tuple(
-                [*(item.id for item in draft.residents), *([initial_oc.id] if initial_oc else [])]
+                [
+                    *(item.id for item in draft.residents),
+                    *([initial_oc.id] if initial_oc else []),
+                ]
             ),
             changes={
                 "residents": {item.id: item.to_dict() for item in draft.residents},
                 "player_ocs": (
-                    {initial_oc.id: initial_oc.to_dict()} if initial_oc is not None else {}
+                    {initial_oc.id: initial_oc.to_dict()}
+                    if initial_oc is not None
+                    else {}
                 ),
             },
             random_ref=random_seed,
@@ -118,7 +123,9 @@ class WorldSimulationService:
             state={
                 "residents": {item.id: item.to_dict() for item in draft.residents},
                 "player_ocs": (
-                    {initial_oc.id: initial_oc.to_dict()} if initial_oc is not None else {}
+                    {initial_oc.id: initial_oc.to_dict()}
+                    if initial_oc is not None
+                    else {}
                 ),
             },
             cognition={initial_oc.id: dict(initial_oc.cognition)} if initial_oc else {},
@@ -160,12 +167,22 @@ class WorldSimulationService:
         if backfill:
             self._validate_backfill(world_id, entry_time, dependency_set)
         revision = expected_revision + 1
+        existing_events = self.repository.list_events(world_id)
+        day_index = max(
+            (
+                item.day_index
+                for item in existing_events
+                if not backfill or item.effective_at <= entry_time
+            ),
+            default=1,
+        )
         event = TimelineEvent(
             id=f"event-{uuid4().hex}",
             world_id=world_id,
             event_type="player_oc.backfilled" if backfill else "player_oc.joined",
             effective_at=entry_time,
             sequence=self.repository.next_event_sequence(world_id),
+            day_index=day_index,
             participants=(oc.id,),
             changes={"player_ocs": {oc.id: oc.to_dict()}},
             is_backfill=backfill,

--- a/world_simulation/settlement.py
+++ b/world_simulation/settlement.py
@@ -54,9 +54,13 @@ class WorldSettlement:
             )
         if run is not None:
             if run.id != proposal.run_id or run.world_id != world.id:
-                raise InvalidWorldProposalError("proposal does not belong to the supplied run")
+                raise InvalidWorldProposalError(
+                    "proposal does not belong to the supplied run"
+                )
             if run.random_seed != proposal.random_seed:
-                raise InvalidWorldProposalError("proposal random seed differs from its run")
+                raise InvalidWorldProposalError(
+                    "proposal random seed differs from its run"
+                )
 
         pending = self._repository.list_pending_barriers(world.id)
         unresolved = [
@@ -80,6 +84,7 @@ class WorldSettlement:
                 event_type=item.event_type,
                 effective_at=item.effective_at,
                 sequence=next_sequence + index,
+                day_index=item.day_index,
                 participants=item.participants,
                 location=item.location,
                 scope=item.scope,
@@ -133,7 +138,9 @@ class WorldSettlement:
             request_id=request_id,
             events=events,
             projection=projection,
-            current_time=max(world.current_time, *(item.effective_at for item in events)),
+            current_time=max(
+                world.current_time, *(item.effective_at for item in events)
+            ),
             result=result,
             run=committed_run,
             barrier=barrier,
@@ -142,15 +149,15 @@ class WorldSettlement:
         )
 
     @staticmethod
-    def _barrier_from(
-        proposal: BeatProposal, world_id: str
-    ) -> DecisionBarrier | None:
+    def _barrier_from(proposal: BeatProposal, world_id: str) -> DecisionBarrier | None:
         if proposal.barrier is None:
             return None
         value = proposal.barrier
         required = ("effective_at", "oc_id", "reason")
         if any(not str(value.get(name, "")).strip() for name in required):
-            raise InvalidWorldProposalError("decision barrier is missing required fields")
+            raise InvalidWorldProposalError(
+                "decision barrier is missing required fields"
+            )
         return DecisionBarrier(
             id=str(value.get("id") or f"barrier-{uuid4().hex}"),
             world_id=world_id,

--- a/world_simulation/timeline.py
+++ b/world_simulation/timeline.py
@@ -18,6 +18,7 @@ class TimelineEvent:
     event_type: str
     effective_at: str
     sequence: int
+    day_index: int = 1
     participants: tuple[str, ...] = ()
     location: str = ""
     scope: str = "world"
@@ -30,6 +31,12 @@ class TimelineEvent:
     committed_revision: int = 0
     dependencies: DependencySet = field(default_factory=DependencySet)
     recorded_at: str = field(default_factory=utc_now)
+
+    def __post_init__(self) -> None:
+        """Reject invalid narrative-day placement before persistence."""
+
+        if self.day_index < 1:
+            raise ValueError("timeline event day_index must be positive")
 
     def to_dict(self) -> dict[str, Any]:
         """Serialize the event including dependency metadata."""


### PR DESCRIPTION
Related to #39

## 变更摘要

- 将 World 普通态改为以剧情为主的 Day 纪事，不展示属性，也不再进入旧三栏工作台。
- 只有带具体演出的场景事件才自动进入 Galgame；普通叙事留在 Day，完成场景后返回 Day，历史场景可回看。
- 使用一次自由文本 OC 行动原子结束当前 Day 并进入下一 Day；历史 Day 只读，待演出场景会阻止 Day 结束。
- 为时间线事件增加结构化 `day_index`，叙事事件不再生成 `PerformancePlan`，演出 cursor 会跳过纯叙事事件。
- 拆分 Day progression、presentation queue、role snapshot 与 renderer scene navigation，避免继续堆积在主 handler/页面入口。
- 按稳定 `planId` 缓存已 hydrate 的演出计划，避免 bridge 刷新、对白刷新和暂停恢复时重建对象并重启 `WorldStage`。

## 自动化验证

- Renderer World 聚焦测试：24 passed。
- Python World/desktop bridge 聚焦回归：27 passed；request dispatcher：6 passed。
- 完整 desktop suite：461 tests，460 passed，1 skipped，0 failed。
- `npm run desktop:typecheck`：通过。
- `npm run desktop:build`：通过。
- 变更前端 ESLint：通过。
- Black `--target-version py312`：通过。
- `git diff --check`：通过。
- `graphify update .`：8306 nodes / 21629 edges；超过 5000 节点，按工具限制跳过 HTML。

## 真实 Electron 验收

在实际 built Electron 与本地 `worlds.db` 上完成以下检查：

- 长纪事打开时定位到 Day 13，历史 Day 只读，已完成场景显示“回看”。
- 新具体场景自动进入 Galgame；对白完成后 checkpoint 持久化并自动返回 Day。
- Day 行动输入有效，结束后 launcher 摘要同步更新。
- 暂停显示“演出已暂停”；恢复后保留完整对白，不出现空对白框。
- 暂停/恢复后继续完成场景，最终状态为 `pending_plans: 0`、`active_plan_id: None`、`status: awaiting_action`。

## 已知阻塞

- #46 仍需完成 Playwright 截图与 canvas 像素检查、多分辨率/DPI、进入与转场耗时、60fps、故障降级，以及多次进出后的 ticker/audio/timer/subscription/texture 资源释放证据。
- 本 PR 不关闭 #39；#46 验收完成后再判断父 Issue 是否可关闭。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores the plot-first Day chronicle and limits Galgame focus to scene events with auto-return to Day. Also fixes the launcher/loading background to resolve from the renderer entry via `WORLD_MENU_BACKGROUND_URL` so it loads correctly in Electron.

- New Features
  - Added `WorldDaySurface` to show a Day chronicle without attributes or workspace columns.
  - New modes: `day` and `scene`; auto-enter focus only for scene events, then return to Day.
  - Historical Days are read-only; completed scenes are replayable from Day.
  - Single end-of-day OC action via bridge `worlds.days.complete`; pending scenes block Day completion.
  - Timeline events now include `day_index`; only scene events produce `PerformancePlan`, and the scene cursor skips narrative events.
  - Cached hydrated plans by stable `planId` to avoid rebuilds across refresh/pause/resume.

- Migration
  - Update renderer modes from `"game"/"workspace"` to `"day"/"scene"` and timeline return mode to `"day"`.
  - Use `completeDay(worldId, content)` to advance a Day; keep `submitAction` for in-scene actions.
  - Consume new Day/scene selectors (`selectCurrentWorldDay`, `selectPendingWorldScene`, `selectWorldScene`) and `WorldDay` in types.
  - Expect `day_index` in timeline entries and beats; narrative beats won’t carry `PerformancePlan`.

<sup>Written for commit 2f498c327ab0f935bf183149c6edd86c2fd2ed68. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/54?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

