### PR TITLE
feat(plugin): 建立 Organization 发现与 Release 原子安装

### DIFF
--- a/agent/config.py
+++ b/agent/config.py
@@ -22,6 +22,7 @@ from agent.config_models import (
     MemoryEmbeddingConfig,
     ModelRegistration,
     NovelAISettings,
+    PluginDistributionConfig,
     QQChannelConfig,
     TelegramChannelConfig,
     WiringConfig,
@@ -32,6 +33,7 @@ from proactive_v2.config import ProactiveConfig
 from proactive_v2.config_loader import ProactiveConfigError, load_proactive_config
 
 logger = logging.getLogger(__name__)
+
 
 def _validated_timezone(tz_name: str, *, enabled: bool) -> str:
     """仅当 anyaction_enabled=True 时校验时区合法性，无效则启动时 fail-fast。"""
@@ -66,6 +68,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
     novelai = _load_novelai_config(data)
     voice = _load_voice_config(data)
     wiring = _load_wiring_config(data)
+    plugin_distribution = _load_plugin_distribution_config(data)
     plugins = _load_plugins_config(data)
     model_registrations = _load_model_registrations(data)
     primary_registration = model_registrations[0]
@@ -105,16 +108,12 @@ def load_config(path: str | Path = "config.toml") -> Config:
         light_api_key=_resolve(
             str(llm_fast.get("api_key") or data.get("light_api_key", ""))
         ),
-        light_base_url=str(
-            llm_fast.get("base_url") or data.get("light_base_url", "")
-        ),
+        light_base_url=str(llm_fast.get("base_url") or data.get("light_base_url", "")),
         agent_model=str(llm_agent.get("model") or data.get("agent_model", "")),
         agent_api_key=_resolve(
             str(llm_agent.get("api_key") or data.get("agent_api_key", ""))
         ),
-        agent_base_url=str(
-            llm_agent.get("base_url") or data.get("agent_base_url", "")
-        ),
+        agent_base_url=str(llm_agent.get("base_url") or data.get("agent_base_url", "")),
         memory=memory,
         tool_search_enabled=bool(
             agent_tools.get("search_enabled", data.get("tool_search_enabled", False))
@@ -138,6 +137,7 @@ def load_config(path: str | Path = "config.toml") -> Config:
         novelai=novelai,
         voice=voice,
         wiring=wiring,
+        plugin_distribution=plugin_distribution,
         plugins=plugins,
         model_registrations=model_registrations,
     )
@@ -279,7 +279,9 @@ def _load_novelai_config(data: dict) -> NovelAISettings:
         max_steps=int(raw.get("max_steps", defaults.max_steps)),
         default_samples=int(raw.get("default_samples", defaults.default_samples)),
         add_quality_tags=bool(raw.get("add_quality_tags", defaults.add_quality_tags)),
-        undesired_content_preset=int(raw.get("undesired_content_preset", defaults.undesired_content_preset)),
+        undesired_content_preset=int(
+            raw.get("undesired_content_preset", defaults.undesired_content_preset)
+        ),
     )
 
 
@@ -294,14 +296,20 @@ def _load_voice_config(data: dict) -> VoiceConfig:
         asr=VoiceAsrConfig(
             enabled=bool(asr.get("enabled", False)),
             provider=str(asr.get("provider", "tencent") or "tencent"),
-            base_url=str(asr.get("base_url", "https://asr.tencentcloudapi.com/") or "https://asr.tencentcloudapi.com/"),
+            base_url=str(
+                asr.get("base_url", "https://asr.tencentcloudapi.com/")
+                or "https://asr.tencentcloudapi.com/"
+            ),
             secret_id=_resolve(str(asr.get("secret_id", ""))),
             secret_key=_resolve(str(asr.get("secret_key", ""))),
         ),
         tts=VoiceTtsConfig(
             enabled=bool(tts.get("enabled", False)),
             provider=str(tts.get("provider", "minimax") or "minimax"),
-            base_url=str(tts.get("base_url", "https://api.minimaxi.com/v1/t2a_v2") or "https://api.minimaxi.com/v1/t2a_v2"),
+            base_url=str(
+                tts.get("base_url", "https://api.minimaxi.com/v1/t2a_v2")
+                or "https://api.minimaxi.com/v1/t2a_v2"
+            ),
             model=str(tts.get("model", "speech-2.8-turbo") or "speech-2.8-turbo"),
             api_key=_resolve(str(tts.get("api_key", ""))),
             volume=float(tts.get("volume", 2.0)),
@@ -332,6 +340,20 @@ def _load_plugins_config(data: dict) -> dict[str, dict[str, Any]]:
         if isinstance(name, str) and isinstance(value, dict):
             plugins[name] = cast(dict[str, Any], _resolve_config_value(value))
     return plugins
+
+
+def _load_plugin_distribution_config(data: dict) -> PluginDistributionConfig:
+    raw = _as_dict(data.get("plugin_distribution"))
+    organization = str(raw.get("organization") or "Shiori-Plugins").strip()
+    if not organization:
+        raise ValueError("plugin_distribution.organization 不能为空")
+    api_version = int(raw.get("api_version", 1))
+    if api_version < 1:
+        raise ValueError("plugin_distribution.api_version 必须大于 0")
+    return PluginDistributionConfig(
+        organization=organization,
+        api_version=api_version,
+    )
 
 
 def _reject_removed_runtime_config(data: dict) -> None:

--- a/agent/config_models.py
+++ b/agent/config_models.py
@@ -73,6 +73,14 @@ class WiringConfig:
     )
 
 
+@dataclass(frozen=True)
+class PluginDistributionConfig:
+    """Source and compatibility settings for independently packaged plugins."""
+
+    organization: str = "Shiori-Plugins"
+    api_version: int = 1
+
+
 @dataclass
 class Config:
     provider: str
@@ -105,15 +113,16 @@ class Config:
     novelai: NovelAISettings = field(default_factory=NovelAISettings)
     voice: VoiceConfig = field(default_factory=VoiceConfig)
     wiring: WiringConfig = field(default_factory=WiringConfig)
+    plugin_distribution: PluginDistributionConfig = field(
+        default_factory=PluginDistributionConfig
+    )
     plugins: dict[str, dict[str, Any]] = field(default_factory=dict)
     model_registrations: list[ModelRegistration] = field(default_factory=list)
 
     def __post_init__(self) -> None:
         if self.model_registrations:
             return
