### PR TITLE
refactor(world): isolate each world database

### DIFF
--- a/desktop_bridge/world_simulation_handler.py
+++ b/desktop_bridge/world_simulation_handler.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
@@ -13,8 +13,11 @@ from desktop_bridge.world_day_handler import WorldDayHandler
 from desktop_bridge.world_presentation_handler import WorldPresentationHandler
 from desktop_bridge.world_snapshot_builder import WorldSnapshotBuilder
 from world_simulation.actors import AutonomyPolicy, PlayerOC
+from world_simulation.catalog import WorldCatalog
+from world_simulation.database_manager import WorldDatabaseManager
 from world_simulation.dependencies import DependencySet
 from world_simulation.days import group_world_days
+from world_simulation.drafts import create_world_draft
 from world_simulation.errors import HistoricalConflictError
 from world_simulation.performance import (
     compile_performance_plan,
@@ -32,22 +35,31 @@ from world_simulation.world import (
 )
 
 
+@dataclass(frozen=True)
+class _WorldContext:
+    repository: WorldRepository
+    service: WorldSimulationService
+    days: WorldDayHandler
+    presentation: WorldPresentationHandler
+
+
 class WorldSimulationHandler:
     """Translate semantic desktop commands into world-owned facts and read models."""
 
     def __init__(self, *, workspace: Path, role_store: RoleStore) -> None:
         self._roles = role_store
-        self._repository = WorldRepository(workspace / "worlds.db")
-        self._service = WorldSimulationService(self._repository)
-        self._days = WorldDayHandler(self._repository, self._service)
-        self._presentation = WorldPresentationHandler(self._repository)
+        self._catalog = WorldCatalog(workspace / "worlds" / "catalog.db")
+        self._databases = WorldDatabaseManager(workspace, self._catalog)
+        self._contexts: dict[str, _WorldContext] = {}
         self._snapshots = WorldSnapshotBuilder(role_store, workspace / "world_assets")
         self._shots: dict[tuple[str, str], dict[str, Any]] = {}
 
     def close(self) -> None:
         """Release the dedicated world transaction store."""
 
-        self._repository.close()
+        self._contexts.clear()
+        self._databases.close()
+        self._catalog.close()
 
     def handle(
         self, method: str, payload: dict[str, Any], *, request_id: str
@@ -57,11 +69,7 @@ class WorldSimulationHandler:
         if not method.startswith("worlds."):
             return None
         if method == "worlds.list":
-            return {
-                "worlds": [
-                    self._summary(world) for world in self._repository.list_worlds()
-                ]
-            }
+            return {"worlds": self._catalog.list_summaries()}
         if method == "worlds.get":
             return {"world": self._world_details(self._world_id(payload))}
         if method == "worlds.drafts.preview":
@@ -75,13 +83,21 @@ class WorldSimulationHandler:
         if method == "worlds.actions.submit":
             return self._submit_action(payload, request_id=request_id)
         if method == "worlds.days.complete":
-            return self._days.complete(
-                self._world_id(payload),
+            world_id = self._world_id(payload)
+            result = self._context(world_id).days.complete(
+                world_id,
                 self._required(payload, "content"),
                 request_id=request_id,
             )
+            self._refresh_summary(world_id)
+            return result
         if method == "worlds.advance":
-            return self._days.advance(self._world_id(payload), request_id=request_id)
+            world_id = self._world_id(payload)
+            result = self._context(world_id).days.advance(
+                world_id, request_id=request_id
+            )
+            self._refresh_summary(world_id)
+            return result
         if method == "worlds.barriers.resolve":
             return {"world": self._resolve_barrier(payload, request_id=request_id)}
         if method == "worlds.timeline":
@@ -97,18 +113,25 @@ class WorldSimulationHandler:
         if method == "worlds.events.catch_up":
             return self._catch_up(payload)
         if method == "worlds.presentation.pause":
-            return {"presentation": self._presentation.pause(self._world_id(payload))}
+            world_id = self._world_id(payload)
+            return {
+                "presentation": self._context(world_id).presentation.pause(world_id)
+            }
         if method == "worlds.presentation.resume":
-            return {"presentation": self._presentation.resume(self._world_id(payload))}
+            world_id = self._world_id(payload)
+            return {
+                "presentation": self._context(world_id).presentation.resume(world_id)
+            }
         if method == "worlds.presentation.checkpoint":
             raw_index = payload.get("cue_index")
             try:
                 cue_index = int(str(raw_index).strip()) if raw_index is not None else -1
             except ValueError as exc:
                 raise ValueError("cue_index 必须是非负整数") from exc
+            world_id = self._world_id(payload)
             return {
-                "presentation": self._presentation.checkpoint(
-                    self._world_id(payload),
+                "presentation": self._context(world_id).presentation.checkpoint(
+                    world_id,
                     self._required(payload, "plan_id"),
                     cue_index,
                 )
@@ -149,7 +172,7 @@ class WorldSimulationHandler:
             },
             narrative_style=input_data["tone"],
         )
-        draft = self._service.create_draft(
+        draft = create_world_draft(
             owner_id="desktop-player",
             template=template,
             role_snapshots=snapshots,
@@ -157,6 +180,7 @@ class WorldSimulationHandler:
             initial_time=input_data["firstOc"]["entryTime"],
             creation_metadata={"input": input_data},
         )
+        self._catalog.save_draft(draft)
         return {
             "id": draft.id,
             "input": input_data,
@@ -169,43 +193,65 @@ class WorldSimulationHandler:
     def _confirm_draft(
         self, payload: dict[str, Any], *, request_id: str
     ) -> dict[str, Any]:
+        existing_world_id = self._catalog.world_id_for_request(request_id)
+        if existing_world_id is not None:
+            return self._world_details(existing_world_id)
         draft_id = self._required(payload, "draft_id")
-        draft = self._repository.get_draft(draft_id)
+        draft = self._catalog.get_draft(draft_id)
         if draft is None:
             raise ValueError("找不到待确认的世界草案")
         identities = payload.get("native_identities")
         if not isinstance(identities, list):
             raise ValueError("原住民草案格式无效")
         edited_draft = self._apply_native_identity_edits(draft, identities)
-        self._repository.replace_draft(edited_draft)
+        self._catalog.replace_draft(edited_draft)
         input_data = self._draft_input(edited_draft)
-        world = self._service.confirm_world(
-            edited_draft.id,
-            request_id=request_id,
-            random_seed=input_data["seed"],
-            initial_oc=self._oc_from_input(input_data["firstOc"]),
-        )
+        world_id = f"world-{uuid4().hex}"
+        context = self._create_context(world_id)
+        try:
+            context.repository.save_draft(edited_draft)
+            world = context.service.confirm_world(
+                edited_draft.id,
+                request_id=request_id,
+                world_id=world_id,
+                random_seed=input_data["seed"],
+                initial_oc=self._oc_from_input(input_data["firstOc"]),
+            )
+            self._catalog.complete_world(
+                draft_id=edited_draft.id,
+                world_id=world.id,
+                relative_db_path=self._databases.relative_path(world.id),
+                summary=self._summary(context, world),
+                request_id=request_id,
+            )
+        except BaseException:
+            self._discard_context(world_id)
+            raise
         return self._world_details(world.id)
 
     def _add_oc(self, payload: dict[str, Any], *, request_id: str) -> dict[str, Any]:
         world_id = self._world_id(payload)
-        world = self._repository.require_world(world_id)
+        context = self._context(world_id)
+        world = context.repository.require_world(world_id)
         oc = self._oc_from_input(self._oc_input(payload.get("oc")))
-        self._service.add_oc(
+        context.service.add_oc(
             world_id,
             oc,
             entry_time=oc.identity["entry_time"],
             expected_revision=world.revision,
             request_id=request_id,
         )
+        self._refresh_summary(world_id)
         return self._world_details(world_id)
 
     def _switch_oc(self, payload: dict[str, Any]) -> dict[str, Any]:
         world_id = self._world_id(payload)
-        world = self._repository.require_world(world_id)
-        self._service.switch_oc(
+        context = self._context(world_id)
+        world = context.repository.require_world(world_id)
+        context.service.switch_oc(
             world_id, self._required(payload, "oc_id"), expected_revision=world.revision
         )
+        self._refresh_summary(world_id)
         return self._world_details(world_id)
 
     def _submit_action(
@@ -213,9 +259,10 @@ class WorldSimulationHandler:
     ) -> dict[str, Any]:
         world_id = self._world_id(payload)
         content = self._required(payload, "content")
-        world = self._repository.require_world(world_id)
-        active_oc = self._active_oc(world_id, world.active_oc_id)
-        run = self._service.start_run(
+        context = self._context(world_id)
+        world = context.repository.require_world(world_id)
+        active_oc = self._active_oc(context, world_id, world.active_oc_id)
+        run = context.service.start_run(
             world_id,
             kind="action",
             request_id=f"{request_id}:run",
@@ -223,12 +270,13 @@ class WorldSimulationHandler:
             random_seed=f"{world.random_state}:{request_id}",
         )
         proposal = self._proposal(
+            context=context,
             world=world,
             run_id=run.id,
             random_seed=run.random_seed,
             event_type="scene.action.committed",
             effective_at=world.current_time,
-            day_index=self._days.current_index(world_id),
+            day_index=context.days.current_index(world_id),
             participants=(active_oc.id,),
             location=active_oc.location,
             presentation={
@@ -239,15 +287,17 @@ class WorldSimulationHandler:
             },
             projection_patch={"last_action": {"oc": active_oc.id, "content": content}},
         )
-        self._service.submit_action(proposal, request_id=request_id)
+        context.service.submit_action(proposal, request_id=request_id)
+        self._refresh_summary(world_id)
         return {"run_id": run.id}
 
     def _resolve_barrier(
         self, payload: dict[str, Any], *, request_id: str
     ) -> dict[str, Any]:
         world_id = self._world_id(payload)
-        world = self._repository.require_world(world_id)
-        barrier = self._repository.get_barrier(
+        context = self._context(world_id)
+        world = context.repository.require_world(world_id)
+        barrier = context.repository.get_barrier(
             world_id, self._required(payload, "barrier_id")
         )
         if barrier is None:
@@ -258,7 +308,7 @@ class WorldSimulationHandler:
         )
         if option is None:
             raise ValueError("不是这个待决事件的选择")
-        run = self._service.start_run(
+        run = context.service.start_run(
             world_id,
             kind="barrier_resolution",
             request_id=f"{request_id}:run",
@@ -266,6 +316,7 @@ class WorldSimulationHandler:
             random_seed=f"{world.random_state}:{request_id}",
         )
         proposal = self._proposal(
+            context=context,
             world=world,
             run_id=run.id,
             random_seed=run.random_seed,
@@ -277,21 +328,23 @@ class WorldSimulationHandler:
                 "content": str(option.get("label") or "作出了决定"),
             },
         )
-        self._service.resolve_barrier(
+        context.service.resolve_barrier(
             world_id,
             barrier.id,
             proposal,
             request_id=request_id,
             resolution={"choice_id": choice_id, "label": option.get("label", "")},
         )
+        self._refresh_summary(world_id)
         return self._world_details(world_id)
 
     def _timeline(self, payload: dict[str, Any]) -> list[dict[str, Any]]:
         world_id = self._world_id(payload)
         perspective = str(payload.get("perspective") or "omniscient")
         oc_id = str(payload.get("oc_id") or "")
+        context = self._context(world_id)
         entries = []
-        for event in self._repository.list_events(world_id):
+        for event in context.repository.list_events(world_id):
             known_to = (
                 set(event.visibility.get("known_to", ()))
                 if isinstance(event.visibility, dict)
@@ -301,7 +354,9 @@ class WorldSimulationHandler:
                 continue
             entries.append(
                 self._timeline_entry(
-                    event, visibility="known" if known_to else "omniscient"
+                    context,
+                    event,
+                    visibility="known" if known_to else "omniscient",
                 )
             )
         return entries
@@ -309,21 +364,42 @@ class WorldSimulationHandler:
     def _copy_world(
         self, payload: dict[str, Any], *, request_id: str
     ) -> dict[str, Any]:
-        world = self._service.copy_world(
-            self._world_id(payload),
-            self._required(payload, "anchor_id"),
-            request_id=request_id,
-        )
+        existing_world_id = self._catalog.world_id_for_request(request_id)
+        if existing_world_id is not None:
+            return self._world_details(existing_world_id)
+        source_world_id = self._world_id(payload)
+        source_context = self._context(source_world_id)
+        target_world_id = f"world-{uuid4().hex}"
+        target_context = self._create_context(target_world_id)
+        try:
+            world = source_context.service.copy_world(
+                source_world_id,
+                self._required(payload, "anchor_id"),
+                request_id=request_id,
+                new_world_id=target_world_id,
+                target_repository=target_context.repository,
+            )
+            self._catalog.complete_world(
+                draft_id=None,
+                world_id=world.id,
+                relative_db_path=self._databases.relative_path(world.id),
+                summary=self._summary(target_context, world),
+                request_id=request_id,
+            )
+        except BaseException:
+            self._discard_context(target_world_id)
+            raise
         return self._world_details(world.id)
 
     def _preview_backfill(self, payload: dict[str, Any]) -> dict[str, Any]:
         world_id = self._world_id(payload)
         anchor_id = self._required(payload, "anchor_id")
-        anchor = self._repository.get_event(world_id, anchor_id)
+        context = self._context(world_id)
+        anchor = context.repository.get_event(world_id, anchor_id)
         if anchor is None:
             raise ValueError("找不到入场锚点")
         oc = self._oc_input(payload.get("oc"))
-        conflicts = self._backfill_conflicts(world_id, oc["entryTime"])
+        conflicts = self._backfill_conflicts(context, world_id, oc["entryTime"])
         return {
             "anchorId": anchor.id,
             "oc": oc,
@@ -351,38 +427,42 @@ class WorldSimulationHandler:
         if not isinstance(preview, dict):
             raise ValueError("历史补写预览格式无效")
         anchor_id = self._required(preview, "anchorId")
-        if self._repository.get_event(world_id, anchor_id) is None:
+        context = self._context(world_id)
+        if context.repository.get_event(world_id, anchor_id) is None:
             raise ValueError("历史入场锚点已经不存在")
         oc = self._oc_from_input(self._oc_input(preview.get("oc")))
-        world = self._repository.require_world(world_id)
-        self._service.add_oc(
+        world = context.repository.require_world(world_id)
+        context.service.add_oc(
             world_id,
             oc,
             entry_time=oc.identity["entry_time"],
             expected_revision=world.revision,
             request_id=request_id,
         )
+        self._refresh_summary(world_id)
         return self._world_details(world_id)
 
     def _cancel_run(self, payload: dict[str, Any]) -> dict[str, Any]:
         world_id = self._world_id(payload)
+        context = self._context(world_id)
         # A run that already committed is intentionally not rolled back.
         run = next(
             (
                 item
-                for item in self._repository.list_runs(world_id)
+                for item in context.repository.list_runs(world_id)
                 if item.status not in {"completed", "failed", "cancelled"}
             ),
             None,
         )
         if run is not None:
-            self._service.cancel_run(run.id)
+            context.service.cancel_run(run.id)
         return self._world_details(world_id)
 
     def _catch_up(self, payload: dict[str, Any]) -> dict[str, Any]:
         world_id = self._world_id(payload)
+        context = self._context(world_id)
         cursor = int(str(payload.get("cursor") or "0").strip() or 0)
-        messages = self._repository.list_outbox(world_id, after_sequence=cursor)
+        messages = context.repository.list_outbox(world_id, after_sequence=cursor)
         beats = [
             self._beat(message["payload"].get("event", {}), int(message["sequence"]))
             for message in messages
@@ -407,18 +487,19 @@ class WorldSimulationHandler:
         return shot
 
     def _world_details(self, world_id: str) -> dict[str, Any]:
-        world = self._repository.require_world(world_id)
-        ocs = self._repository.list_ocs(world_id)
-        residents = self._repository.list_residents(world_id)
-        barriers = self._repository.list_pending_barriers(world_id)
-        events = self._repository.list_events(world_id)
+        context = self._context(world_id)
+        world = context.repository.require_world(world_id)
+        ocs = context.repository.list_ocs(world_id)
+        residents = context.repository.list_residents(world_id)
+        barriers = context.repository.list_pending_barriers(world_id)
+        events = context.repository.list_events(world_id)
         active_oc = next(
             (oc for oc in ocs if oc.id == world.active_oc_id), ocs[0] if ocs else None
         )
         beats = [
             self._beat(event.to_dict(), index + 1) for index, event in enumerate(events)
         ]
-        current_day_index = self._days.current_index(world_id)
+        current_day_index = context.days.current_index(world_id)
         days = [
             {
                 "dayIndex": group.day_index,
@@ -433,7 +514,7 @@ class WorldSimulationHandler:
             for group in group_world_days(events)
         ]
         return {
-            **self._summary(world),
+            **self._summary(context, world),
             "currentDayIndex": current_day_index,
             "days": days,
             "ocs": [
@@ -460,7 +541,9 @@ class WorldSimulationHandler:
                     f"{active_oc.name}准备怎么做？" if active_oc else "先创建一位 OC。"
                 ),
                 "opportunities": [],
-                "barriers": [self._barrier_view(item, ocs) for item in barriers],
+                "barriers": [
+                    self._barrier_view(context, item, ocs) for item in barriers
+                ],
             },
             "relatedCharacters": [
                 {
@@ -476,21 +559,21 @@ class WorldSimulationHandler:
                 "label": "观看现场演出",
                 "canCancel": False,
             },
-            "presentation": self._presentation.state(world_id),
+            "presentation": context.presentation.state(world_id),
         }
 
-    def _summary(self, world: Any) -> dict[str, Any]:
+    def _summary(self, context: _WorldContext, world: Any) -> dict[str, Any]:
         environment = world.template_snapshot.get("initial_environment", {})
         return {
             "id": world.id,
             "name": world.template_snapshot.get("name", "未命名世界"),
             "premise": environment.get("premise", ""),
             "currentTimeLabel": world.current_time,
-            "currentDayIndex": self._days.current_index(world.id),
+            "currentDayIndex": context.days.current_index(world.id),
             "activeOcId": world.active_oc_id,
             "status": (
                 "barrier"
-                if self._repository.list_pending_barriers(world.id)
+                if context.repository.list_pending_barriers(world.id)
                 else "action_required"
             ),
         }
@@ -498,6 +581,7 @@ class WorldSimulationHandler:
     def _proposal(
         self,
         *,
+        context: _WorldContext,
         world: Any,
         run_id: str,
         random_seed: str,
@@ -512,13 +596,14 @@ class WorldSimulationHandler:
         event = ProposedEvent(
             event_type=event_type,
             effective_at=effective_at,
-            day_index=day_index or self._days.current_index(world.id),
+            day_index=day_index or context.days.current_index(world.id),
             participants=participants,
             location=location,
             changes={"presentation": presentation},
             dependencies=DependencySet(write_facts=frozenset({event_type})),
         )
         return self._proposal_from_events(
+            context=context,
             world=world,
             run_id=run_id,
             random_seed=random_seed,
@@ -529,6 +614,7 @@ class WorldSimulationHandler:
     def _proposal_from_events(
         self,
         *,
+        context: _WorldContext,
         world: Any,
         run_id: str,
         random_seed: str,
@@ -544,7 +630,7 @@ class WorldSimulationHandler:
             world_id=world.id,
             world_revision=world.revision,
             run_id=run_id,
-            beat_sequence=self._repository.next_event_sequence(world.id),
+            beat_sequence=context.repository.next_event_sequence(world.id),
             provider="deterministic-world-adapter",
             model="deterministic",
             prompt_version="desktop-v1",
@@ -581,7 +667,7 @@ class WorldSimulationHandler:
         return beat
 
     def _timeline_entry(
-        self, event: TimelineEvent, *, visibility: str
+        self, context: _WorldContext, event: TimelineEvent, *, visibility: str
     ) -> dict[str, Any]:
         return {
             "id": event.id,
@@ -591,7 +677,7 @@ class WorldSimulationHandler:
             "summary": self._beat(event.to_dict(), event.sequence)["content"],
             "visibility": visibility,
             "involvedNames": self._participant_names(
-                event.world_id, event.participants
+                context, event.world_id, event.participants
             ),
             "canCopy": True,
             "canEnter": True,
@@ -658,9 +744,11 @@ class WorldSimulationHandler:
             )
         return replace(draft, residents=tuple(residents))
 
-    def _backfill_conflicts(self, world_id: str, entry_time: str) -> list[str]:
+    def _backfill_conflicts(
+        self, context: _WorldContext, world_id: str, entry_time: str
+    ) -> list[str]:
         try:
-            self._service._validate_backfill(
+            context.service._validate_backfill(
                 world_id,
                 entry_time,
                 DependencySet(write_facts=frozenset({"oc:private_history"})),
@@ -696,14 +784,17 @@ class WorldSimulationHandler:
         }
 
     def _barrier_view(
-        self, barrier: DecisionBarrier, ocs: list[PlayerOC]
+        self,
+        context: _WorldContext,
+        barrier: DecisionBarrier,
+        ocs: list[PlayerOC],
     ) -> dict[str, Any]:
         return {
             "id": barrier.id,
             "title": barrier.reason,
             "context": barrier.reason,
             "affectedOcNames": self._participant_names(
-                barrier.world_id, (barrier.oc_id,)
+                context, barrier.world_id, (barrier.oc_id,)
             ),
             "choices": [
                 {
@@ -716,25 +807,65 @@ class WorldSimulationHandler:
         }
 
     def _participant_names(
-        self, world_id: str, participants: tuple[str, ...]
+        self,
+        context: _WorldContext,
+        world_id: str,
+        participants: tuple[str, ...],
     ) -> list[str]:
-        names = {oc.id: oc.name for oc in self._repository.list_ocs(world_id)}
+        names = {oc.id: oc.name for oc in context.repository.list_ocs(world_id)}
         names.update(
             {
                 resident.id: resident.name
-                for resident in self._repository.list_residents(world_id)
+                for resident in context.repository.list_residents(world_id)
             }
         )
         return [names[item] for item in participants if item in names]
 
-    def _active_oc(self, world_id: str, oc_id: str | None) -> PlayerOC:
+    def _active_oc(
+        self, context: _WorldContext, world_id: str, oc_id: str | None
+    ) -> PlayerOC:
         oc = next(
-            (item for item in self._repository.list_ocs(world_id) if item.id == oc_id),
+            (
+                item
+                for item in context.repository.list_ocs(world_id)
+                if item.id == oc_id
+            ),
             None,
         )
         if oc is None:
             raise ValueError("请先选择一位当前 OC")
         return oc
+
+    def _context(self, world_id: str) -> _WorldContext:
+        context = self._contexts.get(world_id)
+        if context is not None:
+            return context
+        return self._bind_context(world_id, self._databases.open(world_id))
+
+    def _create_context(self, world_id: str) -> _WorldContext:
+        return self._bind_context(world_id, self._databases.create(world_id))
+
+    def _bind_context(
+        self, world_id: str, repository: WorldRepository
+    ) -> _WorldContext:
+        service = WorldSimulationService(repository)
+        context = _WorldContext(
+            repository=repository,
+            service=service,
+            days=WorldDayHandler(repository, service),
+            presentation=WorldPresentationHandler(repository),
+        )
+        self._contexts[world_id] = context
+        return context
+
+    def _discard_context(self, world_id: str) -> None:
+        self._contexts.pop(world_id, None)
+        self._databases.discard_unregistered(world_id)
+
+    def _refresh_summary(self, world_id: str) -> None:
+        context = self._context(world_id)
+        world = context.repository.require_world(world_id)
+        self._catalog.update_summary(world_id, self._summary(context, world))
 
     def _require_role(self, role_id: str) -> Any:
         role = self._roles.get_role(role_id)

--- a/desktop_bridge/world_simulation_handler.py
+++ b/desktop_bridge/world_simulation_handler.py
@@ -53,6 +53,7 @@ class WorldSimulationHandler:
         self._contexts: dict[str, _WorldContext] = {}
         self._snapshots = WorldSnapshotBuilder(role_store, workspace / "world_assets")
         self._shots: dict[tuple[str, str], dict[str, Any]] = {}
+        self._recover_creation_intents()
 
     def close(self) -> None:
         """Release the dedicated world transaction store."""
@@ -196,6 +197,9 @@ class WorldSimulationHandler:
         existing_world_id = self._catalog.world_id_for_request(request_id)
         if existing_world_id is not None:
             return self._world_details(existing_world_id)
+        pending_intent = self._catalog.creation_intent_for_request(request_id)
+        if pending_intent is not None and self._recover_creation_intent(pending_intent):
+            return self._world_details(str(pending_intent["world_id"]))
         draft_id = self._required(payload, "draft_id")
         draft = self._catalog.get_draft(draft_id)
         if draft is None:
@@ -207,6 +211,12 @@ class WorldSimulationHandler:
         self._catalog.replace_draft(edited_draft)
         input_data = self._draft_input(edited_draft)
         world_id = f"world-{uuid4().hex}"
+        self._catalog.register_creation_intent(
+            request_id=request_id,
+            world_id=world_id,
+            draft_id=edited_draft.id,
+            relative_db_path=self._databases.relative_path(world_id),
+        )
         context = self._create_context(world_id)
         try:
             context.repository.save_draft(edited_draft)
@@ -225,7 +235,8 @@ class WorldSimulationHandler:
                 request_id=request_id,
             )
         except BaseException:
-            self._discard_context(world_id)
+            if context.repository.get_world(world_id) is None:
+                self._discard_context(world_id)
             raise
         return self._world_details(world.id)
 
@@ -367,9 +378,18 @@ class WorldSimulationHandler:
         existing_world_id = self._catalog.world_id_for_request(request_id)
         if existing_world_id is not None:
             return self._world_details(existing_world_id)
+        pending_intent = self._catalog.creation_intent_for_request(request_id)
+        if pending_intent is not None and self._recover_creation_intent(pending_intent):
+            return self._world_details(str(pending_intent["world_id"]))
         source_world_id = self._world_id(payload)
         source_context = self._context(source_world_id)
         target_world_id = f"world-{uuid4().hex}"
+        self._catalog.register_creation_intent(
+            request_id=request_id,
+            world_id=target_world_id,
+            draft_id=None,
+            relative_db_path=self._databases.relative_path(target_world_id),
+        )
         target_context = self._create_context(target_world_id)
         try:
             world = source_context.service.copy_world(
@@ -387,7 +407,8 @@ class WorldSimulationHandler:
                 request_id=request_id,
             )
         except BaseException:
-            self._discard_context(target_world_id)
+            if target_context.repository.get_world(target_world_id) is None:
+                self._discard_context(target_world_id)
             raise
         return self._world_details(world.id)
 
@@ -841,6 +862,34 @@ class WorldSimulationHandler:
         if context is not None:
             return context
         return self._bind_context(world_id, self._databases.open(world_id))
+
+    def _recover_creation_intents(self) -> None:
+        """Reconcile committed world databases left behind by a crashed catalog write."""
+
+        for intent in self._catalog.pending_creation_intents():
+            self._recover_creation_intent(intent)
+
+    def _recover_creation_intent(self, intent: dict[str, Any]) -> bool:
+        world_id = str(intent["world_id"])
+        repository = self._databases.open_for_recovery(
+            world_id, str(intent["relative_db_path"])
+        )
+        if repository is None:
+            self._catalog.discard_creation_intent(str(intent["request_id"]))
+            self._databases.discard_unregistered(world_id)
+            return False
+        self._bind_context(world_id, repository)
+        self._catalog.complete_world(
+            draft_id=(
+                str(intent["draft_id"]) if intent.get("draft_id") is not None else None
+            ),
+            world_id=world_id,
+            relative_db_path=str(intent["relative_db_path"]),
+            summary={},
+            request_id=str(intent["request_id"]),
+        )
+        self._refresh_summary(world_id)
+        return True
 
     def _create_context(self, world_id: str) -> _WorldContext:
         return self._bind_context(world_id, self._databases.create(world_id))

--- a/docs/knowledge/modules/persistent-world-and-presentation.md
+++ b/docs/knowledge/modules/persistent-world-and-presentation.md
@@ -18,7 +18,7 @@ related:
 
 ## 模块边界
 
-`world_simulation/` 拥有世界实例、共享时间线、事件结算、决策屏障、角色模板快照和演出协议。`WorldRepository` 将权威事实与派生的播放游标保存到独立 `worlds.db`；React 世界工作台只消费 bridge read model，不直接读数据库。
+`world_simulation/` 拥有世界实例、共享时间线、事件结算、决策屏障、角色模板快照和演出协议。桌面端的 `WorldCatalog` 只保存草案、数据库路径和列表摘要；每个世界的 `WorldRepository` 将权威事实与派生的播放游标保存到 `worlds/<world_id>/world.db`，世界之间不共享事实数据库。React 世界工作台只消费 bridge read model，不直接读数据库。
 
 角色进入世界时会冻结为 `RoleTemplateSnapshot`，角色素材复制到世界私有目录。后续角色修改或删除不能改变已有世界中的 persona、心情立绘、avatar 或声音配置。`WorldVisualResolver` 按“当前 mood、默认 mood、avatar、剪影”解析冻结素材。
 

--- a/tests/desktop_bridge/test_world_simulation_handler.py
+++ b/tests/desktop_bridge/test_world_simulation_handler.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import sqlite3
 from pathlib import Path
 
 from PIL import Image
+import pytest
 
 from core.roles import RoleStore
 from desktop_bridge.world_simulation_handler import WorldSimulationHandler
+from world_simulation.errors import WorldNotFoundError
 
 
 def _creation_input(role_id: str) -> dict[str, object]:
@@ -24,6 +27,119 @@ def _creation_input(role_id: str) -> dict[str, object]:
             "primaryGoal": "找到失踪的姐姐",
         },
     }
+
+
+def _create_world(
+    handler: WorldSimulationHandler,
+    role_id: str,
+    *,
+    name: str,
+    request_prefix: str,
+) -> dict[str, object]:
+    input_data = _creation_input(role_id)
+    input_data["name"] = name
+    draft = handler.handle(
+        "worlds.drafts.preview", input_data, request_id=f"{request_prefix}:preview"
+    )
+    assert draft is not None
+    confirmed = handler.handle(
+        "worlds.drafts.confirm",
+        {
+            "draft_id": draft["draft"]["id"],
+            "native_identities": draft["draft"]["nativeIdentities"],
+        },
+        request_id=f"{request_prefix}:confirm",
+    )
+    assert confirmed is not None
+    return confirmed["world"]
+
+
+def test_each_world_uses_its_own_database_and_catalog_survives_restart(tmp_path):
+    role_store = RoleStore(tmp_path)
+    role = role_store.create_role(name="凛", system_prompt="保持冷静")
+    handler = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    first = _create_world(handler, role.id, name="雨港", request_prefix="rain-harbor")
+    second = _create_world(handler, role.id, name="雪原", request_prefix="snowfield")
+
+    handler.handle(
+        "worlds.actions.submit",
+        {"world_id": first["id"], "content": "点亮旧港的灯。"},
+        request_id="rain-harbor:action",
+    )
+    first_db = tmp_path / "worlds" / str(first["id"]) / "world.db"
+    second_db = tmp_path / "worlds" / str(second["id"]) / "world.db"
+    assert first_db.is_file()
+    assert second_db.is_file()
+    assert not (tmp_path / "worlds.db").exists()
+
+    with sqlite3.connect(first_db) as connection:
+        first_count = connection.execute(
+            "SELECT COUNT(*) FROM timeline_events"
+        ).fetchone()[0]
+        first_world_ids = connection.execute("SELECT id FROM worlds").fetchall()
+    with sqlite3.connect(second_db) as connection:
+        second_count = connection.execute(
+            "SELECT COUNT(*) FROM timeline_events"
+        ).fetchone()[0]
+        second_world_ids = connection.execute("SELECT id FROM worlds").fetchall()
+    assert first_count == 2
+    assert second_count == 1
+    assert first_world_ids == [(first["id"],)]
+    assert second_world_ids == [(second["id"],)]
+
+    handler.close()
+    restarted = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    listed = restarted.handle("worlds.list", {}, request_id="list-worlds")
+    assert listed is not None
+    assert {item["id"] for item in listed["worlds"]} == {
+        first["id"],
+        second["id"],
+    }
+    refreshed = restarted.handle(
+        "worlds.get", {"world_id": second["id"]}, request_id="get-second"
+    )
+    assert refreshed is not None
+    assert refreshed["world"]["name"] == "雪原"
+    with pytest.raises(WorldNotFoundError):
+        restarted.handle(
+            "worlds.get", {"world_id": "world-does-not-exist"}, request_id="missing"
+        )
+    assert not (tmp_path / "worlds" / "world-does-not-exist").exists()
+    restarted.close()
+
+
+def test_copy_world_writes_a_prefix_into_a_new_database(tmp_path):
+    role_store = RoleStore(tmp_path)
+    role = role_store.create_role(name="凛", system_prompt="保持冷静")
+    handler = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    source = _create_world(
+        handler, role.id, name="原始世界", request_prefix="copy-source"
+    )
+    action = handler.handle(
+        "worlds.actions.submit",
+        {"world_id": source["id"], "content": "走进灯塔。"},
+        request_id="copy-source:action",
+    )
+    assert action is not None
+    source_events = handler._context(source["id"]).repository.list_events(source["id"])
+    copied = handler.handle(
+        "worlds.copy",
+        {"world_id": source["id"], "anchor_id": source_events[-1].id},
+        request_id="copy-world",
+    )
+    assert copied is not None
+    copied_world = copied["world"]
+    assert copied_world["id"] != source["id"]
+    copied_db = tmp_path / "worlds" / str(copied_world["id"]) / "world.db"
+    assert copied_db.is_file()
+    with sqlite3.connect(copied_db) as connection:
+        world_ids = connection.execute("SELECT id FROM worlds").fetchall()
+        event_world_ids = connection.execute(
+            "SELECT DISTINCT world_id FROM timeline_events"
+        ).fetchall()
+    assert world_ids == [(copied_world["id"],)]
+    assert event_world_ids == [(copied_world["id"],)]
+    handler.close()
 
 
 def test_creation_draft_survives_handler_restart_and_freezes_role_snapshot(tmp_path):
@@ -133,8 +249,9 @@ def test_presentation_session_checkpoints_pause_and_rebuilds_from_facts(tmp_path
     )
     assert confirmed is not None
     world = confirmed["world"]
-    stored_world = handler._repository.require_world(world["id"])
-    run = handler._service.start_run(
+    context = handler._context(world["id"])
+    stored_world = context.repository.require_world(world["id"])
+    run = context.service.start_run(
         world["id"],
         kind="scene",
         request_id="scene-presentation:run",
@@ -142,6 +259,7 @@ def test_presentation_session_checkpoints_pause_and_rebuilds_from_facts(tmp_path
         random_seed="scene-presentation",
     )
     proposal = handler._proposal(
+        context=context,
         world=stored_world,
         run_id=run.id,
         random_seed=run.random_seed,
@@ -154,7 +272,7 @@ def test_presentation_session_checkpoints_pause_and_rebuilds_from_facts(tmp_path
             "content": "潮声里有人叫住了岚。",
         },
     )
-    handler._service.submit_action(proposal, request_id="scene-presentation")
+    context.service.submit_action(proposal, request_id="scene-presentation")
     refreshed = handler.handle(
         "worlds.get", {"world_id": world["id"]}, request_id="refresh-scene"
     )
@@ -195,7 +313,7 @@ def test_presentation_session_checkpoints_pause_and_rebuilds_from_facts(tmp_path
     )
     assert duplicate == checkpoint
 
-    handler._repository.delete_presentation_session(world["id"])
+    context.repository.delete_presentation_session(world["id"])
     handler.close()
     restarted = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
     rebuilt = restarted.handle(
@@ -253,7 +371,7 @@ def test_completing_a_day_commits_action_and_advances_one_day_atomically(tmp_pat
         -1
     ] == "去旧港寻找失踪者。"
     assert world["days"][1]["events"][0]["content"] == "新的一天开始了。"
-    assert len(handler._repository.list_events(world_id)) == 3
+    assert len(handler._context(world_id).repository.list_events(world_id)) == 3
     handler.close()
 
 
@@ -288,7 +406,7 @@ def test_world_draft_freezes_role_visual_and_voice_snapshots(tmp_path):
         request_id="preview-world",
     )
     assert draft is not None
-    stored = handler._repository.get_draft(draft["draft"]["id"])
+    stored = handler._catalog.get_draft(draft["draft"]["id"])
     assert stored is not None
     snapshot = stored.role_snapshots[0]
     copied_paths = [item["path"] for item in snapshot.assets]
@@ -323,7 +441,7 @@ def test_world_snapshot_normalizes_character_canvas_and_foot_baseline(tmp_path):
     )
 
     assert draft is not None
-    stored = handler._repository.get_draft(draft["draft"]["id"])
+    stored = handler._catalog.get_draft(draft["draft"]["id"])
     assert stored is not None
     normalized_path = Path(stored.role_snapshots[0].assets[0]["path"])
     with Image.open(normalized_path) as normalized:
@@ -373,9 +491,10 @@ def test_world_read_model_resolves_snapshot_visuals_for_sprite_cues(tmp_path):
     )
     assert confirmed is not None
     world_id = confirmed["world"]["id"]
-    world = handler._repository.require_world(world_id)
-    resident = handler._repository.list_residents(world_id)[0]
-    run = handler._service.start_run(
+    context = handler._context(world_id)
+    world = context.repository.require_world(world_id)
+    resident = context.repository.list_residents(world_id)[0]
+    run = context.service.start_run(
         world_id,
         kind="action",
         request_id="visual-action:run",
@@ -383,6 +502,7 @@ def test_world_read_model_resolves_snapshot_visuals_for_sprite_cues(tmp_path):
         random_seed="visual-action",
     )
     proposal = handler._proposal(
+        context=context,
         world=world,
         run_id=run.id,
         random_seed=run.random_seed,
@@ -394,7 +514,7 @@ def test_world_read_model_resolves_snapshot_visuals_for_sprite_cues(tmp_path):
             "sprites": [{"actor_id": resident.id, "mood": "平静"}],
         },
     )
-    handler._service.submit_action(proposal, request_id="visual-action")
+    context.service.submit_action(proposal, request_id="visual-action")
 
     result = handler.handle(
         "worlds.get", {"world_id": world_id}, request_id="get-visual-world"

--- a/tests/desktop_bridge/test_world_simulation_handler.py
+++ b/tests/desktop_bridge/test_world_simulation_handler.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
+from dataclasses import replace
 
 from PIL import Image
 import pytest
@@ -9,6 +10,7 @@ import pytest
 from core.roles import RoleStore
 from desktop_bridge.world_simulation_handler import WorldSimulationHandler
 from world_simulation.errors import WorldNotFoundError
+from world_simulation.service import WorldSimulationService
 
 
 def _creation_input(role_id: str) -> dict[str, object]:
@@ -176,6 +178,135 @@ def test_creation_draft_survives_handler_restart_and_freezes_role_snapshot(tmp_p
     assert world["ocs"][0]["name"] == "岚"
     assert world["relatedCharacters"][0]["relationship"] == "沉默的向导"
     second_handler.close()
+
+
+def test_committed_world_is_recovered_after_catalog_registration_interruption(tmp_path):
+    role_store = RoleStore(tmp_path)
+    role = role_store.create_role(name="凛", system_prompt="保持冷静")
+    first_handler = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    draft_response = first_handler.handle(
+        "worlds.drafts.preview",
+        _creation_input(role.id),
+        request_id="recovery-preview",
+    )
+    assert draft_response is not None
+    draft = first_handler._catalog.get_draft(draft_response["draft"]["id"])
+    assert draft is not None
+
+    world_id = "world-recovered"
+    first_handler._catalog.register_creation_intent(
+        request_id="recovery-confirm",
+        world_id=world_id,
+        draft_id=draft.id,
+        relative_db_path=first_handler._databases.relative_path(world_id),
+    )
+    repository = first_handler._databases.create(world_id)
+    repository.save_draft(draft)
+    WorldSimulationService(repository).confirm_world(
+        draft.id,
+        request_id="recovery-confirm",
+        world_id=world_id,
+        random_seed="recovery-seed",
+    )
+    first_handler.close()
+
+    restarted = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    listed = restarted.handle("worlds.list", {}, request_id="recovery-list")
+
+    assert listed is not None
+    assert [item["id"] for item in listed["worlds"]] == [world_id]
+    assert restarted._catalog.pending_creation_intents() == []
+    recovered = restarted.handle(
+        "worlds.get", {"world_id": world_id}, request_id="recovery-get"
+    )
+    assert recovered is not None
+    assert recovered["world"]["name"] == "雨港"
+    restarted.close()
+
+
+def test_incomplete_creation_intent_removes_empty_world_database(tmp_path):
+    role_store = RoleStore(tmp_path)
+    catalog_handler = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    world_id = "world-incomplete"
+    catalog_handler._catalog.register_creation_intent(
+        request_id="incomplete-confirm",
+        world_id=world_id,
+        draft_id=None,
+        relative_db_path=catalog_handler._databases.relative_path(world_id),
+    )
+    repository = catalog_handler._databases.create(world_id)
+    repository.close()
+    catalog_handler.close()
+
+    restarted = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+
+    assert restarted._catalog.pending_creation_intents() == []
+    assert not (tmp_path / "worlds" / world_id).exists()
+    restarted.close()
+
+
+def test_copy_world_preserves_cross_database_scene_state_at_anchor(tmp_path):
+    role_store = RoleStore(tmp_path)
+    role = role_store.create_role(name="凛", system_prompt="保持冷静")
+    handler = WorldSimulationHandler(workspace=tmp_path, role_store=role_store)
+    source = _create_world(handler, role.id, name="原始世界", request_prefix="state-source")
+    context = handler._context(source["id"])
+    world = context.repository.require_world(source["id"])
+    run = context.service.start_run(
+        source["id"],
+        kind="scene",
+        request_id="state-scene:run",
+        expected_revision=world.revision,
+        random_seed="state-scene",
+    )
+    proposal = handler._proposal(
+        context=context,
+        world=world,
+        run_id=run.id,
+        random_seed=run.random_seed,
+        event_type="scene.choice.committed",
+        effective_at=world.current_time,
+        participants=(world.active_oc_id,),
+        presentation={"mode": "scene", "kind": "dialogue", "content": "选择"},
+    )
+    proposal = replace(
+        proposal,
+        barrier={
+            "id": "barrier-copy",
+            "effective_at": world.current_time,
+            "oc_id": world.active_oc_id,
+            "reason": "需要选择方向",
+        },
+        scene_thread={
+            "id": "scene-copy",
+            "world_time": world.current_time,
+            "location": "旧港",
+            "participants": {world.active_oc_id: "岚"},
+            "status": "active",
+            "messages": ({"content": "选择"},),
+        },
+    )
+    context.service.submit_action(proposal, request_id="state-scene")
+    anchor = context.repository.list_events(source["id"])[-1]
+
+    copied = handler.handle(
+        "worlds.copy",
+        {"world_id": source["id"], "anchor_id": anchor.id},
+        request_id="state-copy",
+    )
+
+    assert copied is not None
+    target_id = copied["world"]["id"]
+    target = handler._context(target_id).repository
+    barriers = target.list_pending_barriers(target_id)
+    threads = target.list_scene_threads(target_id)
+    session = target.get_presentation_session(target_id)
+    assert [item.id for item in barriers] == ["barrier-copy"]
+    assert [item.id for item in threads] == ["scene-copy"]
+    assert threads[0].world_id == target_id
+    assert session is not None
+    assert session.status == "playing"
+    handler.close()
 
 
 def test_action_catch_up_only_returns_committed_beats(tmp_path):

--- a/tests/world_simulation/test_catalog.py
+++ b/tests/world_simulation/test_catalog.py
@@ -57,3 +57,28 @@ def test_catalog_persists_drafts_world_summaries_and_idempotency(tmp_path):
     catalog.update_summary("world-1", updated)
     assert catalog.list_summaries() == [updated]
     catalog.close()
+
+
+def test_catalog_creation_intent_is_completed_with_world_registration(tmp_path):
+    catalog = WorldCatalog(tmp_path / "worlds" / "catalog.db")
+
+    intent = catalog.register_creation_intent(
+        request_id="confirm-1",
+        world_id="world-1",
+        draft_id=None,
+        relative_db_path="world-1/world.db",
+    )
+
+    assert intent["status"] == "pending"
+    assert catalog.creation_intent_for_request("confirm-1") == intent
+    catalog.complete_world(
+        draft_id=None,
+        world_id="world-1",
+        relative_db_path="world-1/world.db",
+        summary={"id": "world-1"},
+        request_id="confirm-1",
+    )
+
+    assert catalog.pending_creation_intents() == []
+    assert catalog.creation_intent_for_request("confirm-1") is None
+    catalog.close()

--- a/tests/world_simulation/test_catalog.py
+++ b/tests/world_simulation/test_catalog.py
@@ -1,0 +1,59 @@
+from world_simulation.catalog import WorldCatalog
+from world_simulation.drafts import create_world_draft
+from world_simulation.world import NativeResident, RoleTemplateSnapshot, WorldTemplate
+
+
+def test_catalog_persists_drafts_world_summaries_and_idempotency(tmp_path):
+    catalog = WorldCatalog(tmp_path / "worlds" / "catalog.db")
+    snapshot = RoleTemplateSnapshot(
+        id="snapshot-rin",
+        source_role_id="rin",
+        source_version="v1",
+        persona={"temperament": "calm"},
+    )
+    draft = create_world_draft(
+        owner_id="player-1",
+        template=WorldTemplate(id="template-1", name="雨港", era="modern"),
+        role_snapshots=(snapshot,),
+        residents=(
+            NativeResident(
+                id="resident-rin",
+                snapshot_id=snapshot.id,
+                name="凛",
+                occupation="student",
+                residence="dorm",
+            ),
+        ),
+        initial_time="2026-07-31T08:00:00+00:00",
+        draft_id="draft-1",
+    )
+    catalog.save_draft(draft)
+    restored = catalog.get_draft(draft.id)
+    assert restored is not None
+    assert restored.id == draft.id
+    assert restored.template.name == draft.template.name
+    assert restored.role_snapshots[0].source_role_id == "rin"
+    assert restored.residents[0].name == "凛"
+
+    summary = {
+        "id": "world-1",
+        "name": "雨港",
+        "currentDayIndex": 1,
+        "status": "action_required",
+    }
+    catalog.complete_world(
+        draft_id=draft.id,
+        world_id="world-1",
+        relative_db_path="world-1/world.db",
+        summary=summary,
+        request_id="confirm-1",
+    )
+    assert catalog.world_id_for_request("confirm-1") == "world-1"
+    assert catalog.relative_db_path("world-1") == "world-1/world.db"
+    assert catalog.list_summaries() == [summary]
+    assert catalog.get_draft(draft.id).status == "confirmed"
+
+    updated = {**summary, "currentDayIndex": 2}
+    catalog.update_summary("world-1", updated)
+    assert catalog.list_summaries() == [updated]
+    catalog.close()

--- a/tests/world_simulation/test_database_manager.py
+++ b/tests/world_simulation/test_database_manager.py
@@ -1,0 +1,18 @@
+from world_simulation.catalog import WorldCatalog
+from world_simulation.database_manager import WorldDatabaseManager
+
+
+def test_removes_legacy_database_and_sqlite_sidecars(tmp_path):
+    legacy_root = tmp_path / "worlds.db"
+    for suffix in ("", "-wal", "-shm"):
+        (legacy_root.parent / f"{legacy_root.name}{suffix}").write_bytes(b"legacy")
+
+    catalog = WorldCatalog(tmp_path / "worlds" / "catalog.db")
+    manager = WorldDatabaseManager(tmp_path, catalog)
+
+    assert not legacy_root.exists()
+    assert not (tmp_path / "worlds.db-wal").exists()
+    assert not (tmp_path / "worlds.db-shm").exists()
+
+    manager.close()
+    catalog.close()

--- a/tests/world_simulation/test_drafts.py
+++ b/tests/world_simulation/test_drafts.py
@@ -1,0 +1,54 @@
+import pytest
+
+from world_simulation.drafts import create_world_draft
+from world_simulation.world import NativeResident, RoleTemplateSnapshot, WorldTemplate
+
+
+def _snapshot() -> RoleTemplateSnapshot:
+    return RoleTemplateSnapshot(
+        id="snapshot-rin",
+        source_role_id="rin",
+        source_version="v1",
+        persona={"temperament": "calm"},
+    )
+
+
+def _resident(snapshot_id: str) -> NativeResident:
+    return NativeResident(
+        id="resident-rin",
+        snapshot_id=snapshot_id,
+        name="Rin",
+        occupation="student",
+        residence="dorm",
+    )
+
+
+def test_create_world_draft_preserves_metadata_and_accepts_explicit_id():
+    snapshot = _snapshot()
+    metadata = {"input": {"seed": "rain-harbor"}}
+
+    draft = create_world_draft(
+        owner_id="player-1",
+        template=WorldTemplate(id="template-1", name="Rain Harbor", era="modern"),
+        role_snapshots=(snapshot,),
+        residents=(_resident(snapshot.id),),
+        initial_time="2026-07-31T08:00:00+00:00",
+        creation_metadata=metadata,
+        draft_id="draft-1",
+    )
+
+    assert draft.id == "draft-1"
+    assert draft.creation_metadata == metadata
+    assert draft.role_snapshots == (snapshot,)
+    assert draft.residents == (_resident(snapshot.id),)
+
+
+def test_create_world_draft_rejects_resident_from_unknown_snapshot():
+    with pytest.raises(ValueError, match="every resident"):
+        create_world_draft(
+            owner_id="player-1",
+            template=WorldTemplate(id="template-1", name="Rain Harbor", era="modern"),
+            role_snapshots=(_snapshot(),),
+            residents=(_resident("snapshot-missing"),),
+            initial_time="2026-07-31T08:00:00+00:00",
+        )

--- a/world_simulation/__init__.py
+++ b/world_simulation/__init__.py
@@ -1,6 +1,8 @@
 """Persistent shared-world simulation bounded context."""
 
 from world_simulation.actors import AutonomyPolicy, PlayerOC
+from world_simulation.catalog import WorldCatalog
+from world_simulation.database_manager import WorldDatabaseManager
 from world_simulation.dependencies import DependencySet
 from world_simulation.performance import (
     PRESENTATION_PROTOCOL_VERSION,
@@ -46,6 +48,8 @@ __all__ = [
     "SceneThread",
     "TimelineEvent",
     "WorldDraft",
+    "WorldCatalog",
+    "WorldDatabaseManager",
     "WorldInstance",
     "WorldRepository",
     "WorldRun",

--- a/world_simulation/catalog.py
+++ b/world_simulation/catalog.py
@@ -41,6 +41,16 @@ CREATE TABLE IF NOT EXISTS catalog_idempotency (
     request_id TEXT PRIMARY KEY,
     world_id TEXT NOT NULL REFERENCES world_entries(world_id)
 );
+
+CREATE TABLE IF NOT EXISTS world_creation_intents (
+    request_id TEXT PRIMARY KEY,
+    world_id TEXT NOT NULL UNIQUE,
+    draft_id TEXT,
+    relative_db_path TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL,
+    completed_at TEXT
+);
 """
 
 
@@ -100,6 +110,81 @@ class WorldCatalog:
         if updated.rowcount != 1:
             raise WorldNotFoundError(f"world draft is not editable: {draft.id}")
 
+    def register_creation_intent(
+        self,
+        *,
+        request_id: str,
+        world_id: str,
+        draft_id: str | None,
+        relative_db_path: str,
+    ) -> dict[str, Any]:
+        """Record a world creation before its dedicated database is opened."""
+
+        with self._lock:
+            self._connection.execute("BEGIN IMMEDIATE")
+            try:
+                row = self._connection.execute(
+                    "SELECT * FROM world_creation_intents WHERE request_id = ?",
+                    (request_id,),
+                ).fetchone()
+                if row is None:
+                    self._connection.execute(
+                        """INSERT INTO world_creation_intents
+                        VALUES (?, ?, ?, ?, 'pending', ?, NULL)""",
+                        (
+                            request_id,
+                            world_id,
+                            draft_id,
+                            relative_db_path,
+                            utc_now(),
+                        ),
+                    )
+                    row = self._connection.execute(
+                        "SELECT * FROM world_creation_intents WHERE request_id = ?",
+                        (request_id,),
+                    ).fetchone()
+                elif row["world_id"] != world_id:
+                    raise ValueError(
+                        f"creation request already belongs to world: {request_id}"
+                    )
+            except BaseException:
+                self._connection.rollback()
+                raise
+            else:
+                self._connection.commit()
+        return self._row_to_creation_intent(row)
+
+    def pending_creation_intents(self) -> list[dict[str, Any]]:
+        """List creation intents that still need catalog recovery."""
+
+        with self._lock:
+            rows = self._connection.execute(
+                """SELECT * FROM world_creation_intents
+                WHERE status = 'pending' ORDER BY created_at, request_id"""
+            ).fetchall()
+        return [self._row_to_creation_intent(row) for row in rows]
+
+    def creation_intent_for_request(self, request_id: str) -> dict[str, Any] | None:
+        """Load one pending creation intent for same-request recovery."""
+
+        with self._lock:
+            row = self._connection.execute(
+                """SELECT * FROM world_creation_intents
+                WHERE request_id = ? AND status = 'pending'""",
+                (request_id,),
+            ).fetchone()
+        return self._row_to_creation_intent(row) if row is not None else None
+
+    def discard_creation_intent(self, request_id: str) -> None:
+        """Remove an intent whose database was never committed."""
+
+        with self._lock:
+            self._connection.execute(
+                """DELETE FROM world_creation_intents
+                WHERE request_id = ? AND status = 'pending'""",
+                (request_id,),
+            )
+
     def complete_world(
         self,
         *,
@@ -114,24 +199,51 @@ class WorldCatalog:
         with self._lock:
             self._connection.execute("BEGIN IMMEDIATE")
             try:
-                self._connection.execute(
-                    "INSERT INTO world_entries VALUES (?, ?, ?, ?)",
-                    (world_id, relative_db_path, _dump(summary), utc_now()),
-                )
-                self._connection.execute(
-                    "INSERT INTO catalog_idempotency VALUES (?, ?)",
-                    (request_id, world_id),
-                )
+                entry = self._connection.execute(
+                    "SELECT relative_db_path FROM world_entries WHERE world_id = ?",
+                    (world_id,),
+                ).fetchone()
+                if entry is None:
+                    self._connection.execute(
+                        "INSERT INTO world_entries VALUES (?, ?, ?, ?)",
+                        (world_id, relative_db_path, _dump(summary), utc_now()),
+                    )
+                elif entry["relative_db_path"] != relative_db_path:
+                    raise ValueError(f"world path changed: {world_id}")
+                else:
+                    self._connection.execute(
+                        "UPDATE world_entries SET summary = ? WHERE world_id = ?",
+                        (_dump(summary), world_id),
+                    )
+                request = self._connection.execute(
+                    "SELECT world_id FROM catalog_idempotency WHERE request_id = ?",
+                    (request_id,),
+                ).fetchone()
+                if request is None:
+                    self._connection.execute(
+                        "INSERT INTO catalog_idempotency VALUES (?, ?)",
+                        (request_id, world_id),
+                    )
+                elif request["world_id"] != world_id:
+                    raise ValueError(
+                        f"catalog request already belongs to world: {request_id}"
+                    )
                 if draft_id is not None:
                     updated = self._connection.execute(
                         """UPDATE world_drafts SET status = 'confirmed'
-                        WHERE id = ? AND status = 'draft'""",
+                        WHERE id = ? AND status IN ('draft', 'confirmed')""",
                         (draft_id,),
                     )
                     if updated.rowcount != 1:
                         raise WorldNotFoundError(
                             f"world draft is not confirmable: {draft_id}"
                         )
+                self._connection.execute(
+                    """UPDATE world_creation_intents
+                    SET status = 'completed', completed_at = ?
+                    WHERE request_id = ? AND world_id = ?""",
+                    (utc_now(), request_id, world_id),
+                )
             except BaseException:
                 self._connection.rollback()
                 raise
@@ -179,6 +291,18 @@ class WorldCatalog:
             )
         if updated.rowcount != 1:
             raise WorldNotFoundError(f"world not found: {world_id}")
+
+    @staticmethod
+    def _row_to_creation_intent(row: sqlite3.Row) -> dict[str, Any]:
+        return {
+            "request_id": row["request_id"],
+            "world_id": row["world_id"],
+            "draft_id": row["draft_id"],
+            "relative_db_path": row["relative_db_path"],
+            "status": row["status"],
+            "created_at": row["created_at"],
+            "completed_at": row["completed_at"],
+        }
 
     @staticmethod
     def _draft_payload(draft: WorldDraft) -> dict[str, Any]:

--- a/world_simulation/catalog.py
+++ b/world_simulation/catalog.py
@@ -1,0 +1,208 @@
+"""Workspace catalog for world drafts, database locations, and list summaries."""
+
+from __future__ import annotations
+
+import sqlite3
+import threading
+from pathlib import Path
+from typing import Any
+
+from world_simulation.errors import WorldNotFoundError
+from world_simulation.repository_records import _dump, _load
+from world_simulation.world import (
+    NativeResident,
+    RoleTemplateSnapshot,
+    WorldDraft,
+    WorldTemplate,
+    utc_now,
+)
+
+
+_CATALOG_SCHEMA = """
+PRAGMA foreign_keys = ON;
+PRAGMA journal_mode = WAL;
+
+CREATE TABLE IF NOT EXISTS world_drafts (
+    id TEXT PRIMARY KEY,
+    owner_id TEXT NOT NULL,
+    payload TEXT NOT NULL,
+    status TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS world_entries (
+    world_id TEXT PRIMARY KEY,
+    relative_db_path TEXT NOT NULL UNIQUE,
+    summary TEXT NOT NULL,
+    created_at TEXT NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS catalog_idempotency (
+    request_id TEXT PRIMARY KEY,
+    world_id TEXT NOT NULL REFERENCES world_entries(world_id)
+);
+"""
+
+
+class WorldCatalog:
+    """Persist workspace-level discovery data without owning world facts."""
+
+    def __init__(self, db_path: str | Path) -> None:
+        self.db_path = Path(db_path)
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._connection = sqlite3.connect(
+            str(self.db_path), check_same_thread=False, isolation_level=None
+        )
+        self._connection.row_factory = sqlite3.Row
+        self._lock = threading.RLock()
+        with self._lock:
+            self._connection.executescript(_CATALOG_SCHEMA)
+
+    def close(self) -> None:
+        """Close the catalog connection."""
+
+        with self._lock:
+            self._connection.close()
+
+    def save_draft(self, draft: WorldDraft) -> None:
+        """Persist a newly previewed world draft."""
+
+        with self._lock:
+            self._connection.execute(
+                "INSERT INTO world_drafts VALUES (?, ?, ?, ?, ?)",
+                (
+                    draft.id,
+                    draft.owner_id,
+                    _dump(self._draft_payload(draft)),
+                    draft.status,
+                    draft.created_at,
+                ),
+            )
+
+    def get_draft(self, draft_id: str) -> WorldDraft | None:
+        """Load a draft without opening any world database."""
+
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT * FROM world_drafts WHERE id = ?", (draft_id,)
+            ).fetchone()
+        return self._row_to_draft(row) if row is not None else None
+
+    def replace_draft(self, draft: WorldDraft) -> None:
+        """Save player edits while the draft remains confirmable."""
+
+        with self._lock:
+            updated = self._connection.execute(
+                """UPDATE world_drafts SET payload = ?
+                WHERE id = ? AND status = 'draft'""",
+                (_dump(self._draft_payload(draft)), draft.id),
+            )
+        if updated.rowcount != 1:
+            raise WorldNotFoundError(f"world draft is not editable: {draft.id}")
+
+    def complete_world(
+        self,
+        *,
+        draft_id: str | None,
+        world_id: str,
+        relative_db_path: str,
+        summary: dict[str, Any],
+        request_id: str,
+    ) -> None:
+        """Make one fully created world discoverable and record request idempotency."""
+
+        with self._lock:
+            self._connection.execute("BEGIN IMMEDIATE")
+            try:
+                self._connection.execute(
+                    "INSERT INTO world_entries VALUES (?, ?, ?, ?)",
+                    (world_id, relative_db_path, _dump(summary), utc_now()),
+                )
+                self._connection.execute(
+                    "INSERT INTO catalog_idempotency VALUES (?, ?)",
+                    (request_id, world_id),
+                )
+                if draft_id is not None:
+                    updated = self._connection.execute(
+                        """UPDATE world_drafts SET status = 'confirmed'
+                        WHERE id = ? AND status = 'draft'""",
+                        (draft_id,),
+                    )
+                    if updated.rowcount != 1:
+                        raise WorldNotFoundError(
+                            f"world draft is not confirmable: {draft_id}"
+                        )
+            except BaseException:
+                self._connection.rollback()
+                raise
+            else:
+                self._connection.commit()
+
+    def world_id_for_request(self, request_id: str) -> str | None:
+        """Resolve catalog-scoped creation idempotency."""
+
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT world_id FROM catalog_idempotency WHERE request_id = ?",
+                (request_id,),
+            ).fetchone()
+        return str(row["world_id"]) if row is not None else None
+
+    def relative_db_path(self, world_id: str) -> str:
+        """Return the registered relative database path for one world."""
+
+        with self._lock:
+            row = self._connection.execute(
+                "SELECT relative_db_path FROM world_entries WHERE world_id = ?",
+                (world_id,),
+            ).fetchone()
+        if row is None:
+            raise WorldNotFoundError(f"world not found: {world_id}")
+        return str(row["relative_db_path"])
+
+    def list_summaries(self) -> list[dict[str, Any]]:
+        """List cached desktop summaries without opening world databases."""
+
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT summary FROM world_entries ORDER BY created_at, world_id"
+            ).fetchall()
+        return [_load(row["summary"], {}) for row in rows]
+
+    def update_summary(self, world_id: str, summary: dict[str, Any]) -> None:
+        """Synchronize the catalog projection after a committed world mutation."""
+
+        with self._lock:
+            updated = self._connection.execute(
+                "UPDATE world_entries SET summary = ? WHERE world_id = ?",
+                (_dump(summary), world_id),
+            )
+        if updated.rowcount != 1:
+            raise WorldNotFoundError(f"world not found: {world_id}")
+
+    @staticmethod
+    def _draft_payload(draft: WorldDraft) -> dict[str, Any]:
+        return {
+            "template": draft.template.to_dict(),
+            "role_snapshots": [item.to_dict() for item in draft.role_snapshots],
+            "residents": [item.to_dict() for item in draft.residents],
+            "initial_time": draft.initial_time,
+            "creation_metadata": draft.creation_metadata,
+        }
+
+    @staticmethod
+    def _row_to_draft(row: sqlite3.Row) -> WorldDraft:
+        payload = _load(row["payload"], {})
+        return WorldDraft(
+            id=row["id"],
+            owner_id=row["owner_id"],
+            template=WorldTemplate(**payload["template"]),
+            role_snapshots=tuple(
+                RoleTemplateSnapshot(**item) for item in payload["role_snapshots"]
+            ),
+            residents=tuple(NativeResident(**item) for item in payload["residents"]),
+            initial_time=payload["initial_time"],
+            creation_metadata=dict(payload.get("creation_metadata", {})),
+            status=row["status"],
+            created_at=row["created_at"],
+        )

--- a/world_simulation/database_manager.py
+++ b/world_simulation/database_manager.py
@@ -1,0 +1,97 @@
+"""Lifecycle manager for one SQLite database per persistent world."""
+
+from __future__ import annotations
+
+import re
+import threading
+from pathlib import Path
+
+from world_simulation.catalog import WorldCatalog
+from world_simulation.repository import WorldRepository
+
+
+_WORLD_ID_PATTERN = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
+
+
+class WorldDatabaseManager:
+    """Open registered world databases and own their process-lifetime connections."""
+
+    def __init__(self, workspace: Path, catalog: WorldCatalog) -> None:
+        self.root = workspace / "worlds"
+        self.root.mkdir(parents=True, exist_ok=True)
+        self.catalog = catalog
+        self._repositories: dict[str, WorldRepository] = {}
+        self._lock = threading.RLock()
+
+    def open(self, world_id: str) -> WorldRepository:
+        """Open an existing registered world without creating paths for unknown ids."""
+
+        with self._lock:
+            existing = self._repositories.get(world_id)
+            if existing is not None:
+                return existing
+            relative_path = self.catalog.relative_db_path(world_id)
+            db_path = self._resolve_registered_path(relative_path)
+            repository = WorldRepository(db_path)
+            try:
+                repository.require_world(world_id)
+            except BaseException:
+                repository.close()
+                raise
+            self._repositories[world_id] = repository
+            return repository
+
+    def create(self, world_id: str) -> WorldRepository:
+        """Create an unregistered database for a new internally generated world id."""
+
+        if not _WORLD_ID_PATTERN.fullmatch(world_id):
+            raise ValueError(f"invalid world id: {world_id}")
+        with self._lock:
+            if world_id in self._repositories:
+                raise ValueError(f"world database already open: {world_id}")
+            db_path = self.root / world_id / "world.db"
+            if db_path.exists():
+                raise ValueError(f"world database already exists: {world_id}")
+            repository = WorldRepository(db_path)
+            self._repositories[world_id] = repository
+            return repository
+
+    def relative_path(self, world_id: str) -> str:
+        """Return the portable catalog path for a newly created world database."""
+
+        if not _WORLD_ID_PATTERN.fullmatch(world_id):
+            raise ValueError(f"invalid world id: {world_id}")
+        return (Path(world_id) / "world.db").as_posix()
+
+    def discard_unregistered(self, world_id: str) -> None:
+        """Remove a failed new database that was never exposed through the catalog."""
+
+        with self._lock:
+            repository = self._repositories.pop(world_id, None)
+            if repository is not None:
+                repository.close()
+            world_dir = self.root / world_id
+            for suffix in ("world.db-wal", "world.db-shm", "world.db"):
+                path = world_dir / suffix
+                if path.exists():
+                    path.unlink()
+            if world_dir.exists() and not any(world_dir.iterdir()):
+                world_dir.rmdir()
+
+    def close(self) -> None:
+        """Close every cached world connection."""
+
+        with self._lock:
+            repositories = list(self._repositories.values())
+            self._repositories.clear()
+        for repository in repositories:
+            repository.close()
+
+    def _resolve_registered_path(self, relative_path: str) -> Path:
+        candidate = (self.root / relative_path).resolve()
+        root = self.root.resolve()
+        if candidate == root or root not in candidate.parents:
+            raise ValueError("world database path escapes the workspace")
+        if not candidate.is_file():
+            raise FileNotFoundError(f"world database is missing: {candidate}")
+        return candidate

--- a/world_simulation/database_manager.py
+++ b/world_simulation/database_manager.py
@@ -7,6 +7,7 @@ import threading
 from pathlib import Path
 
 from world_simulation.catalog import WorldCatalog
+from world_simulation.errors import WorldNotFoundError
 from world_simulation.repository import WorldRepository
 
 
@@ -39,6 +40,32 @@ class WorldDatabaseManager:
             except BaseException:
                 repository.close()
                 raise
+            self._repositories[world_id] = repository
+            return repository
+
+    def open_for_recovery(
+        self, world_id: str, relative_db_path: str
+    ) -> WorldRepository | None:
+        """Open a pending creation database only when it contains its world row."""
+
+        if not _WORLD_ID_PATTERN.fullmatch(world_id):
+            raise ValueError(f"invalid world id: {world_id}")
+        if relative_db_path != self.relative_path(world_id):
+            raise ValueError(f"invalid recovery database path: {relative_db_path}")
+        with self._lock:
+            existing = self._repositories.get(world_id)
+            if existing is not None:
+                existing.require_world(world_id)
+                return existing
+            db_path = self.root / relative_db_path
+            if not db_path.is_file():
+                return None
+            repository = WorldRepository(db_path)
+            try:
+                repository.require_world(world_id)
+            except WorldNotFoundError:
+                repository.close()
+                return None
             self._repositories[world_id] = repository
             return repository
 

--- a/world_simulation/database_manager.py
+++ b/world_simulation/database_manager.py
@@ -19,6 +19,7 @@ class WorldDatabaseManager:
     def __init__(self, workspace: Path, catalog: WorldCatalog) -> None:
         self.root = workspace / "worlds"
         self.root.mkdir(parents=True, exist_ok=True)
+        self._remove_legacy_database()
         self.catalog = catalog
         self._repositories: dict[str, WorldRepository] = {}
         self._lock = threading.RLock()
@@ -95,3 +96,11 @@ class WorldDatabaseManager:
         if not candidate.is_file():
             raise FileNotFoundError(f"world database is missing: {candidate}")
         return candidate
+
+    def _remove_legacy_database(self) -> None:
+        """Remove the retired monolithic database and SQLite sidecars."""
+
+        legacy_root = self.root.parent / "worlds.db"
+        for suffix in ("", "-wal", "-shm"):
+            path = legacy_root.parent / f"{legacy_root.name}{suffix}"
+            path.unlink(missing_ok=True)

--- a/world_simulation/drafts.py
+++ b/world_simulation/drafts.py
@@ -1,0 +1,39 @@
+"""Draft construction shared by world application boundaries."""
+
+from __future__ import annotations
+
+from typing import Any
+from uuid import uuid4
+
+from world_simulation.world import (
+    NativeResident,
+    RoleTemplateSnapshot,
+    WorldDraft,
+    WorldTemplate,
+)
+
+
+def create_world_draft(
+    *,
+    owner_id: str,
+    template: WorldTemplate,
+    role_snapshots: tuple[RoleTemplateSnapshot, ...],
+    residents: tuple[NativeResident, ...],
+    initial_time: str,
+    creation_metadata: dict[str, Any] | None = None,
+    draft_id: str | None = None,
+) -> WorldDraft:
+    """Build and validate a reviewable draft without choosing its storage."""
+
+    snapshot_ids = {item.id for item in role_snapshots}
+    if any(item.snapshot_id not in snapshot_ids for item in residents):
+        raise ValueError("every resident must reference a snapshot in the draft")
+    return WorldDraft(
+        id=draft_id or f"draft-{uuid4().hex}",
+        owner_id=owner_id,
+        template=template,
+        role_snapshots=role_snapshots,
+        residents=residents,
+        initial_time=initial_time,
+        creation_metadata=dict(creation_metadata or {}),
+    )

--- a/world_simulation/repository.py
+++ b/world_simulation/repository.py
@@ -490,11 +490,27 @@ class WorldRepository(RepositoryRecords):
     def list_pending_barriers(self, world_id: str) -> list[DecisionBarrier]:
         """List unresolved barriers in deterministic world-time order."""
 
+        return [
+            item
+            for item in self.list_barriers(world_id)
+            if item.status == "pending"
+        ]
+
+    def list_barriers(
+        self, world_id: str, *, through_time: str | None = None
+    ) -> list[DecisionBarrier]:
+        """List barrier state through one world-time boundary."""
+
         with self._lock:
+            query = "SELECT payload FROM barriers WHERE world_id = ?"
+            params: list[Any] = [world_id]
+            if through_time is not None:
+                query += " AND effective_at <= ?"
+                params.append(through_time)
+            query += " ORDER BY effective_at, id"
             rows = self._connection.execute(
-                """SELECT payload FROM barriers WHERE world_id = ? AND status = 'pending'
-                ORDER BY effective_at, id""",
-                (world_id,),
+                query,
+                params,
             ).fetchall()
         return [DecisionBarrier(**_load(row["payload"], {})) for row in rows]
 
@@ -507,6 +523,29 @@ class WorldRepository(RepositoryRecords):
                 (world_id, barrier_id),
             ).fetchone()
         return DecisionBarrier(**_load(row["payload"], {})) if row else None
+
+    def list_scene_threads(
+        self,
+        world_id: str,
+        *,
+        through_time: str | None = None,
+        through_sequence: int | None = None,
+    ) -> list[SceneThread]:
+        """List scene thread state through one world-time and sequence boundary."""
+
+        with self._lock:
+            rows = self._connection.execute(
+                "SELECT payload FROM scene_threads WHERE world_id = ?",
+                (world_id,),
+            ).fetchall()
+        threads = [SceneThread(**_load(row["payload"], {})) for row in rows]
+        if through_time is not None:
+            threads = [item for item in threads if item.world_time <= through_time]
+        if through_sequence is not None:
+            threads = [
+                item for item in threads if item.beat_sequence <= through_sequence
+            ]
+        return sorted(threads, key=lambda item: (item.world_time, item.id))
 
     def save_run(self, run: WorldRun) -> None:
         """Persist or update a recoverable run state."""

--- a/world_simulation/repository.py
+++ b/world_simulation/repository.py
@@ -1,4 +1,4 @@
-﻿"""Transactional SQLite persistence for the persistent world bounded context."""
+"""Transactional SQLite persistence for the persistent world bounded context."""
 
 from __future__ import annotations
 
@@ -72,7 +72,13 @@ class WorldRepository(RepositoryRecords):
         with self.transaction() as connection:
             connection.execute(
                 "INSERT INTO world_drafts VALUES (?, ?, ?, ?, ?)",
-                (draft.id, draft.owner_id, _dump(payload), draft.status, draft.created_at),
+                (
+                    draft.id,
+                    draft.owner_id,
+                    _dump(payload),
+                    draft.status,
+                    draft.created_at,
+                ),
             )
 
     def get_draft(self, draft_id: str) -> WorldDraft | None:
@@ -153,11 +159,17 @@ class WorldRepository(RepositoryRecords):
             )
             connection.executemany(
                 "INSERT INTO role_snapshots VALUES (?, ?, ?)",
-                [(item.id, world.id, _dump(item.to_dict())) for item in draft.role_snapshots],
+                [
+                    (item.id, world.id, _dump(item.to_dict()))
+                    for item in draft.role_snapshots
+                ],
             )
             connection.executemany(
                 "INSERT INTO residents VALUES (?, ?, ?)",
-                [(item.id, world.id, _dump(item.to_dict())) for item in draft.residents],
+                [
+                    (item.id, world.id, _dump(item.to_dict()))
+                    for item in draft.residents
+                ],
             )
             if initial_oc is not None:
                 connection.execute(
@@ -185,7 +197,10 @@ class WorldRepository(RepositoryRecords):
                 event_id=f"outbox:{initial_event.id}",
                 world_id=world.id,
                 event_type="SceneBeatCommitted",
-                payload={"event": initial_event.to_dict(), "world_revision": world.revision},
+                payload={
+                    "event": initial_event.to_dict(),
+                    "world_revision": world.revision,
+                },
             )
             self._save_idempotency(connection, request_id, world.id, result)
 
@@ -347,7 +362,10 @@ class WorldRepository(RepositoryRecords):
                 event_id=f"outbox:{event.id}",
                 world_id=world_id,
                 event_type="SceneBeatCommitted",
-                payload={"event": event.to_dict(), "world_revision": event.committed_revision},
+                payload={
+                    "event": event.to_dict(),
+                    "world_revision": event.committed_revision,
+                },
             )
             self._save_idempotency(connection, request_id, world_id, result)
             return result
@@ -357,14 +375,31 @@ class WorldRepository(RepositoryRecords):
 
         with self._lock:
             rows = self._connection.execute(
-                "SELECT payload FROM player_ocs WHERE world_id = ? ORDER BY id", (world_id,)
+                "SELECT payload FROM player_ocs WHERE world_id = ? ORDER BY id",
+                (world_id,),
             ).fetchall()
-        values = []
-        for row in rows:
-            payload = _load(row["payload"], {})
-            payload["autonomy"] = AutonomyPolicy(**payload.get("autonomy", {}))
-            values.append(PlayerOC(**payload))
-        return values
+        return [self._row_to_oc(row) for row in rows]
+
+    def list_oc_memberships(
+        self, world_id: str, *, through_time: str | None = None
+    ) -> list[tuple[PlayerOC, str]]:
+        """Return OC records with their join time for deterministic world copies."""
+
+        query = "SELECT payload, joined_at FROM player_ocs WHERE world_id = ?"
+        params: list[Any] = [world_id]
+        if through_time is not None:
+            query += " AND joined_at <= ?"
+            params.append(through_time)
+        query += " ORDER BY id"
+        with self._lock:
+            rows = self._connection.execute(query, params).fetchall()
+        return [(self._row_to_oc(row), row["joined_at"]) for row in rows]
+
+    @staticmethod
+    def _row_to_oc(row: sqlite3.Row) -> PlayerOC:
+        payload = _load(row["payload"], {})
+        payload["autonomy"] = AutonomyPolicy(**payload.get("autonomy", {}))
+        return PlayerOC(**payload)
 
     def get_projection(self, world_id: str) -> WorldStateProjection:
         """Load the rebuildable current projection."""
@@ -578,7 +613,10 @@ class WorldRepository(RepositoryRecords):
                     event_id=f"outbox:{event.id}",
                     world_id=world_id,
                     event_type="SceneBeatCommitted",
-                    payload={"event": event.to_dict(), "world_revision": projection.revision},
+                    payload={
+                        "event": event.to_dict(),
+                        "world_revision": projection.revision,
+                    },
                 )
             self._save_idempotency(connection, request_id, world_id, result)
             return result

--- a/world_simulation/repository_records.py
+++ b/world_simulation/repository_records.py
@@ -4,13 +4,16 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from world_simulation.dependencies import DependencySet
 from world_simulation.errors import StaleWorldRevisionError, WorldNotFoundError
 from world_simulation.runs import WorldRun
 from world_simulation.timeline import TimelineEvent, WorldStateProjection
 from world_simulation.world import WorldInstance, utc_now
+
+if TYPE_CHECKING:
+    from world_simulation.repository import WorldRepository
 
 
 def _dump(value: Any) -> str:
@@ -78,6 +81,104 @@ class RepositoryRecords:
             ).fetchall()
             for row in rows:
                 event = self._row_to_event(row)
+                copied = TimelineEvent(
+                    **{
+                        **event.to_dict(),
+                        "world_id": target.id,
+                        "dependencies": event.dependencies,
+                    }
+                )
+                self._insert_event(connection, copied)
+            self._upsert_projection(connection, projection)
+            connection.execute(
+                """INSERT INTO world_presentation_sessions
+                VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    target.id,
+                    through_event.sequence,
+                    None,
+                    0,
+                    "awaiting_action",
+                    target.created_at,
+                ),
+            )
+            self._save_idempotency(connection, request_id, target.id, result)
+            self._insert_outbox(
+                connection,
+                event_id=f"outbox:world-copied:{target.id}",
+                world_id=target.id,
+                event_type="WorldCopied",
+                payload=result,
+            )
+            return result
+
+    def copy_world_prefix_from(
+        self,
+        source_repository: WorldRepository,
+        *,
+        source_world_id: str,
+        through_event: TimelineEvent,
+        target: WorldInstance,
+        projection: WorldStateProjection,
+        request_id: str,
+        result: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Copy a stable source prefix into this repository's target database."""
+
+        if source_repository is self:
+            return self.copy_world_prefix(
+                source_world_id=source_world_id,
+                through_event=through_event,
+                target=target,
+                projection=projection,
+                request_id=request_id,
+                result=result,
+            )
+        source_repository.require_world(source_world_id)
+        snapshots = source_repository.list_role_snapshots(source_world_id)
+        residents = source_repository.list_residents(source_world_id)
+        memberships = source_repository.list_oc_memberships(
+            source_world_id, through_time=through_event.effective_at
+        )
+        events = source_repository.list_events(
+            source_world_id, through_sequence=through_event.sequence
+        )
+
+        with self.transaction() as connection:
+            existing = self._idempotency_in(connection, request_id)
+            if existing is not None:
+                return existing
+            connection.execute(
+                "INSERT INTO worlds VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (
+                    target.id,
+                    target.owner_id,
+                    _dump(target.template_snapshot),
+                    target.current_time,
+                    target.revision,
+                    target.active_oc_id,
+                    target.parent_world_id,
+                    target.fork_event_id,
+                    target.random_state,
+                    target.created_at,
+                ),
+            )
+            connection.executemany(
+                "INSERT INTO role_snapshots VALUES (?, ?, ?)",
+                [(item.id, target.id, _dump(item.to_dict())) for item in snapshots],
+            )
+            connection.executemany(
+                "INSERT INTO residents VALUES (?, ?, ?)",
+                [(item.id, target.id, _dump(item.to_dict())) for item in residents],
+            )
+            connection.executemany(
+                "INSERT INTO player_ocs VALUES (?, ?, ?, ?)",
+                [
+                    (oc.id, target.id, _dump(oc.to_dict()), joined_at)
+                    for oc, joined_at in memberships
+                ],
+            )
+            for event in events:
                 copied = TimelineEvent(
                     **{
                         **event.to_dict(),

--- a/world_simulation/repository_records.py
+++ b/world_simulation/repository_records.py
@@ -4,13 +4,22 @@ from __future__ import annotations
 
 import json
 import sqlite3
-from typing import TYPE_CHECKING, Any
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any, Sequence
 
 from world_simulation.dependencies import DependencySet
 from world_simulation.errors import StaleWorldRevisionError, WorldNotFoundError
+from world_simulation.performance import compile_performance_plan, presentation_mode_for_event
+from world_simulation.presentation_session import WorldPresentationSession
 from world_simulation.runs import WorldRun
+from world_simulation.scenes import DecisionBarrier, SceneThread
 from world_simulation.timeline import TimelineEvent, WorldStateProjection
-from world_simulation.world import WorldInstance, utc_now
+from world_simulation.world import (
+    NativeResident,
+    RoleTemplateSnapshot,
+    WorldInstance,
+    utc_now,
+)
 
 if TYPE_CHECKING:
     from world_simulation.repository import WorldRepository
@@ -48,69 +57,76 @@ class RepositoryRecords:
             ).fetchone()
             if source is None:
                 raise WorldNotFoundError(f"world not found: {source_world_id}")
-            connection.execute(
-                "INSERT INTO worlds VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            snapshots = [
+                RoleTemplateSnapshot(**_load(row["payload"], {}))
+                for row in connection.execute(
+                    "SELECT payload FROM role_snapshots WHERE world_id = ? ORDER BY id",
+                    (source_world_id,),
+                ).fetchall()
+            ]
+            residents = [
+                NativeResident(**_load(row["payload"], {}))
+                for row in connection.execute(
+                    "SELECT payload FROM residents WHERE world_id = ? ORDER BY id",
+                    (source_world_id,),
+                ).fetchall()
+            ]
+            memberships = [
                 (
-                    target.id,
-                    target.owner_id,
-                    _dump(target.template_snapshot),
-                    target.current_time,
-                    target.revision,
-                    target.active_oc_id,
-                    target.parent_world_id,
-                    target.fork_event_id,
-                    target.random_state,
-                    target.created_at,
-                ),
-            )
-            for table in ("role_snapshots", "residents"):
-                connection.execute(
-                    f"INSERT INTO {table} SELECT id, ?, payload FROM {table} WHERE world_id = ?",
-                    (target.id, source_world_id),
+                    self._row_to_oc(row),
+                    row["joined_at"],
                 )
-            connection.execute(
-                """INSERT INTO player_ocs
-                SELECT id, ?, payload, joined_at FROM player_ocs
-                WHERE world_id = ? AND joined_at <= ?""",
-                (target.id, source_world_id, through_event.effective_at),
-            )
-            rows = connection.execute(
+                for row in connection.execute(
+                    """SELECT payload, joined_at FROM player_ocs
+                    WHERE world_id = ? AND joined_at <= ? ORDER BY id""",
+                    (source_world_id, through_event.effective_at),
+                ).fetchall()
+            ]
+            events = connection.execute(
                 """SELECT * FROM timeline_events WHERE world_id = ? AND sequence <= ?
                 ORDER BY sequence""",
                 (source_world_id, through_event.sequence),
             ).fetchall()
-            for row in rows:
-                event = self._row_to_event(row)
-                copied = TimelineEvent(
-                    **{
-                        **event.to_dict(),
-                        "world_id": target.id,
-                        "dependencies": event.dependencies,
-                    }
+            barriers = [
+                DecisionBarrier(**_load(row["payload"], {}))
+                for row in connection.execute(
+                    """SELECT payload FROM barriers
+                    WHERE world_id = ? AND effective_at <= ?
+                    ORDER BY effective_at, id""",
+                    (source_world_id, through_event.effective_at),
+                ).fetchall()
+            ]
+            scene_threads = [
+                thread
+                for thread in (
+                    SceneThread(**_load(row["payload"], {}))
+                    for row in connection.execute(
+                        "SELECT payload FROM scene_threads WHERE world_id = ?",
+                        (source_world_id,),
+                    ).fetchall()
                 )
-                self._insert_event(connection, copied)
-            self._upsert_projection(connection, projection)
-            connection.execute(
-                """INSERT INTO world_presentation_sessions
-                VALUES (?, ?, ?, ?, ?, ?)""",
-                (
-                    target.id,
-                    through_event.sequence,
-                    None,
-                    0,
-                    "awaiting_action",
-                    target.created_at,
-                ),
-            )
-            self._save_idempotency(connection, request_id, target.id, result)
-            self._insert_outbox(
+                if (
+                    thread.world_time <= through_event.effective_at
+                    and thread.beat_sequence <= through_event.sequence
+                )
+            ]
+            presentation_session = self.get_presentation_session(source_world_id)
+            return self._copy_world_prefix_in(
                 connection,
-                event_id=f"outbox:world-copied:{target.id}",
-                world_id=target.id,
-                event_type="WorldCopied",
-                payload=result,
+                source_world_id=source_world_id,
+                through_event=through_event,
+                target=target,
+                projection=projection,
+                request_id=request_id,
+                result=result,
+                snapshots=snapshots,
+                residents=residents,
+                memberships=memberships,
+                events=[self._row_to_event(row) for row in events],
+                barriers=barriers,
+                scene_threads=scene_threads,
+                presentation_session=presentation_session,
             )
-            return result
 
     def copy_world_prefix_from(
         self,
@@ -143,72 +159,217 @@ class RepositoryRecords:
         events = source_repository.list_events(
             source_world_id, through_sequence=through_event.sequence
         )
+        barriers = source_repository.list_barriers(
+            source_world_id, through_time=through_event.effective_at
+        )
+        scene_threads = source_repository.list_scene_threads(
+            source_world_id,
+            through_time=through_event.effective_at,
+            through_sequence=through_event.sequence,
+        )
+        presentation_session = source_repository.get_presentation_session(
+            source_world_id
+        )
 
         with self.transaction() as connection:
             existing = self._idempotency_in(connection, request_id)
             if existing is not None:
                 return existing
-            connection.execute(
-                "INSERT INTO worlds VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                (
-                    target.id,
-                    target.owner_id,
-                    _dump(target.template_snapshot),
-                    target.current_time,
-                    target.revision,
-                    target.active_oc_id,
-                    target.parent_world_id,
-                    target.fork_event_id,
-                    target.random_state,
-                    target.created_at,
-                ),
-            )
-            connection.executemany(
-                "INSERT INTO role_snapshots VALUES (?, ?, ?)",
-                [(item.id, target.id, _dump(item.to_dict())) for item in snapshots],
-            )
-            connection.executemany(
-                "INSERT INTO residents VALUES (?, ?, ?)",
-                [(item.id, target.id, _dump(item.to_dict())) for item in residents],
-            )
-            connection.executemany(
-                "INSERT INTO player_ocs VALUES (?, ?, ?, ?)",
-                [
-                    (oc.id, target.id, _dump(oc.to_dict()), joined_at)
-                    for oc, joined_at in memberships
-                ],
-            )
-            for event in events:
-                copied = TimelineEvent(
-                    **{
-                        **event.to_dict(),
-                        "world_id": target.id,
-                        "dependencies": event.dependencies,
-                    }
-                )
-                self._insert_event(connection, copied)
-            self._upsert_projection(connection, projection)
-            connection.execute(
-                """INSERT INTO world_presentation_sessions
-                VALUES (?, ?, ?, ?, ?, ?)""",
-                (
-                    target.id,
-                    through_event.sequence,
-                    None,
-                    0,
-                    "awaiting_action",
-                    target.created_at,
-                ),
-            )
-            self._save_idempotency(connection, request_id, target.id, result)
-            self._insert_outbox(
+            return self._copy_world_prefix_in(
                 connection,
-                event_id=f"outbox:world-copied:{target.id}",
-                world_id=target.id,
-                event_type="WorldCopied",
-                payload=result,
+                source_world_id=source_world_id,
+                through_event=through_event,
+                target=target,
+                projection=projection,
+                request_id=request_id,
+                result=result,
+                snapshots=snapshots,
+                residents=residents,
+                memberships=memberships,
+                events=events,
+                barriers=barriers,
+                scene_threads=scene_threads,
+                presentation_session=presentation_session,
             )
-            return result
+
+    def _copy_world_prefix_in(
+        self,
+        connection: sqlite3.Connection,
+        *,
+        source_world_id: str,
+        through_event: TimelineEvent,
+        target: WorldInstance,
+        projection: WorldStateProjection,
+        request_id: str,
+        result: dict[str, Any],
+        snapshots: Sequence[RoleTemplateSnapshot],
+        residents: Sequence[NativeResident],
+        memberships: Sequence[tuple[Any, str]],
+        events: Sequence[TimelineEvent],
+        barriers: Sequence[DecisionBarrier],
+        scene_threads: Sequence[SceneThread],
+        presentation_session: WorldPresentationSession | None,
+    ) -> dict[str, Any]:
+        """Write one copied prefix while the caller owns the target transaction."""
+
+        connection.execute(
+            "INSERT INTO worlds VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (
+                target.id,
+                target.owner_id,
+                _dump(target.template_snapshot),
+                target.current_time,
+                target.revision,
+                target.active_oc_id,
+                target.parent_world_id,
+                target.fork_event_id,
+                target.random_state,
+                target.created_at,
+            ),
+        )
+        connection.executemany(
+            "INSERT INTO role_snapshots VALUES (?, ?, ?)",
+            [(item.id, target.id, _dump(item.to_dict())) for item in snapshots],
+        )
+        connection.executemany(
+            "INSERT INTO residents VALUES (?, ?, ?)",
+            [(item.id, target.id, _dump(item.to_dict())) for item in residents],
+        )
+        connection.executemany(
+            "INSERT INTO player_ocs VALUES (?, ?, ?, ?)",
+            [
+                (oc.id, target.id, _dump(oc.to_dict()), joined_at)
+                for oc, joined_at in memberships
+            ],
+        )
+        copied_events = [
+            TimelineEvent(
+                **{
+                    **event.to_dict(),
+                    "world_id": target.id,
+                    "dependencies": event.dependencies,
+                }
+            )
+            for event in events
+        ]
+        for event in copied_events:
+            self._insert_event(connection, event)
+        for barrier in barriers:
+            copied = replace(barrier, world_id=target.id)
+            connection.execute(
+                "INSERT INTO barriers VALUES (?, ?, ?, ?, ?)",
+                (
+                    copied.id,
+                    target.id,
+                    copied.effective_at,
+                    copied.status,
+                    _dump(copied.to_dict()),
+                ),
+            )
+        for thread in scene_threads:
+            copied = replace(thread, world_id=target.id)
+            connection.execute(
+                "INSERT INTO scene_threads VALUES (?, ?, ?)",
+                (copied.id, target.id, _dump(copied.to_dict())),
+            )
+        self._upsert_projection(connection, projection)
+        copied_session = self._copy_presentation_session(
+            presentation_session,
+            target.id,
+            through_event.sequence,
+            events,
+            copied_events,
+            barriers,
+        )
+        connection.execute(
+            """INSERT INTO world_presentation_sessions
+            VALUES (?, ?, ?, ?, ?, ?)""",
+            (
+                copied_session.world_id,
+                copied_session.last_presented_event_sequence,
+                copied_session.active_plan_id,
+                copied_session.active_cue_index,
+                copied_session.status,
+                copied_session.updated_at,
+            ),
+        )
+        self._save_idempotency(connection, request_id, target.id, result)
+        self._insert_outbox(
+            connection,
+            event_id=f"outbox:world-copied:{target.id}",
+            world_id=target.id,
+            event_type="WorldCopied",
+            payload=result,
+        )
+        return result
+
+    @staticmethod
+    def _copy_presentation_session(
+        source: WorldPresentationSession | None,
+        target_world_id: str,
+        anchor_sequence: int,
+        source_events: Sequence[TimelineEvent],
+        target_events: Sequence[TimelineEvent],
+        barriers: Sequence[DecisionBarrier],
+    ) -> WorldPresentationSession:
+        """Clamp and remap a derived presentation cursor to the copied prefix."""
+
+        source_missing = source is None
+        source = source or WorldPresentationSession(world_id=target_world_id)
+        use_anchor_baseline = (
+            source_missing
+            or source.last_presented_event_sequence == 0
+            and source.active_plan_id is None
+            and source.status == "playing"
+        )
+        active_plan_id = None
+        active_cue_index = 0
+        if source.active_plan_id and not use_anchor_baseline:
+            source_event = next(
+                (
+                    event
+                    for event in source_events
+                    if event.sequence <= anchor_sequence
+                    and presentation_mode_for_event(event) == "scene"
+                    and compile_performance_plan(event).id == source.active_plan_id
+                ),
+                None,
+            )
+            if source_event is not None:
+                target_event = next(
+                    event
+                    for event in target_events
+                    if event.sequence == source_event.sequence
+                )
+                active_plan_id = compile_performance_plan(target_event).id
+                active_cue_index = source.active_cue_index
+        last_presented = (
+            anchor_sequence
+            if use_anchor_baseline
+            else min(source.last_presented_event_sequence, anchor_sequence)
+        )
+        has_unpresented_scene = any(
+            event.sequence > last_presented
+            and event.sequence <= anchor_sequence
+            and presentation_mode_for_event(event) == "scene"
+            for event in target_events
+        )
+        if source.status == "paused":
+            status = "paused"
+        elif active_plan_id or has_unpresented_scene:
+            status = "playing"
+        elif any(item.status == "pending" for item in barriers):
+            status = "awaiting_barrier"
+        else:
+            status = "awaiting_action"
+        return replace(
+            source,
+            world_id=target_world_id,
+            last_presented_event_sequence=last_presented,
+            active_plan_id=active_plan_id,
+            active_cue_index=active_cue_index,
+            status=status,
+        )
 
     def _assert_revision(
         self, connection: sqlite3.Connection, world_id: str, expected: int

--- a/world_simulation/service.py
+++ b/world_simulation/service.py
@@ -8,6 +8,7 @@ from uuid import uuid4
 
 from world_simulation.actors import PlayerOC
 from world_simulation.dependencies import DependencySet
+from world_simulation.drafts import create_world_draft
 from world_simulation.errors import HistoricalConflictError, WorldNotFoundError
 from world_simulation.proposals import BeatProposal
 from world_simulation.repository import WorldRepository
@@ -43,17 +44,14 @@ class WorldSimulationService:
     ) -> WorldDraft:
         """Persist a reviewable draft without creating any world timeline facts."""
 
-        snapshot_ids = {item.id for item in role_snapshots}
-        if any(item.snapshot_id not in snapshot_ids for item in residents):
-            raise ValueError("every resident must reference a snapshot in the draft")
-        draft = WorldDraft(
-            id=draft_id or f"draft-{uuid4().hex}",
+        draft = create_world_draft(
             owner_id=owner_id,
             template=template,
             role_snapshots=role_snapshots,
             residents=residents,
             initial_time=initial_time,
-            creation_metadata=dict(creation_metadata or {}),
+            creation_metadata=creation_metadata,
+            draft_id=draft_id,
         )
         self.repository.save_draft(draft)
         return draft
@@ -309,12 +307,14 @@ class WorldSimulationService:
         *,
         request_id: str,
         new_world_id: str | None = None,
+        target_repository: WorldRepository | None = None,
     ) -> WorldInstance:
         """Copy a committed timeline prefix into an independently evolving world."""
 
-        existing = self.repository.get_idempotency_result(request_id)
+        target_store = target_repository or self.repository
+        existing = target_store.get_idempotency_result(request_id)
         if existing is not None:
-            return self.repository.require_world(str(existing["world_id"]))
+            return target_store.require_world(str(existing["world_id"]))
         source = self.repository.require_world(source_world_id)
         event = self.repository.get_event(source_world_id, event_id)
         if event is None:
@@ -345,7 +345,8 @@ class WorldSimulationService:
             "fork_event_id": event_id,
             "world_revision": event.committed_revision,
         }
-        self.repository.copy_world_prefix(
+        target_store.copy_world_prefix_from(
+            self.repository,
             source_world_id=source_world_id,
             through_event=event,
             target=target,
@@ -353,7 +354,7 @@ class WorldSimulationService:
             request_id=request_id,
             result=result,
         )
-        return self.repository.require_world(target_id)
+        return target_store.require_world(target_id)
 
     def cancel_run(self, run_id: str) -> WorldRun:
         """Prevent a run from starting another beat while preserving committed facts."""


### PR DESCRIPTION
Relates to #39.

Summary: isolate each persistent world into worlds/<world_id>/world.db with worlds/catalog.db for drafts, discovery summaries, idempotency, and durable creation intents. Retire the legacy workspace worlds.db and its SQLite sidecars. Recover committed world databases after a crash between world-db commit and catalog registration, and remove incomplete intent artifacts on startup. World prefix copies now share one transaction writer and preserve anchor-bounded DecisionBarrier, SceneThread, and presentation cursor state across databases.

Validation:
- `python -m pytest tests/world_simulation tests/desktop_bridge/test_world_simulation_handler.py -q` (37 passed)
- `.venv\Scripts\ruff.exe check` on all changed Python sources/tests (passed)
- `git diff --check` (passed)
- `graphify update .` (completed)

Known blockers: real Electron runtime, production packaging, and provider/hardware validation were not run; no remote PR checks are currently reported.