-        stable_key = "|".join(
-            [self.provider, str(self.base_url or ""), self.model]
-        )
+        stable_key = "|".join([self.provider, str(self.base_url or ""), self.model])
         self.model_registrations = [
             ModelRegistration(
                 id=str(uuid.uuid5(uuid.NAMESPACE_URL, stable_key)),

--- a/agent/plugin_packages/__init__.py
+++ b/agent/plugin_packages/__init__.py
@@ -1,0 +1,26 @@
+"""Independent plugin discovery and package installation contracts."""
+
+from agent.plugin_packages.catalog import GitHubPluginCatalog
+from agent.plugin_packages.contracts import (
+    HOST_PLUGIN_API_VERSION,
+    PLUGIN_REPOSITORY_MANIFEST_PATH,
+    PluginCatalogEntry,
+    PluginManifest,
+    PluginManifestError,
+    PluginRelease,
+)
+from agent.plugin_packages.installer import InstalledPlugin, PluginPackageInstaller
+from agent.plugin_packages.service import PluginPackageService
+
+__all__ = [
+    "GitHubPluginCatalog",
+    "HOST_PLUGIN_API_VERSION",
+    "InstalledPlugin",
+    "PLUGIN_REPOSITORY_MANIFEST_PATH",
+    "PluginCatalogEntry",
+    "PluginManifest",
+    "PluginManifestError",
+    "PluginPackageInstaller",
+    "PluginPackageService",
+    "PluginRelease",
+]

--- a/agent/plugin_packages/catalog.py
+++ b/agent/plugin_packages/catalog.py
@@ -1,0 +1,219 @@
+from __future__ import annotations
+
+import base64
+import os
+from collections.abc import Mapping
+from typing import Any, Protocol
+from urllib.parse import quote
+
+import httpx
+
+from agent.plugin_packages.contracts import (
+    HOST_PLUGIN_API_VERSION,
+    PLUGIN_REPOSITORY_MANIFEST_PATH,
+    PluginCatalogEntry,
+    PluginManifest,
+    PluginManifestError,
+    PluginRelease,
+    current_host_platform,
+)
+
+
+class HttpGetter(Protocol):
+    """Minimal asynchronous HTTP contract required by the GitHub catalog."""
+
+    async def get(self, url: str, **kwargs: Any) -> httpx.Response: ...
+
+
+class GitHubPluginCatalog:
+    """Discovers installable plugin releases from one GitHub Organization."""
+
+    def __init__(
+        self,
+        requester: HttpGetter,
+        *,
+        organization: str,
+        api_version: int = HOST_PLUGIN_API_VERSION,
+        os_name: str | None = None,
+        arch: str | None = None,
+        token: str | None = None,
+    ) -> None:
+        clean_organization = organization.strip()
+        if not clean_organization:
+            raise ValueError("plugin organization is required")
+        host_os, host_arch = current_host_platform()
+        self._requester = requester
+        self._organization = clean_organization
+        self._api_version = api_version
+        self._os_name = os_name or host_os
+        self._arch = arch or host_arch
+        self._token = token or os.getenv("GITHUB_TOKEN") or os.getenv("GH_TOKEN")
+
+    async def list_plugins(self) -> list[PluginCatalogEntry]:
+        """Returns repositories containing a valid plugin manifest."""
+
+        repositories = await self._list_repositories()
+        entries: list[PluginCatalogEntry] = []
+        for repository in repositories:
+            entry = await self._load_repository(repository)
+            if entry is not None:
+                entries.append(entry)
+        return sorted(
+            entries, key=lambda item: (item.manifest.name.lower(), item.repository)
+        )
+
+    async def get_plugin(self, repository: str) -> PluginCatalogEntry:
+        """Loads one named repository and fails when it is not a valid plugin."""
+
+        clean_repository = repository.strip()
+        expected_prefix = f"{self._organization}/"
+        full_name = (
+            clean_repository
+            if "/" in clean_repository
+            else f"{self._organization}/{clean_repository}"
+        )
+        if not full_name.startswith(expected_prefix) or full_name.count("/") != 1:
+            raise ValueError(
+                "plugin repository must belong to the configured organization"
+            )
+        response = await self._get(f"https://api.github.com/repos/{full_name}")
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, Mapping):
+            raise ValueError("GitHub repository response must be an object")
+        entry = await self._load_repository(payload, require_manifest=True)
+        if entry is None:
+            raise ValueError(f"repository is not a valid plugin: {full_name}")
+        return entry
+
+    async def _list_repositories(self) -> list[Mapping[str, Any]]:
+        repositories: list[Mapping[str, Any]] = []
+        page = 1
+        while True:
+            response = await self._get(
+                f"https://api.github.com/orgs/{quote(self._organization, safe='')}/repos",
+                params={"type": "public", "per_page": 100, "page": page},
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if not isinstance(payload, list):
+                raise ValueError("GitHub Organization repositories must be an array")
+            batch = [item for item in payload if isinstance(item, Mapping)]
+            repositories.extend(batch)
+            if len(payload) < 100:
+                return repositories
+            page += 1
+
+    async def _load_repository(
+        self,
+        repository: Mapping[str, Any],
+        *,
+        require_manifest: bool = False,
+    ) -> PluginCatalogEntry | None:
+        full_name = str(repository.get("full_name") or "").strip()
+        repository_url = str(repository.get("html_url") or "").strip()
+        if not full_name:
+            return None
+        manifest_response = await self._get(
+            f"https://api.github.com/repos/{full_name}/contents/"
+            f"{quote(PLUGIN_REPOSITORY_MANIFEST_PATH, safe='/')}"
+        )
+        if manifest_response.status_code == 404 and not require_manifest:
+            return None
+        manifest_response.raise_for_status()
+        manifest = self._decode_manifest(manifest_response, repository=full_name)
+        if not manifest.supports_host(
+            os_name=self._os_name,
+            arch=self._arch,
+            api_version=self._api_version,
+        ):
+            return PluginCatalogEntry(
+                repository=full_name,
+                repository_url=repository_url,
+                manifest=manifest,
+                release=None,
+                unavailable_reason="incompatible_host",
+            )
+        release, reason = await self._latest_release(full_name, manifest)
+        return PluginCatalogEntry(
+            repository=full_name,
+            repository_url=repository_url,
+            manifest=manifest,
+            release=release,
+            unavailable_reason=reason,
+        )
+
+    def _decode_manifest(
+        self,
+        response: httpx.Response,
+        *,
+        repository: str,
+    ) -> PluginManifest:
+        payload = response.json()
+        if not isinstance(payload, Mapping) or payload.get("encoding") != "base64":
+            raise PluginManifestError(
+                f"GitHub manifest response is not base64 content: {repository}"
+            )
+        encoded = payload.get("content")
+        if not isinstance(encoded, str):
+            raise PluginManifestError(
+                f"GitHub manifest content is missing: {repository}"
+            )
+        try:
+            raw = base64.b64decode(encoded, validate=False)
+        except ValueError as exc:
+            raise PluginManifestError(
+                f"GitHub manifest content is invalid base64: {repository}"
+            ) from exc
+        return PluginManifest.from_json_bytes(
+            raw,
+            source=f"{repository}/{PLUGIN_REPOSITORY_MANIFEST_PATH}",
+        )
+
+    async def _latest_release(
+        self,
+        repository: str,
+        manifest: PluginManifest,
+    ) -> tuple[PluginRelease | None, str | None]:
+        response = await self._get(
+            f"https://api.github.com/repos/{repository}/releases/latest"
+        )
+        if response.status_code == 404:
+            return None, "release_not_found"
+        response.raise_for_status()
+        payload = response.json()
+        if not isinstance(payload, Mapping):
+            raise ValueError("GitHub release response must be an object")
+        tag = str(payload.get("tag_name") or "").strip()
+        if tag.lstrip("v") != manifest.version:
+            return None, "release_version_mismatch"
+        raw_assets = payload.get("assets")
+        if not isinstance(raw_assets, list):
+            return None, "release_assets_missing"
+        assets = {
+            str(item.get("name") or ""): str(item.get("browser_download_url") or "")
+            for item in raw_assets
+            if isinstance(item, Mapping)
+        }
+        package_url = assets.get(manifest.release.asset, "")
+        checksums_url = assets.get(manifest.release.checksums_asset, "")
+        if not package_url or not checksums_url:
+            return None, "release_assets_missing"
+        return (
+            PluginRelease(
+                tag=tag,
+                package_url=package_url,
+                checksums_url=checksums_url,
+            ),
+            None,
+        )
+
+    async def _get(self, url: str, **kwargs: Any) -> httpx.Response:
+        headers = {
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+            "User-Agent": "Shiori-Desktop-Plugin-Installer",
+        }
+        if self._token:
+            headers["Authorization"] = f"Bearer {self._token}"
+        return await self._requester.get(url, headers=headers, **kwargs)

--- a/agent/plugin_packages/contracts.py
+++ b/agent/plugin_packages/contracts.py
@@ -1,0 +1,316 @@
+from __future__ import annotations
+
+import json
+import platform
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any, Mapping
+
+PLUGIN_REPOSITORY_MANIFEST_PATH = ".akashic-plugin/plugin.json"
+HOST_PLUGIN_API_VERSION = 1
+_PLUGIN_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{1,63}$")
+_VERSION_PATTERN = re.compile(
+    r"^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)"
+    r"(?:-[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?"
+    r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
+)
+_CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+$")
+
+
+class PluginManifestError(ValueError):
+    """Raised when a repository or packaged plugin manifest is invalid."""
+
+
+@dataclass(frozen=True)
+class PluginPlatform:
+    """One operating-system and CPU pair supported by a plugin release."""
+
+    os: str
+    arch: str
+
+
+@dataclass(frozen=True)
+class PluginEntrypoints:
+    """Runtime entrypoints contained inside the installed plugin package."""
+
+    backend: str | None
+    desktop: str | None
+
+
+@dataclass(frozen=True)
+class PluginReleaseContract:
+    """Release asset names used to install one plugin version."""
+
+    asset: str
+    checksums_asset: str
+
+
+@dataclass(frozen=True)
+class PluginManifest:
+    """Validated public contract shared by repository and release manifests."""
+
+    schema_version: int
+    plugin_id: str
+    name: str
+    description: str
+    version: str
+    plugin_api_version: int
+    platforms: tuple[PluginPlatform, ...]
+    entrypoints: PluginEntrypoints
+    capabilities: tuple[str, ...]
+    permissions: tuple[str, ...]
+    release: PluginReleaseContract
+
+    @classmethod
+    def from_json_bytes(cls, raw: bytes, *, source: str) -> "PluginManifest":
+        """Decodes and validates a UTF-8 plugin manifest."""
+
+        try:
+            value = json.loads(raw.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+            raise PluginManifestError(
+                f"plugin manifest is not valid UTF-8 JSON: {source}"
+            ) from exc
+        if not isinstance(value, Mapping):
+            raise PluginManifestError(f"plugin manifest must be an object: {source}")
+        return cls.from_mapping(value, source=source)
+
+    @classmethod
+    def from_mapping(
+        cls,
+        value: Mapping[str, Any],
+        *,
+        source: str,
+    ) -> "PluginManifest":
+        """Validates a decoded plugin manifest mapping."""
+
+        schema_version = _required_int(value, "schema_version", source=source)
+        if schema_version != 1:
+            raise PluginManifestError(
+                f"unsupported plugin manifest schema_version {schema_version}: {source}"
+            )
+        plugin_id = _required_string(value, "plugin_id", source=source)
+        if not _PLUGIN_ID_PATTERN.fullmatch(plugin_id):
+            raise PluginManifestError(f"invalid plugin_id {plugin_id!r}: {source}")
+        version = _required_string(value, "version", source=source)
+        if not _VERSION_PATTERN.fullmatch(version):
+            raise PluginManifestError(f"invalid semantic version {version!r}: {source}")
+        plugin_api_version = _required_int(
+            value,
+            "plugin_api_version",
+            source=source,
+        )
+        raw_platforms = value.get("platforms")
+        if not isinstance(raw_platforms, list) or not raw_platforms:
+            raise PluginManifestError(f"platforms must be a non-empty array: {source}")
+        platforms = tuple(
+            _parse_platform(item, source=source) for item in raw_platforms
+        )
+        entrypoints = _parse_entrypoints(value.get("entrypoints"), source=source)
+        capabilities = _string_tuple(
+            value.get("capabilities", []),
+            field="capabilities",
+            source=source,
+            pattern=_CAPABILITY_PATTERN,
+        )
+        permissions = _string_tuple(
+            value.get("permissions", []),
+            field="permissions",
+            source=source,
+            pattern=_CAPABILITY_PATTERN,
+        )
+        release = _parse_release(value.get("release"), source=source)
+        return cls(
+            schema_version=schema_version,
+            plugin_id=plugin_id,
+            name=_required_string(value, "name", source=source),
+            description=str(value.get("description") or "").strip(),
+            version=version,
+            plugin_api_version=plugin_api_version,
+            platforms=platforms,
+            entrypoints=entrypoints,
+            capabilities=capabilities,
+            permissions=permissions,
+            release=release,
+        )
+
+    def supports_host(self, *, os_name: str, arch: str, api_version: int) -> bool:
+        """Returns whether this manifest supports one concrete Shiori host."""
+
+        return self.plugin_api_version == api_version and any(
+            item.os == os_name and item.arch == arch for item in self.platforms
+        )
+
+    def to_dict(self) -> dict[str, object]:
+        """Serializes the validated manifest for installed registry records."""
+
+        return {
+            "schema_version": self.schema_version,
+            "plugin_id": self.plugin_id,
+            "name": self.name,
+            "description": self.description,
+            "version": self.version,
+            "plugin_api_version": self.plugin_api_version,
+            "platforms": [
+                {"os": item.os, "arch": item.arch} for item in self.platforms
+            ],
+            "entrypoints": {
+                **(
+                    {"backend": self.entrypoints.backend}
+                    if self.entrypoints.backend
+                    else {}
+                ),
+                **(
+                    {"desktop": self.entrypoints.desktop}
+                    if self.entrypoints.desktop
+                    else {}
+                ),
+            },
+            "capabilities": list(self.capabilities),
+            "permissions": list(self.permissions),
+            "release": {
+                "asset": self.release.asset,
+                "checksums_asset": self.release.checksums_asset,
+            },
+        }
+
+
+@dataclass(frozen=True)
+class PluginRelease:
+    """Resolved GitHub Release assets for one installable plugin version."""
+
+    tag: str
+    package_url: str
+    checksums_url: str
+
+
+@dataclass(frozen=True)
+class PluginCatalogEntry:
+    """One repository plugin and its latest compatible release, when available."""
+
+    repository: str
+    repository_url: str
+    manifest: PluginManifest
+    release: PluginRelease | None
+    unavailable_reason: str | None = None
+
+    @property
+    def installable(self) -> bool:
+        """Returns whether this catalog entry can be installed now."""
+
+        return self.release is not None and self.unavailable_reason is None
+
+
+def current_host_platform() -> tuple[str, str]:
+    """Returns normalized platform identifiers used by plugin manifests."""
+
+    os_name = {"win32": "win32", "darwin": "darwin"}.get(sys.platform, "linux")
+    machine = platform.machine().lower()
+    arch = {
+        "amd64": "x64",
+        "x86_64": "x64",
+        "aarch64": "arm64",
+        "arm64": "arm64",
+    }.get(machine, machine)
+    return os_name, arch
+
+
+def _required_string(value: Mapping[str, Any], field: str, *, source: str) -> str:
+    raw = value.get(field)
+    if not isinstance(raw, str) or not raw.strip():
+        raise PluginManifestError(f"{field} must be a non-empty string: {source}")
+    return raw.strip()
+
+
+def _required_int(value: Mapping[str, Any], field: str, *, source: str) -> int:
+    raw = value.get(field)
+    if isinstance(raw, bool) or not isinstance(raw, int):
+        raise PluginManifestError(f"{field} must be an integer: {source}")
+    return raw
+
+
+def _safe_package_path(value: str, *, field: str, source: str) -> str:
+    path = PurePosixPath(value)
+    if (
+        not value
+        or "\\" in value
+        or path.is_absolute()
+        or ".." in path.parts
+        or path == "."
+        or (path.parts and path.parts[0].endswith(":"))
+    ):
+        raise PluginManifestError(f"{field} contains an unsafe path: {source}")
+    return path.as_posix()
+
+
+def _parse_platform(value: object, *, source: str) -> PluginPlatform:
+    if not isinstance(value, Mapping):
+        raise PluginManifestError(f"platform entries must be objects: {source}")
+    return PluginPlatform(
+        os=_required_string(value, "os", source=source),
+        arch=_required_string(value, "arch", source=source),
+    )
+
+
+def _parse_entrypoints(value: object, *, source: str) -> PluginEntrypoints:
+    if not isinstance(value, Mapping):
+        raise PluginManifestError(f"entrypoints must be an object: {source}")
+    backend = value.get("backend")
+    desktop = value.get("desktop")
+    parsed_backend = (
+        _safe_package_path(backend.strip(), field="entrypoints.backend", source=source)
+        if isinstance(backend, str) and backend.strip()
+        else None
+    )
+    parsed_desktop = (
+        _safe_package_path(desktop.strip(), field="entrypoints.desktop", source=source)
+        if isinstance(desktop, str) and desktop.strip()
+        else None
+    )
+    if parsed_backend is None and parsed_desktop is None:
+        raise PluginManifestError(
+            f"at least one plugin entrypoint is required: {source}"
+        )
+    return PluginEntrypoints(backend=parsed_backend, desktop=parsed_desktop)
+
+
+def _parse_release(value: object, *, source: str) -> PluginReleaseContract:
+    if not isinstance(value, Mapping):
+        raise PluginManifestError(f"release must be an object: {source}")
+    asset = _safe_package_path(
+        _required_string(value, "asset", source=source),
+        field="release.asset",
+        source=source,
+    )
+    checksums_asset = _safe_package_path(
+        _required_string(value, "checksums_asset", source=source),
+        field="release.checksums_asset",
+        source=source,
+    )
+    if "/" in asset or "/" in checksums_asset:
+        raise PluginManifestError(
+            f"release asset names cannot contain directories: {source}"
+        )
+    return PluginReleaseContract(asset=asset, checksums_asset=checksums_asset)
+
+
+def _string_tuple(
+    value: object,
+    *,
+    field: str,
+    source: str,
+    pattern: re.Pattern[str],
+) -> tuple[str, ...]:
+    if not isinstance(value, list):
+        raise PluginManifestError(f"{field} must be an array: {source}")
+    result: list[str] = []
+    for item in value:
+        if not isinstance(item, str) or not pattern.fullmatch(item.strip()):
+            raise PluginManifestError(f"invalid {field} entry {item!r}: {source}")
+        clean = item.strip()
+        if clean in result:
+            raise PluginManifestError(f"duplicate {field} entry {clean!r}: {source}")
+        result.append(clean)
+    return tuple(result)

--- a/agent/plugin_packages/installer.py
+++ b/agent/plugin_packages/installer.py
@@ -1,0 +1,256 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+import shutil
+import stat
+import tempfile
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Mapping, Protocol
+
+import httpx
+
+from agent.plugin_packages.contracts import PluginCatalogEntry, PluginManifest
+from infra.persistence.json_store import atomic_save_json, load_json
+
+_MAX_PACKAGE_BYTES = 128 * 1024 * 1024
+_MAX_EXPANDED_BYTES = 512 * 1024 * 1024
+_PLUGIN_ID_PATTERN = re.compile(r"^[a-z][a-z0-9_-]{1,63}$")
+
+
+class HttpGetter(Protocol):
+    """Minimal asynchronous HTTP contract required to download release assets."""
+
+    async def get(self, url: str, **kwargs: Any) -> httpx.Response: ...
+
+
+@dataclass(frozen=True)
+class InstalledPlugin:
+    """One atomically selected installed plugin version."""
+
+    plugin_id: str
+    version: str
+    package_dir: Path
+    manifest: PluginManifest
+
+    def to_dict(self) -> dict[str, object]:
+        """Serializes installed plugin metadata for bridge responses."""
+
+        return {
+            "plugin_id": self.plugin_id,
+            "version": self.version,
+            "package_dir": str(self.package_dir),
+            "manifest": self.manifest.to_dict(),
+        }
+
+
+class PluginPackageInstaller:
+    """Downloads, validates and atomically selects plugin release packages."""
+
+    def __init__(self, workspace: Path, requester: HttpGetter) -> None:
+        self._requester = requester
+        self._packages_root = workspace / "plugins"
+        self._data_root = workspace / "private_runtime" / "plugins"
+
+    async def install(self, entry: PluginCatalogEntry) -> InstalledPlugin:
+        """Installs or upgrades one catalog entry without executing plugin code."""
+
+        if not entry.installable or entry.release is None:
+            raise ValueError(
+                entry.unavailable_reason or "plugin release is unavailable"
+            )
+        package_response = await self._requester.get(
+            entry.release.package_url,
+            follow_redirects=True,
+        )
+        package_response.raise_for_status()
+        package_bytes = package_response.content
+        if not package_bytes or len(package_bytes) > _MAX_PACKAGE_BYTES:
+            raise ValueError("plugin package size is invalid")
+        checksums_response = await self._requester.get(
+            entry.release.checksums_url,
+            follow_redirects=True,
+        )
+        checksums_response.raise_for_status()
+        expected_digest = _checksum_for_asset(
+            checksums_response.content,
+            entry.manifest.release.asset,
+        )
+        actual_digest = hashlib.sha256(package_bytes).hexdigest()
+        if actual_digest != expected_digest:
+            raise ValueError("plugin package checksum mismatch")
+        return self._install_archive(package_bytes, expected=entry.manifest)
+
+    def list_installed(self) -> list[InstalledPlugin]:
+        """Returns every valid atomically selected installed plugin."""
+
+        if not self._packages_root.is_dir():
+            return []
+        installed: list[InstalledPlugin] = []
+        for plugin_root in sorted(self._packages_root.iterdir()):
+            if not plugin_root.is_dir():
+                continue
+            current = load_json(
+                plugin_root / "current.json",
+                default=None,
+                domain="plugin_packages",
+            )
+            if not isinstance(current, Mapping):
+                continue
+            version = str(current.get("version") or "").strip()
+            package_dir = plugin_root / "versions" / version
+            manifest_path = package_dir / "plugin.json"
+            if not version or not manifest_path.is_file():
+                continue
+            manifest = PluginManifest.from_json_bytes(
+                manifest_path.read_bytes(),
+                source=str(manifest_path),
+            )
+            if manifest.plugin_id != plugin_root.name or manifest.version != version:
+                raise ValueError(
+                    f"installed plugin registry mismatch: {plugin_root.name}"
+                )
+            installed.append(
+                InstalledPlugin(
+                    plugin_id=manifest.plugin_id,
+                    version=version,
+                    package_dir=package_dir,
+                    manifest=manifest,
+                )
+            )
+        return installed
+
+    def uninstall(self, plugin_id: str, *, purge_data: bool = False) -> bool:
+        """Removes installed code and optionally deletes plugin-owned user data."""
+
+        plugin_root = self._plugin_root(plugin_id)
+        existed = plugin_root.exists()
+        if existed:
+            shutil.rmtree(plugin_root)
+        if purge_data:
+            data_root = self._data_root / plugin_id
+            if data_root.exists():
+                shutil.rmtree(data_root)
+        return existed
+
+    def _install_archive(
+        self,
+        package_bytes: bytes,
+        *,
+        expected: PluginManifest,
+    ) -> InstalledPlugin:
+        plugin_root = self._plugin_root(expected.plugin_id)
+        versions_root = plugin_root / "versions"
+        versions_root.mkdir(parents=True, exist_ok=True)
+        temporary = Path(tempfile.mkdtemp(prefix=".install-", dir=plugin_root))
+        try:
+            archive_path = temporary / "package.zip"
+            archive_path.write_bytes(package_bytes)
+            extracted = temporary / "extracted"
+            extracted.mkdir()
+            with zipfile.ZipFile(archive_path) as archive:
+                _validate_archive(archive)
+                archive.extractall(extracted)
+            package_root = _single_package_root(extracted)
+            manifest_path = package_root / "plugin.json"
+            if not manifest_path.is_file():
+                raise ValueError("plugin package is missing plugin.json")
+            manifest = PluginManifest.from_json_bytes(
+                manifest_path.read_bytes(),
+                source="release:plugin.json",
+            )
+            if manifest != expected:
+                raise ValueError(
+                    "release plugin manifest does not match repository manifest"
+                )
+            _validate_entrypoints(package_root, manifest)
+            destination = versions_root / manifest.version
+            if not destination.exists():
+                os.replace(package_root, destination)
+            atomic_save_json(
+                plugin_root / "current.json",
+                {"version": manifest.version},
+                domain="plugin_packages",
+            )
+            return InstalledPlugin(
+                plugin_id=manifest.plugin_id,
+                version=manifest.version,
+                package_dir=destination,
+                manifest=manifest,
+            )
+        finally:
+            shutil.rmtree(temporary, ignore_errors=True)
+
+    def _plugin_root(self, plugin_id: str) -> Path:
+        if not _PLUGIN_ID_PATTERN.fullmatch(plugin_id):
+            raise ValueError("invalid plugin_id")
+        return self._packages_root / plugin_id
+
+
+def _checksum_for_asset(raw: bytes, asset_name: str) -> str:
+    try:
+        payload = json.loads(raw.decode("utf-8"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ValueError("plugin checksums asset is invalid JSON") from exc
+    files = payload.get("files") if isinstance(payload, Mapping) else None
+    if not isinstance(files, Mapping):
+        raise ValueError("plugin checksums asset must contain a files object")
+    digest = files.get(asset_name)
+    if not isinstance(digest, str) or len(digest) != 64:
+        raise ValueError("plugin package checksum is missing")
+    clean_digest = digest.lower()
+    if any(character not in "0123456789abcdef" for character in clean_digest):
+        raise ValueError("plugin package checksum is invalid")
+    return clean_digest
+
+
+def _validate_archive(archive: zipfile.ZipFile) -> None:
+    expanded_size = 0
+    names: set[str] = set()
+    for entry in archive.infolist():
+        path = PurePosixPath(entry.filename)
+        if (
+            not entry.filename
+            or "\\" in entry.filename
+            or path.is_absolute()
+            or ".." in path.parts
+            or path == "."
+            or (path.parts and path.parts[0].endswith(":"))
+        ):
+            raise ValueError("plugin package contains an unsafe path")
+        normalized = path.as_posix()
+        if normalized in names:
+            raise ValueError("plugin package contains duplicate paths")
+        names.add(normalized)
+        expanded_size += entry.file_size
+        if expanded_size > _MAX_EXPANDED_BYTES:
+            raise ValueError("plugin package expanded size is too large")
+        mode = entry.external_attr >> 16
+        if stat.S_ISLNK(mode):
+            raise ValueError("plugin package cannot contain symbolic links")
+
+
+def _single_package_root(extracted: Path) -> Path:
+    if (extracted / "plugin.json").is_file():
+        return extracted
+    children = [item for item in extracted.iterdir() if item.name != "__MACOSX"]
+    if len(children) == 1 and children[0].is_dir():
+        return children[0]
+    raise ValueError("plugin package must contain one root with plugin.json")
+
+
+def _validate_entrypoints(package_root: Path, manifest: PluginManifest) -> None:
+    for entrypoint in (manifest.entrypoints.backend, manifest.entrypoints.desktop):
+        if entrypoint is None:
+            continue
+        target = (package_root / entrypoint).resolve()
+        try:
+            target.relative_to(package_root.resolve())
+        except ValueError as exc:
+            raise ValueError("plugin entrypoint escapes package root") from exc
+        if not target.is_file():
+            raise ValueError(f"plugin package entrypoint is missing: {entrypoint}")

--- a/agent/plugin_packages/service.py
+++ b/agent/plugin_packages/service.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from agent.plugin_packages.catalog import GitHubPluginCatalog
+from agent.plugin_packages.installer import InstalledPlugin, PluginPackageInstaller
+
+
+class PluginPackageService:
+    """Coordinates plugin catalog queries and package installation operations."""
+
+    def __init__(
+        self,
+        catalog: GitHubPluginCatalog,
+        installer: PluginPackageInstaller,
+    ) -> None:
+        self._catalog = catalog
+        self._installer = installer
+
+    async def catalog(self) -> list[dict[str, object]]:
+        """Returns renderer-safe plugin catalog records."""
+
+        entries = await self._catalog.list_plugins()
+        return [
+            {
+                "repository": entry.repository,
+                "repository_url": entry.repository_url,
+                "manifest": entry.manifest.to_dict(),
+                "installable": entry.installable,
+                "unavailable_reason": entry.unavailable_reason,
+                "release_tag": entry.release.tag if entry.release else None,
+            }
+            for entry in entries
+        ]
+
+    def installed(self) -> list[dict[str, object]]:
+        """Returns renderer-safe installed plugin records."""
+
+        return [item.to_dict() for item in self._installer.list_installed()]
+
+    async def install(self, repository: str) -> InstalledPlugin:
+        """Resolves and installs the latest compatible release from one repository."""
+
+        entry = await self._catalog.get_plugin(repository)
+        return await self._installer.install(entry)
+
+    def uninstall(self, plugin_id: str, *, purge_data: bool = False) -> bool:
+        """Uninstalls one plugin package and optionally clears its user data."""
+
+        return self._installer.uninstall(plugin_id, purge_data=purge_data)

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -6,6 +6,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, cast
 
 if TYPE_CHECKING:
+    from agent.plugin_packages import PluginPackageService
     from agent.plugins.manager import PluginManager
 
 from agent.config_models import Config, WiringConfig
@@ -93,6 +94,7 @@ class CoreRuntime:
     vl_provider: LLMProvider | None = None
     image_sync_service: ExternalImageSyncService | None = None
     agent_provider: LLMProvider | None = None
+    plugin_packages: "PluginPackageService | None" = None
     plugin_manager: "PluginManager | None" = None
     memory_optimizer: Any | None = None
     screen_observation: ScreenObservationService | None = None
@@ -151,7 +153,9 @@ class CoreRuntime:
         before_reasoning_modules = (
             manager.before_reasoning_modules if manager is not None else []
         )
-        prompt_render_modules = manager.prompt_render_modules if manager is not None else []
+        prompt_render_modules = (
+            manager.prompt_render_modules if manager is not None else []
+        )
         before_step_modules = manager.before_step_modules if manager is not None else []
         after_step_modules = manager.after_step_modules if manager is not None else []
         after_reasoning_modules = (
@@ -218,7 +222,10 @@ class CoreRuntime:
                 "after_turn",
                 default_after_turn_modules(
                     self.event_bus,
-                    cast(Any, getattr(pipeline, "_outbound_port", BusOutboundPort(self.bus))),
+                    cast(
+                        Any,
+                        getattr(pipeline, "_outbound_port", BusOutboundPort(self.bus)),
+                    ),
                     cast(Any, context),
                     cast(int, getattr(pipeline, "_history_window", 500)),
                     plugin_modules=cast(Any, after_turn_modules),
@@ -592,6 +599,20 @@ def build_core_runtime(
     )
 
     from agent.plugins.manager import PluginManager as _PluginManager
+    from agent.plugin_packages import (
+        GitHubPluginCatalog,
+        PluginPackageInstaller,
+        PluginPackageService,
+    )
+
+    plugin_packages = PluginPackageService(
+        GitHubPluginCatalog(
+            http_resources.external_default,
+            organization=config.plugin_distribution.organization,
+            api_version=config.plugin_distribution.api_version,
+        ),
+        PluginPackageInstaller(workspace, http_resources.external_default),
+    )
     plugin_light_provider, plugin_light_model = _resolve_plugin_llm_dependencies(
         config,
         provider,
@@ -631,6 +652,7 @@ def build_core_runtime(
         presence=presence,
         relationship_runtime=relationship_runtime,
         role_world_registry=role_world_registry,
+        plugin_packages=plugin_packages,
         plugin_manager=plugin_manager,
         screen_observation=screen_observation,
     )

--- a/desktop_bridge/plugin_package_requests.py
+++ b/desktop_bridge/plugin_package_requests.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+from typing import Any
+
+from agent.plugin_packages import PluginPackageService
+
+
+class DesktopPluginPackageRequestHandler:
+    """Handles package catalog and installation RPCs for the desktop client."""
+
+    def __init__(self, service: PluginPackageService) -> None:
+        self._service = service
+
+    async def handle(
+        self,
+        method: str,
+        payload: dict[str, Any],
+    ) -> dict[str, Any] | None:
+        """Dispatches one host-owned plugin package request."""
+
+        if not method.startswith("plugins."):
+            return None
+        if method == "plugins.catalog":
+            return {"plugins": await self._service.catalog()}
+        if method == "plugins.installed":
+            return {"plugins": self._service.installed()}
+        if method == "plugins.install":
+            repository = str(payload.get("repository") or "").strip()
+            if not repository:
+                raise ValueError("repository is required")
+            installed = await self._service.install(repository)
+            return {"plugin": installed.to_dict()}
+        if method == "plugins.uninstall":
+            plugin_id = str(payload.get("plugin_id") or "").strip()
+            if not plugin_id:
+                raise ValueError("plugin_id is required")
+            purge_data = payload.get("purge_data", False)
+            if not isinstance(purge_data, bool):
+                raise ValueError("purge_data must be a boolean")
+            return {
+                "removed": self._service.uninstall(
+                    plugin_id,
+                    purge_data=purge_data,
+                )
+            }
+        raise ValueError(f"unknown plugin package method: {method}")

--- a/desktop_bridge/request_router.py
+++ b/desktop_bridge/request_router.py
@@ -7,6 +7,7 @@ from agent.screen_observation.service import ScreenObservationService
 
 from .chat_requests import DesktopChatRequestHandler
 from .image_requests import DesktopImageRequestHandler
+from .plugin_package_requests import DesktopPluginPackageRequestHandler
 from .role_requests import DesktopRoleRequestHandler
 from .session_task_requests import DesktopSessionTaskRequestHandler
 from .voice_handler import DesktopVoiceHandler
@@ -28,6 +29,7 @@ class DesktopBridgeRequestRouter:
         voice: DesktopVoiceHandler,
         stories: StorySimulationHandler,
         observation: ScreenObservationService | None,
+        plugin_packages: DesktopPluginPackageRequestHandler | None = None,
     ) -> None:
         self._roles = roles
         self._sessions_and_tasks = sessions_and_tasks
@@ -36,6 +38,7 @@ class DesktopBridgeRequestRouter:
         self._voice = voice
         self._stories = stories
         self._observation = observation
+        self._plugin_packages = plugin_packages
 
     async def dispatch(
         self,
@@ -45,6 +48,10 @@ class DesktopBridgeRequestRouter:
         request_id: str,
         emit_event: EventEmitter,
     ) -> dict[str, Any] | None:
+        if method.startswith("plugins."):
+            if self._plugin_packages is None:
+                raise RuntimeError("plugin package service unavailable")
+            return await self._plugin_packages.handle(method, payload)
         if method in {"observation.analyze", "observation.remember"}:
             if self._observation is None:
                 raise RuntimeError("desktop observation service unavailable")

--- a/desktop_bridge/server.py
+++ b/desktop_bridge/server.py
@@ -54,6 +54,7 @@ class DesktopBridgeServer:
             observation_service=observation_service,
             role_world_registry=getattr(runtime, "role_world_registry", None),
             image_tool=image_tool,
+            plugin_packages=getattr(runtime, "plugin_packages", None),
         )
         self._pet_action_handler = self._handle_pet_action
         runtime.event_bus.on(DesktopPetActionRequested, self._pet_action_handler)

--- a/desktop_bridge/service.py
+++ b/desktop_bridge/service.py
@@ -6,6 +6,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 from agent.looping.core import AgentLoop
+from agent.plugin_packages import PluginPackageService
 from agent.tools.message_push import MessagePushTool
 from bus.event_bus import EventBus
 from bus.events_lifecycle import (
@@ -36,6 +37,7 @@ from desktop_bridge.chat_service import ChatTurnBusyError, DesktopChatService
 from desktop_bridge.image_requests import DesktopImageRequestHandler
 from desktop_bridge.image_service import DesktopImageService
 from desktop_bridge.models import BridgeError, BridgeEvent, BridgeResponse
+from desktop_bridge.plugin_package_requests import DesktopPluginPackageRequestHandler
 from desktop_bridge.request_router import DesktopBridgeRequestRouter
 from desktop_bridge.role_requests import DesktopRoleRequestHandler
 from agent.screen_observation.service import ScreenObservationService
@@ -99,6 +101,7 @@ class DesktopBridgeService:
         role_world_registry: RoleWorldRegistry | None = None,
         story_director: Any | None = None,
         image_tool: Any | None = None,
+        plugin_packages: PluginPackageService | None = None,
     ) -> None:
         self.workspace = workspace
         self.role_store = role_store
@@ -238,6 +241,11 @@ class DesktopBridgeService:
             voice=self.voice_handler,
             stories=self.story_simulation,
             observation=observation_service,
+            plugin_packages=(
+                DesktopPluginPackageRequestHandler(plugin_packages)
+                if plugin_packages is not None
+                else None
+            ),
         )
         if push_tool is not None:
             self.register_desktop_push_channel(push_tool)

--- a/tests/agent/plugin_packages/__init__.py
+++ b/tests/agent/plugin_packages/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for independently packaged plugin infrastructure."""

--- a/tests/agent/plugin_packages/test_catalog.py
+++ b/tests/agent/plugin_packages/test_catalog.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any
+
+import httpx
+
+from agent.plugin_packages.catalog import GitHubPluginCatalog
+
+
+def _manifest(*, api_version: int = 1) -> dict[str, object]:
+    return {
+        "schema_version": 1,
+        "plugin_id": "desktop-pet",
+        "name": "Desktop Pet",
+        "description": "Desktop overlay pet",
+        "version": "1.0.0",
+        "plugin_api_version": api_version,
+        "platforms": [{"os": "win32", "arch": "x64"}],
+        "entrypoints": {"backend": "backend/main.py"},
+        "capabilities": ["agent.tool"],
+        "permissions": [],
+        "release": {
+            "asset": "desktop-pet.zip",
+            "checksums_asset": "checksums.json",
+        },
+    }
+
+
+def _response(url: str, status: int, payload: object) -> httpx.Response:
+    return httpx.Response(
+        status,
+        json=payload,
+        request=httpx.Request("GET", url),
+    )
+
+
+class FakeRequester:
+    def __init__(self, responses: dict[str, httpx.Response]) -> None:
+        self.responses = responses
+
+    async def get(self, url: str, **_: Any) -> httpx.Response:
+        return self.responses[url]
+
+
+def _content_response(url: str, manifest: dict[str, object]) -> httpx.Response:
+    encoded = base64.b64encode(json.dumps(manifest).encode("utf-8")).decode("ascii")
+    return _response(url, 200, {"encoding": "base64", "content": encoded})
+
+
+async def test_catalog_ignores_non_plugins_and_resolves_release_assets() -> None:
+    repos_url = "https://api.github.com/orgs/Shiori-Plugins/repos"
+    pet_manifest_url = (
+        "https://api.github.com/repos/Shiori-Plugins/desktop-pet/contents/"
+        ".akashic-plugin/plugin.json"
+    )
+    notes_manifest_url = (
+        "https://api.github.com/repos/Shiori-Plugins/notes/contents/"
+        ".akashic-plugin/plugin.json"
+    )
+    release_url = (
+        "https://api.github.com/repos/Shiori-Plugins/desktop-pet/releases/latest"
+    )
+    requester = FakeRequester(
+        {
+            repos_url: _response(
+                repos_url,
+                200,
+                [
+                    {
+                        "full_name": "Shiori-Plugins/desktop-pet",
+                        "html_url": "https://github.com/Shiori-Plugins/desktop-pet",
+                    },
+                    {
+                        "full_name": "Shiori-Plugins/notes",
+                        "html_url": "https://github.com/Shiori-Plugins/notes",
+                    },
+                ],
+            ),
+            pet_manifest_url: _content_response(pet_manifest_url, _manifest()),
+            notes_manifest_url: _response(notes_manifest_url, 404, {}),
+            release_url: _response(
+                release_url,
+                200,
+                {
+                    "tag_name": "v1.0.0",
+                    "assets": [
+                        {
+                            "name": "desktop-pet.zip",
+                            "browser_download_url": "https://download/pet.zip",
+                        },
+                        {
+                            "name": "checksums.json",
+                            "browser_download_url": "https://download/checksums.json",
+                        },
+                    ],
+                },
+            ),
+        }
+    )
+    catalog = GitHubPluginCatalog(
+        requester,
+        organization="Shiori-Plugins",
+        os_name="win32",
+        arch="x64",
+    )
+
+    entries = await catalog.list_plugins()
+
+    assert len(entries) == 1
+    assert entries[0].repository == "Shiori-Plugins/desktop-pet"
+    assert entries[0].installable is True
+    assert entries[0].release is not None
+    assert entries[0].release.package_url == "https://download/pet.zip"
+
+
+async def test_catalog_marks_incompatible_manifest_without_querying_release() -> None:
+    repos_url = "https://api.github.com/orgs/Shiori-Plugins/repos"
+    manifest_url = (
+        "https://api.github.com/repos/Shiori-Plugins/desktop-pet/contents/"
+        ".akashic-plugin/plugin.json"
+    )
+    requester = FakeRequester(
+        {
+            repos_url: _response(
+                repos_url,
+                200,
+                [{"full_name": "Shiori-Plugins/desktop-pet", "html_url": "repo"}],
+            ),
+            manifest_url: _content_response(
+                manifest_url,
+                _manifest(api_version=2),
+            ),
+        }
+    )
+    catalog = GitHubPluginCatalog(
+        requester,
+        organization="Shiori-Plugins",
+        os_name="win32",
+        arch="x64",
+    )
+
+    entries = await catalog.list_plugins()
+
+    assert entries[0].installable is False
+    assert entries[0].unavailable_reason == "incompatible_host"

--- a/tests/agent/plugin_packages/test_contracts.py
+++ b/tests/agent/plugin_packages/test_contracts.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+import pytest
+
+from agent.plugin_packages.contracts import PluginManifest, PluginManifestError
+
+
+def _manifest(**overrides: object) -> dict[str, object]:
+    value: dict[str, object] = {
+        "schema_version": 1,
+        "plugin_id": "desktop-pet",
+        "name": "Desktop Pet",
+        "description": "Desktop overlay pet",
+        "version": "1.0.0",
+        "plugin_api_version": 1,
+        "platforms": [{"os": "win32", "arch": "x64"}],
+        "entrypoints": {
+            "backend": "backend/main.py",
+            "desktop": "desktop/index.html",
+        },
+        "capabilities": ["agent.tool", "desktop.overlay"],
+        "permissions": ["plugin.storage"],
+        "release": {
+            "asset": "desktop-pet-1.0.0-win32-x64.zip",
+            "checksums_asset": "checksums.json",
+        },
+    }
+    value.update(overrides)
+    return value
+
+
+def test_manifest_validates_host_and_serializes_contract() -> None:
+    manifest = PluginManifest.from_mapping(_manifest(), source="test")
+
+    assert manifest.supports_host(os_name="win32", arch="x64", api_version=1)
+    assert not manifest.supports_host(os_name="linux", arch="x64", api_version=1)
+    assert manifest.to_dict()["plugin_id"] == "desktop-pet"
+
+
+@pytest.mark.parametrize(
+    ("field", "value"),
+    [
+        ("plugin_id", "../pet"),
+        ("version", "latest"),
+        ("entrypoints", {"backend": "..\\outside.py"}),
+        (
+            "release",
+            {"asset": "C:/outside.zip", "checksums_asset": "checksums.json"},
+        ),
+    ],
+)
+def test_manifest_rejects_unsafe_or_unversioned_contracts(
+    field: str,
+    value: object,
+) -> None:
+    with pytest.raises(PluginManifestError):
+        PluginManifest.from_mapping(_manifest(**{field: value}), source="test")
+
+
+def test_manifest_rejects_duplicate_capabilities() -> None:
+    with pytest.raises(PluginManifestError, match="duplicate capabilities"):
+        PluginManifest.from_mapping(
+            _manifest(capabilities=["agent.tool", "agent.tool"]),
+            source="test",
+        )

--- a/tests/agent/plugin_packages/test_installer.py
+++ b/tests/agent/plugin_packages/test_installer.py
@@ -1,0 +1,163 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import zipfile
+from pathlib import Path
+from typing import Any
+
+import httpx
+import pytest
+
+from agent.plugin_packages.contracts import (
+    PluginCatalogEntry,
+    PluginManifest,
+    PluginRelease,
+)
+from agent.plugin_packages.installer import PluginPackageInstaller
+
+
+def _manifest(*, version: str = "1.0.0") -> PluginManifest:
+    return PluginManifest.from_mapping(
+        {
+            "schema_version": 1,
+            "plugin_id": "desktop-pet",
+            "name": "Desktop Pet",
+            "description": "Desktop overlay pet",
+            "version": version,
+            "plugin_api_version": 1,
+            "platforms": [{"os": "win32", "arch": "x64"}],
+            "entrypoints": {
+                "backend": "backend/main.py",
+                "desktop": "desktop/index.html",
+            },
+            "capabilities": ["agent.tool", "desktop.overlay"],
+            "permissions": ["plugin.storage"],
+            "release": {
+                "asset": "desktop-pet.zip",
+                "checksums_asset": "checksums.json",
+            },
+        },
+        source="test",
+    )
+
+
+def _archive(manifest: PluginManifest, *, unsafe_name: str | None = None) -> bytes:
+    output = io.BytesIO()
+    with zipfile.ZipFile(output, "w") as archive:
+        archive.writestr("plugin.json", json.dumps(manifest.to_dict()))
+        archive.writestr("backend/main.py", "print('ready')")
+        archive.writestr("desktop/index.html", "<main>pet</main>")
+        if unsafe_name is not None:
+            archive.writestr(unsafe_name, "escape")
+    return output.getvalue()
+
+
+def _response(url: str, content: bytes, *, status: int = 200) -> httpx.Response:
+    return httpx.Response(
+        status,
+        content=content,
+        request=httpx.Request("GET", url),
+    )
+
+
+class FakeRequester:
+    def __init__(self, responses: dict[str, httpx.Response]) -> None:
+        self.responses = responses
+
+    async def get(self, url: str, **_: Any) -> httpx.Response:
+        return self.responses[url]
+
+
+def _entry(manifest: PluginManifest) -> PluginCatalogEntry:
+    return PluginCatalogEntry(
+        repository="Shiori-Plugins/desktop-pet",
+        repository_url="https://github.com/Shiori-Plugins/desktop-pet",
+        manifest=manifest,
+        release=PluginRelease(
+            tag=f"v{manifest.version}",
+            package_url="https://download/package.zip",
+            checksums_url="https://download/checksums.json",
+        ),
+    )
+
+
+def _requester(package: bytes, *, digest: str | None = None) -> FakeRequester:
+    checksum = digest or hashlib.sha256(package).hexdigest()
+    return FakeRequester(
+        {
+            "https://download/package.zip": _response(
+                "https://download/package.zip",
+                package,
+            ),
+            "https://download/checksums.json": _response(
+                "https://download/checksums.json",
+                json.dumps({"files": {"desktop-pet.zip": checksum}}).encode(),
+            ),
+        }
+    )
+
+
+async def test_installer_atomically_selects_release_and_preserves_data_on_uninstall(
+    tmp_path: Path,
+) -> None:
+    manifest = _manifest()
+    package = _archive(manifest)
+    installer = PluginPackageInstaller(tmp_path, _requester(package))
+
+    installed = await installer.install(_entry(manifest))
+    data_file = tmp_path / "private_runtime" / "plugins" / "desktop-pet" / "state.json"
+    data_file.parent.mkdir(parents=True)
+    data_file.write_text("{}", encoding="utf-8")
+
+    assert installed.package_dir == (
+        tmp_path / "plugins" / "desktop-pet" / "versions" / "1.0.0"
+    )
+    assert installer.list_installed()[0].version == "1.0.0"
+    assert installer.uninstall("desktop-pet") is True
+    assert data_file.is_file()
+
+
+async def test_failed_upgrade_keeps_current_version(tmp_path: Path) -> None:
+    first = _manifest(version="1.0.0")
+    installer = PluginPackageInstaller(tmp_path, _requester(_archive(first)))
+    await installer.install(_entry(first))
+    second = _manifest(version="2.0.0")
+    broken_installer = PluginPackageInstaller(
+        tmp_path,
+        _requester(_archive(second), digest="0" * 64),
+    )
+
+    with pytest.raises(ValueError, match="checksum mismatch"):
+        await broken_installer.install(_entry(second))
+
+    assert installer.list_installed()[0].version == "1.0.0"
+
+
+async def test_installer_rejects_windows_path_traversal(tmp_path: Path) -> None:
+    manifest = _manifest()
+    package = _archive(manifest, unsafe_name="..\\outside.txt")
+    installer = PluginPackageInstaller(tmp_path, _requester(package))
+
+    with pytest.raises(ValueError, match="unsafe path"):
+        await installer.install(_entry(manifest))
+
+    assert not (tmp_path / "outside.txt").exists()
+
+
+async def test_uninstall_can_explicitly_clear_plugin_data(tmp_path: Path) -> None:
+    data_root = tmp_path / "private_runtime" / "plugins" / "desktop-pet"
+    data_root.mkdir(parents=True)
+    (data_root / "state.json").write_text("{}", encoding="utf-8")
+    installer = PluginPackageInstaller(tmp_path, _requester(b"unused"))
+
+    assert installer.uninstall("desktop-pet", purge_data=True) is False
+    assert not data_root.exists()
+
+
+def test_uninstall_rejects_path_like_plugin_id(tmp_path: Path) -> None:
+    installer = PluginPackageInstaller(tmp_path, _requester(b"unused"))
+
+    with pytest.raises(ValueError, match="invalid plugin_id"):
+        installer.uninstall("..\\outside", purge_data=True)

--- a/tests/agent/test_config.py
+++ b/tests/agent/test_config.py
@@ -41,6 +41,27 @@ def test_load_voice_config_reads_global_provider_and_input_settings() -> None:
     assert loaded.tts.volume == 2.5
 
 
+def test_load_plugin_distribution_config_reads_organization_and_api_version() -> None:
+    loaded = config._load_plugin_distribution_config(
+        {
+            "plugin_distribution": {
+                "organization": "Example-Plugins",
+                "api_version": 2,
+            }
+        }
+    )
+
+    assert loaded.organization == "Example-Plugins"
+    assert loaded.api_version == 2
+
+
+def test_load_plugin_distribution_config_rejects_non_positive_api_version() -> None:
+    with pytest.raises(ValueError, match="api_version"):
+        config._load_plugin_distribution_config(
+            {"plugin_distribution": {"api_version": 0}}
+        )
+
+
 def test_load_config_rejects_legacy_model_sections(tmp_path: Path) -> None:
     config_path = tmp_path / "config.toml"
     config_path.write_text(

--- a/tests/desktop_bridge/test_plugin_package_requests.py
+++ b/tests/desktop_bridge/test_plugin_package_requests.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from desktop_bridge.plugin_package_requests import DesktopPluginPackageRequestHandler
+
+
+@pytest.mark.asyncio
+async def test_plugin_package_handler_routes_catalog_and_install() -> None:
+    installed = SimpleNamespace(to_dict=Mock(return_value={"plugin_id": "desktop-pet"}))
+    service = SimpleNamespace(
+        catalog=AsyncMock(return_value=[{"repository": "Shiori-Plugins/desktop-pet"}]),
+        installed=Mock(return_value=[]),
+        install=AsyncMock(return_value=installed),
+        uninstall=Mock(return_value=True),
+    )
+    handler = DesktopPluginPackageRequestHandler(service)
+
+    catalog = await handler.handle("plugins.catalog", {})
+    result = await handler.handle(
+        "plugins.install",
+        {"repository": "desktop-pet"},
+    )
+
+    assert catalog == {"plugins": [{"repository": "Shiori-Plugins/desktop-pet"}]}
+    assert result == {"plugin": {"plugin_id": "desktop-pet"}}
+    service.install.assert_awaited_once_with("desktop-pet")
+
+
+@pytest.mark.asyncio
+async def test_plugin_package_handler_preserves_or_purges_data_explicitly() -> None:
+    service = SimpleNamespace(uninstall=Mock(return_value=True))
+    handler = DesktopPluginPackageRequestHandler(service)
+
+    result = await handler.handle(
+        "plugins.uninstall",
+        {"plugin_id": "desktop-pet", "purge_data": True},
+    )
+
+    assert result == {"removed": True}
+    service.uninstall.assert_called_once_with("desktop-pet", purge_data=True)
+
+
+@pytest.mark.asyncio
+async def test_plugin_package_handler_rejects_invalid_mutation_payloads() -> None:
+    handler = DesktopPluginPackageRequestHandler(SimpleNamespace())
+
+    with pytest.raises(ValueError, match="repository"):
+        await handler.handle("plugins.install", {})
+    with pytest.raises(ValueError, match="purge_data"):
+        await handler.handle(
+            "plugins.uninstall",
+            {"plugin_id": "desktop-pet", "purge_data": "yes"},
+        )

--- a/tests/desktop_bridge/test_request_router.py
+++ b/tests/desktop_bridge/test_request_router.py
@@ -15,6 +15,7 @@ def _router(*, role_result=None, story_result=None):
         voice=SimpleNamespace(handle=AsyncMock(return_value=None)),
         stories=SimpleNamespace(handle=AsyncMock(return_value=story_result)),
         observation=None,
+        plugin_packages=SimpleNamespace(handle=AsyncMock(return_value=None)),
     )
 
 
@@ -65,3 +66,20 @@ async def test_request_router_stops_after_story_handler_matches() -> None:
 
     assert result == {"stories": []}
     router._stories.handle.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_request_router_sends_plugin_package_methods_to_their_owner() -> None:
+    router = _router()
+    router._plugin_packages.handle.return_value = {"plugins": []}
+
+    result = await router.dispatch(
+        "plugins.catalog",
+        {},
+        request_id="request-4",
+        emit_event=Mock(),
+    )
+
+    assert result == {"plugins": []}
+    router._plugin_packages.handle.assert_awaited_once_with("plugins.catalog", {})
+    router._stories.handle.assert_not_awaited()


### PR DESCRIPTION
Closes #72
Part of #36

## 变更摘要

- 增加版本化 `.akashic-plugin/plugin.json` 契约，校验插件 ID、SemVer、Plugin API、平台、入口、capability、权限和 Release 资产。
- 增加 GitHub Organization catalog，仅识别包含合法清单的仓库，并解析最新兼容 Release。
- 增加 Release ZIP 下载、SHA-256 校验、路径穿越/符号链接/展开体积防护。
- 使用版本目录和原子 `current.json` 完成安装与升级，失败时保留旧版本。
- 普通卸载保留 `private_runtime/plugins/<plugin_id>`，支持显式清除数据。
- 增加 `plugins.catalog`、`plugins.installed`、`plugins.install`、`plugins.uninstall` Desktop Bridge RPC。
- 增加可配置的 `plugin_distribution.organization` 和 Plugin API 版本，默认组织为 `Shiori-Plugins`。

## 实际验证

- `pytest tests/agent/plugin_packages tests/agent/test_config.py tests/desktop_bridge/test_plugin_package_requests.py tests/desktop_bridge/test_request_router.py tests/desktop_bridge/test_server.py -q`：36 passed
- `pytest tests/test_bootstrap_wiring_p2.py tests/test_runtime_smoke.py -q`：30 passed
- changed Python Ruff：通过
- changed package/bridge Pyright：0 errors
- 真实扫描 `Shiori-Plugins`：成功返回空 catalog（当前组织尚无仓库）
- `git diff --check`：通过
- `graphify update .`：完成，8226 nodes / 21603 edges

## 已知阻塞项

- 真实 Release 的下载与安装 smoke 需要 #74 创建并发布 `Shiori-Plugins/desktop-pet` 后完成。
- 插件进程启动与桌面 capability host 属于 #73，不在本 PR 范围。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GitHub Organization discovery and atomic plugin release installation with manifest validation, safe ZIP extraction, and desktop RPCs for catalog/install/uninstall.

- **New Features**
  - Define and validate versioned `.akashic-plugin/plugin.json` (ID, SemVer, Plugin API, platforms, entrypoints, capabilities, permissions, release assets).
  - GitHub catalog for one Organization; lists repos with a valid manifest and resolves the latest compatible Release.
  - Safe installer: downloads ZIP, verifies SHA‑256 from `checksums.json`, blocks path traversal/symlinks/oversized archives, and validates entrypoints.
  - Atomic installs under `plugins/<plugin_id>/versions/<version>` with `current.json`; failed upgrades keep the previous version.
  - Uninstall keeps `private_runtime/plugins/<plugin_id>` by default; supports explicit data purge.
  - Desktop Bridge RPCs: `plugins.catalog`, `plugins.installed`, `plugins.install`, `plugins.uninstall`.
  - Config: new `plugin_distribution` with `organization` (default `Shiori-Plugins`) and Plugin API `api_version`.

<sup>Written for commit 5f1ad61f8bbb679a749df5ebc5fe1b718efcaa60. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/75?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

