### PR TITLE
feat(plugin): 建立隔离运行时与桌面 capability host

### DIFF
--- a/agent/mcp/client.py
+++ b/agent/mcp/client.py
@@ -41,12 +41,15 @@ class McpClient:
         command: list[str],
         env: dict[str, str] | None = None,
         cwd: str | None = None,
+        *,
+        inherit_env: bool = True,
     ) -> None:
         self.name = name
         self.command = command
         self.env = env or {}
         # cwd 未指定时从 command 中推断，避免子进程继承 agent 工作目录
         self.cwd = cwd or _infer_cwd(command)
+        self.inherit_env = inherit_env
         self._process: asyncio.subprocess.Process | None = None
         self._next_id = 1
         self._tool_infos: list[McpToolInfo] = []
@@ -69,7 +72,7 @@ class McpClient:
 
     async def _connect_impl(self) -> list[McpToolInfo]:
         """启动子进程，完成握手，获取工具列表。"""
-        proc_env = {**os.environ, **self.env}
+        proc_env = {**os.environ, **self.env} if self.inherit_env else dict(self.env)
         logger.debug("[mcp] 启动 %r: %s  cwd=%s", self.name, self.command, self.cwd)
         self._process = await asyncio.create_subprocess_exec(
             *self.command,
@@ -171,6 +174,19 @@ class McpClient:
             logger.warning("[mcp] 断开 %r 时出错: %s", self.name, e)
         finally:
             self._process = None
+
+    @property
+    def is_running(self) -> bool:
+        """Returns whether the managed MCP subprocess is still running."""
+
+        return self._process is not None and self._process.returncode is None
+
+    async def wait_until_exit(self) -> int:
+        """Waits for the current MCP subprocess to exit and returns its code."""
+
+        if self._process is None:
+            return 0
+        return await self._process.wait()
 
     def _new_id(self) -> int:
         i = self._next_id

--- a/agent/plugin_packages/contracts.py
+++ b/agent/plugin_packages/contracts.py
@@ -17,6 +17,7 @@ _VERSION_PATTERN = re.compile(
     r"(?:\+[0-9A-Za-z-]+(?:\.[0-9A-Za-z-]+)*)?$"
 )
 _CAPABILITY_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)+$")
+_RPC_METHOD_PATTERN = re.compile(r"^[a-z][a-z0-9_-]*(?:\.[a-z][a-z0-9_-]*)*$")
 
 
 class PluginManifestError(ValueError):
@@ -48,6 +49,41 @@ class PluginReleaseContract:
 
 
 @dataclass(frozen=True)
+class PluginToolDeclaration:
+    """One allowlisted MCP tool exposed by an installed plugin backend."""
+
+    remote_name: str
+    name: str
+    risk: str
+    always_on: bool
+    search_hint: str | None
+
+
+@dataclass(frozen=True)
+class PluginRpcDeclaration:
+    """One backend RPC method exposed only to this plugin's desktop pages."""
+
+    method: str
+    remote_name: str
+
+
+@dataclass(frozen=True)
+class PluginDesktopContribution:
+    """One sandboxed desktop surface contributed by an installed plugin."""
+
+    contribution_id: str
+    kind: str
+    entrypoint: str
+    width: int
+    height: int
+    transparent: bool
+    always_on_top: bool
+    skip_taskbar: bool
+    resizable: bool
+    frame: bool
+
+
+@dataclass(frozen=True)
 class PluginManifest:
     """Validated public contract shared by repository and release manifests."""
 
@@ -61,6 +97,9 @@ class PluginManifest:
     entrypoints: PluginEntrypoints
     capabilities: tuple[str, ...]
     permissions: tuple[str, ...]
+    tools: tuple[PluginToolDeclaration, ...]
+    rpc_methods: tuple[PluginRpcDeclaration, ...]
+    desktop_contributions: tuple[PluginDesktopContribution, ...]
     release: PluginReleaseContract
 
     @classmethod
@@ -121,6 +160,34 @@ class PluginManifest:
             source=source,
             pattern=_CAPABILITY_PATTERN,
         )
+        tools = _parse_tools(value.get("tools", []), source=source)
+        if tools and "agent.tool" not in capabilities:
+            raise PluginManifestError(
+                f"tools require the agent.tool capability: {source}"
+            )
+        if tools and entrypoints.backend is None:
+            raise PluginManifestError(f"tools require a backend entrypoint: {source}")
+        rpc_methods = _parse_rpc_methods(value.get("rpc_methods", []), source=source)
+        if rpc_methods and "plugin.rpc" not in capabilities:
+            raise PluginManifestError(
+                f"rpc_methods require the plugin.rpc capability: {source}"
+            )
+        if rpc_methods and entrypoints.backend is None:
+            raise PluginManifestError(
+                f"rpc_methods require a backend entrypoint: {source}"
+            )
+        desktop_contributions = _parse_desktop_contributions(
+            value.get("desktop_contributions", []),
+            source=source,
+        )
+        if desktop_contributions and "desktop.overlay" not in capabilities:
+            raise PluginManifestError(
+                f"desktop_contributions require the desktop.overlay capability: {source}"
+            )
+        if desktop_contributions and entrypoints.desktop is None:
+            raise PluginManifestError(
+                f"desktop_contributions require a desktop entrypoint: {source}"
+            )
         release = _parse_release(value.get("release"), source=source)
         return cls(
             schema_version=schema_version,
@@ -133,6 +200,9 @@ class PluginManifest:
             entrypoints=entrypoints,
             capabilities=capabilities,
             permissions=permissions,
+            tools=tools,
+            rpc_methods=rpc_methods,
+            desktop_contributions=desktop_contributions,
             release=release,
         )
 
@@ -170,6 +240,39 @@ class PluginManifest:
             },
             "capabilities": list(self.capabilities),
             "permissions": list(self.permissions),
+            "tools": [
+                {
+                    "remote_name": item.remote_name,
+                    "name": item.name,
+                    "risk": item.risk,
+                    "always_on": item.always_on,
+                    **(
+                        {"search_hint": item.search_hint}
+                        if item.search_hint is not None
+                        else {}
+                    ),
+                }
+                for item in self.tools
+            ],
+            "rpc_methods": [
+                {"method": item.method, "remote_name": item.remote_name}
+                for item in self.rpc_methods
+            ],
+            "desktop_contributions": [
+                {
+                    "id": item.contribution_id,
+                    "kind": item.kind,
+                    "entrypoint": item.entrypoint,
+                    "width": item.width,
+                    "height": item.height,
+                    "transparent": item.transparent,
+                    "always_on_top": item.always_on_top,
+                    "skip_taskbar": item.skip_taskbar,
+                    "resizable": item.resizable,
+                    "frame": item.frame,
+                }
+                for item in self.desktop_contributions
+            ],
             "release": {
                 "asset": self.release.asset,
                 "checksums_asset": self.release.checksums_asset,
@@ -314,3 +417,166 @@ def _string_tuple(
             raise PluginManifestError(f"duplicate {field} entry {clean!r}: {source}")
         result.append(clean)
     return tuple(result)
+
+
+def _parse_tools(value: object, *, source: str) -> tuple[PluginToolDeclaration, ...]:
+    if not isinstance(value, list):
+        raise PluginManifestError(f"tools must be an array: {source}")
+    tools: list[PluginToolDeclaration] = []
+    remote_names: set[str] = set()
+    public_names: set[str] = set()
+    for raw in value:
+        if not isinstance(raw, Mapping):
+            raise PluginManifestError(f"tool entries must be objects: {source}")
+        remote_name = _required_string(raw, "remote_name", source=source)
+        name = _required_string(raw, "name", source=source)
+        if not _PLUGIN_ID_PATTERN.fullmatch(remote_name):
+            raise PluginManifestError(
+                f"invalid tool remote_name {remote_name!r}: {source}"
+            )
+        if not _PLUGIN_ID_PATTERN.fullmatch(name):
+            raise PluginManifestError(f"invalid tool name {name!r}: {source}")
+        if remote_name in remote_names or name in public_names:
+            raise PluginManifestError(f"duplicate plugin tool declaration: {source}")
+        risk = str(raw.get("risk") or "external-side-effect").strip()
+        if risk not in {"read-only", "write", "external-side-effect"}:
+            raise PluginManifestError(f"invalid tool risk {risk!r}: {source}")
+        always_on = raw.get("always_on", False)
+        if not isinstance(always_on, bool):
+            raise PluginManifestError(f"tool always_on must be a boolean: {source}")
+        raw_search_hint = raw.get("search_hint")
+        if raw_search_hint is not None and (
+            not isinstance(raw_search_hint, str) or not raw_search_hint.strip()
+        ):
+            raise PluginManifestError(f"tool search_hint must be a string: {source}")
+        tools.append(
+            PluginToolDeclaration(
+                remote_name=remote_name,
+                name=name,
+                risk=risk,
+                always_on=always_on,
+                search_hint=(
+                    raw_search_hint.strip()
+                    if isinstance(raw_search_hint, str)
+                    else None
+                ),
+            )
+        )
+        remote_names.add(remote_name)
+        public_names.add(name)
+    return tuple(tools)
+
+
+def _parse_rpc_methods(
+    value: object,
+    *,
+    source: str,
+) -> tuple[PluginRpcDeclaration, ...]:
+    if not isinstance(value, list):
+        raise PluginManifestError(f"rpc_methods must be an array: {source}")
+    declarations: list[PluginRpcDeclaration] = []
+    methods: set[str] = set()
+    for raw in value:
+        if not isinstance(raw, Mapping):
+            raise PluginManifestError(f"rpc method entries must be objects: {source}")
+        method = _required_string(raw, "method", source=source)
+        remote_name = _required_string(raw, "remote_name", source=source)
+        if not _RPC_METHOD_PATTERN.fullmatch(method):
+            raise PluginManifestError(f"invalid rpc method {method!r}: {source}")
+        if not _PLUGIN_ID_PATTERN.fullmatch(remote_name):
+            raise PluginManifestError(
+                f"invalid rpc remote_name {remote_name!r}: {source}"
+            )
+        if method in methods:
+            raise PluginManifestError(f"duplicate rpc method {method!r}: {source}")
+        declarations.append(
+            PluginRpcDeclaration(method=method, remote_name=remote_name)
+        )
+        methods.add(method)
+    return tuple(declarations)
+
+
+def _parse_desktop_contributions(
+    value: object,
+    *,
+    source: str,
+) -> tuple[PluginDesktopContribution, ...]:
+    if not isinstance(value, list):
+        raise PluginManifestError(f"desktop_contributions must be an array: {source}")
+    contributions: list[PluginDesktopContribution] = []
+    contribution_ids: set[str] = set()
+    for raw in value:
+        if not isinstance(raw, Mapping):
+            raise PluginManifestError(
+                f"desktop contribution entries must be objects: {source}"
+            )
+        contribution_id = _required_string(raw, "id", source=source)
+        if not _PLUGIN_ID_PATTERN.fullmatch(contribution_id):
+            raise PluginManifestError(
+                f"invalid desktop contribution id {contribution_id!r}: {source}"
+            )
+        if contribution_id in contribution_ids:
+            raise PluginManifestError(
+                f"duplicate desktop contribution id {contribution_id!r}: {source}"
+            )
+        kind = _required_string(raw, "kind", source=source)
+        if kind != "overlay":
+            raise PluginManifestError(
+                f"unsupported desktop contribution kind {kind!r}: {source}"
+            )
+        entrypoint = _safe_package_path(
+            _required_string(raw, "entrypoint", source=source),
+            field="desktop_contributions.entrypoint",
+            source=source,
+        )
+        contributions.append(
+            PluginDesktopContribution(
+                contribution_id=contribution_id,
+                kind=kind,
+                entrypoint=entrypoint,
+                width=_bounded_int(
+                    raw, "width", source=source, minimum=64, maximum=4096
+                ),
+                height=_bounded_int(
+                    raw, "height", source=source, minimum=64, maximum=4096
+                ),
+                transparent=_optional_bool(raw, "transparent", False, source=source),
+                always_on_top=_optional_bool(
+                    raw, "always_on_top", False, source=source
+                ),
+                skip_taskbar=_optional_bool(raw, "skip_taskbar", True, source=source),
+                resizable=_optional_bool(raw, "resizable", False, source=source),
+                frame=_optional_bool(raw, "frame", False, source=source),
+            )
+        )
+        contribution_ids.add(contribution_id)
+    return tuple(contributions)
+
+
+def _bounded_int(
+    value: Mapping[str, Any],
+    field: str,
+    *,
+    source: str,
+    minimum: int,
+    maximum: int,
+) -> int:
+    result = _required_int(value, field, source=source)
+    if result < minimum or result > maximum:
+        raise PluginManifestError(
+            f"{field} must be between {minimum} and {maximum}: {source}"
+        )
+    return result
+
+
+def _optional_bool(
+    value: Mapping[str, Any],
+    field: str,
+    default: bool,
+    *,
+    source: str,
+) -> bool:
+    result = value.get(field, default)
+    if not isinstance(result, bool):
+        raise PluginManifestError(f"{field} must be a boolean: {source}")
+    return result

--- a/agent/plugin_packages/installer.py
+++ b/agent/plugin_packages/installer.py
@@ -36,6 +36,7 @@ class InstalledPlugin:
     version: str
     package_dir: Path
     manifest: PluginManifest
+    enabled: bool = True
 
     def to_dict(self) -> dict[str, object]:
         """Serializes installed plugin metadata for bridge responses."""
@@ -43,6 +44,7 @@ class InstalledPlugin:
         return {
             "plugin_id": self.plugin_id,
             "version": self.version,
+            "enabled": self.enabled,
             "package_dir": str(self.package_dir),
             "manifest": self.manifest.to_dict(),
         }
@@ -102,6 +104,11 @@ class PluginPackageInstaller:
             if not isinstance(current, Mapping):
                 continue
             version = str(current.get("version") or "").strip()
+            enabled = current.get("enabled", True)
+            if not isinstance(enabled, bool):
+                raise ValueError(
+                    f"installed plugin enabled state is invalid: {plugin_root.name}"
+                )
             package_dir = plugin_root / "versions" / version
             manifest_path = package_dir / "plugin.json"
             if not version or not manifest_path.is_file():
@@ -120,6 +127,7 @@ class PluginPackageInstaller:
                     version=version,
                     package_dir=package_dir,
                     manifest=manifest,
+                    enabled=enabled,
                 )
             )
         return installed
@@ -136,6 +144,28 @@ class PluginPackageInstaller:
             if data_root.exists():
                 shutil.rmtree(data_root)
         return existed
+
+    def set_enabled(self, plugin_id: str, enabled: bool) -> InstalledPlugin:
+        """Atomically changes whether one installed plugin starts with the runtime."""
+
+        installed = next(
+            (item for item in self.list_installed() if item.plugin_id == plugin_id),
+            None,
+        )
+        if installed is None:
+            raise KeyError(f"plugin is not installed: {plugin_id}")
+        atomic_save_json(
+            self._plugin_root(plugin_id) / "current.json",
+            {"version": installed.version, "enabled": enabled},
+            domain="plugin_packages",
+        )
+        return InstalledPlugin(
+            plugin_id=installed.plugin_id,
+            version=installed.version,
+            package_dir=installed.package_dir,
+            manifest=installed.manifest,
+            enabled=enabled,
+        )
 
     def _install_archive(
         self,
@@ -173,7 +203,10 @@ class PluginPackageInstaller:
                 os.replace(package_root, destination)
             atomic_save_json(
                 plugin_root / "current.json",
-                {"version": manifest.version},
+                {
+                    "version": manifest.version,
+                    "enabled": _current_enabled(plugin_root),
+                },
                 domain="plugin_packages",
             )
             return InstalledPlugin(
@@ -181,6 +214,7 @@ class PluginPackageInstaller:
                 version=manifest.version,
                 package_dir=destination,
                 manifest=manifest,
+                enabled=_current_enabled(plugin_root),
             )
         finally:
             shutil.rmtree(temporary, ignore_errors=True)
@@ -206,6 +240,18 @@ def _checksum_for_asset(raw: bytes, asset_name: str) -> str:
     if any(character not in "0123456789abcdef" for character in clean_digest):
         raise ValueError("plugin package checksum is invalid")
     return clean_digest
+
+
+def _current_enabled(plugin_root: Path) -> bool:
+    current = load_json(
+        plugin_root / "current.json",
+        default=None,
+        domain="plugin_packages",
+    )
+    if not isinstance(current, Mapping):
+        return True
+    enabled = current.get("enabled", True)
+    return enabled if isinstance(enabled, bool) else True
 
 
 def _validate_archive(archive: zipfile.ZipFile) -> None:
@@ -244,7 +290,11 @@ def _single_package_root(extracted: Path) -> Path:
 
 
 def _validate_entrypoints(package_root: Path, manifest: PluginManifest) -> None:
-    for entrypoint in (manifest.entrypoints.backend, manifest.entrypoints.desktop):
+    for entrypoint in (
+        manifest.entrypoints.backend,
+        manifest.entrypoints.desktop,
+        *(item.entrypoint for item in manifest.desktop_contributions),
+    ):
         if entrypoint is None:
             continue
         target = (package_root / entrypoint).resolve()

--- a/agent/plugin_packages/service.py
+++ b/agent/plugin_packages/service.py
@@ -46,3 +46,8 @@ class PluginPackageService:
         """Uninstalls one plugin package and optionally clears its user data."""
 
         return self._installer.uninstall(plugin_id, purge_data=purge_data)
+
+    def set_enabled(self, plugin_id: str, enabled: bool) -> dict[str, object]:
+        """Persists one installed plugin's runtime enablement state."""
+
+        return self._installer.set_enabled(plugin_id, enabled).to_dict()

--- a/agent/plugin_runtime/__init__.py
+++ b/agent/plugin_runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Isolated runtime host for independently installed plugins."""
+
+from agent.plugin_runtime.manager import PluginRuntimeManager
+
+__all__ = ["PluginRuntimeManager"]

--- a/agent/plugin_runtime/manager.py
+++ b/agent/plugin_runtime/manager.py
@@ -1,0 +1,259 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import sys
+from collections.abc import Callable
+from dataclasses import dataclass
+from pathlib import Path
+
+from agent.mcp.client import McpClient
+from agent.plugin_packages import InstalledPlugin, PluginPackageInstaller
+from agent.plugin_runtime.tool import PluginMcpTool
+from agent.tools.registry import ToolRegistry
+
+logger = logging.getLogger(__name__)
+
+McpClientFactory = Callable[..., McpClient]
+
+
+@dataclass
+class _RunningPlugin:
+    installed: InstalledPlugin
+    client: McpClient
+    tool_names: tuple[str, ...]
+    watcher: asyncio.Task[None] | None = None
+
+
+class PluginRuntimeManager:
+    """Runs installed plugin backends as isolated MCP subprocesses."""
+
+    def __init__(
+        self,
+        workspace: Path,
+        installer: PluginPackageInstaller,
+        tool_registry: ToolRegistry,
+        *,
+        client_factory: McpClientFactory = McpClient,
+    ) -> None:
+        self._workspace = workspace
+        self._installer = installer
+        self._tool_registry = tool_registry
+        self._client_factory = client_factory
+        self._running: dict[str, _RunningPlugin] = {}
+        self._lock = asyncio.Lock()
+
+    @property
+    def running_plugin_ids(self) -> tuple[str, ...]:
+        """Returns stable IDs for plugin backends that are currently connected."""
+
+        return tuple(sorted(self._running))
+
+    async def start_all(self) -> None:
+        """Starts every enabled installed backend without blocking other plugins."""
+
+        for installed in self._installer.list_installed():
+            if not installed.enabled or installed.manifest.entrypoints.backend is None:
+                continue
+            try:
+                await self.start(installed.plugin_id)
+            except Exception as exc:
+                logger.error(
+                    "plugin backend failed to start (%s): %s",
+                    installed.plugin_id,
+                    exc,
+                )
+
+    async def start(self, plugin_id: str) -> bool:
+        """Starts one enabled installed plugin backend and registers its tools."""
+
+        async with self._lock:
+            if plugin_id in self._running:
+                return False
+            installed = self._installed(plugin_id)
+            if not installed.enabled:
+                raise ValueError(f"plugin is disabled: {plugin_id}")
+            backend = installed.manifest.entrypoints.backend
+            if backend is None:
+                return False
+            backend_path = (installed.package_dir / backend).resolve()
+            try:
+                backend_path.relative_to(installed.package_dir.resolve())
+            except ValueError as exc:
+                raise ValueError(
+                    "plugin backend entrypoint escapes package root"
+                ) from exc
+            if not backend_path.is_file():
+                raise FileNotFoundError(
+                    f"plugin backend entrypoint is missing: {backend}"
+                )
+            command = _backend_command(backend_path)
+            data_dir = self._workspace / "private_runtime" / "plugins" / plugin_id
+            data_dir.mkdir(parents=True, exist_ok=True)
+            client = self._client_factory(
+                name=f"plugin_{plugin_id}",
+                command=command,
+                env=_plugin_environment(plugin_id, data_dir),
+                cwd=str(installed.package_dir),
+                inherit_env=False,
+            )
+            registered: list[str] = []
+            try:
+                infos = await client.connect()
+                info_by_name = {info.name: info for info in infos}
+                for declaration in installed.manifest.tools:
+                    info = info_by_name.get(declaration.remote_name)
+                    if info is None:
+                        raise ValueError(
+                            "plugin backend did not expose declared tool: "
+                            f"{declaration.remote_name}"
+                        )
+                    if self._tool_registry.has_tool(declaration.name):
+                        raise ValueError(
+                            f"plugin tool name is already registered: {declaration.name}"
+                        )
+                for declaration in installed.manifest.rpc_methods:
+                    if declaration.remote_name not in info_by_name:
+                        raise ValueError(
+                            "plugin backend did not expose declared RPC method: "
+                            f"{declaration.remote_name}"
+                        )
+                for declaration in installed.manifest.tools:
+                    info = info_by_name[declaration.remote_name]
+                    tool = PluginMcpTool(
+                        client,
+                        info,
+                        declaration,
+                        plugin_name=installed.manifest.name,
+                    )
+                    self._tool_registry.register(
+                        tool,
+                        risk=declaration.risk,
+                        always_on=declaration.always_on,
+                        search_hint=declaration.search_hint,
+                        source_type="plugin",
+                        source_name=plugin_id,
+                    )
+                    registered.append(tool.name)
+            except Exception:
+                for tool_name in registered:
+                    self._tool_registry.unregister(tool_name)
+                await client.disconnect()
+                raise
+            running = _RunningPlugin(
+                installed=installed,
+                client=client,
+                tool_names=tuple(registered),
+            )
+            self._running[plugin_id] = running
+            running.watcher = asyncio.create_task(
+                self._watch(plugin_id, client),
+                name=f"plugin_runtime_watch:{plugin_id}",
+            )
+            return True
+
+    async def stop(self, plugin_id: str) -> bool:
+        """Stops one plugin backend and deterministically unregisters its tools."""
+
+        async with self._lock:
+            running = self._running.pop(plugin_id, None)
+            if running is None:
+                return False
+            watcher = running.watcher
+            if watcher is not None:
+                watcher.cancel()
+            for tool_name in running.tool_names:
+                self._tool_registry.unregister(tool_name)
+            await running.client.disconnect()
+        if watcher is not None:
+            await asyncio.gather(watcher, return_exceptions=True)
+        return True
+
+    async def stop_all(self) -> None:
+        """Stops every running plugin backend."""
+
+        for plugin_id in tuple(self._running):
+            await self.stop(plugin_id)
+
+    async def call_rpc(
+        self,
+        plugin_id: str,
+        method: str,
+        payload: dict[str, object],
+    ) -> str:
+        """Calls one manifest-allowlisted backend method for a plugin desktop page."""
+
+        running = self._running.get(plugin_id)
+        if running is None:
+            raise RuntimeError(f"plugin backend is not running: {plugin_id}")
+        declaration = next(
+            (
+                item
+                for item in running.installed.manifest.rpc_methods
+                if item.method == method
+            ),
+            None,
+        )
+        if declaration is None:
+            raise PermissionError(f"plugin RPC method is not declared: {method}")
+        return await running.client.call(declaration.remote_name, payload)
+
+    async def _watch(self, plugin_id: str, client: McpClient) -> None:
+        try:
+            exit_code = await client.wait_until_exit()
+        except asyncio.CancelledError:
+            return
+        async with self._lock:
+            running = self._running.get(plugin_id)
+            if running is None or running.client is not client:
+                return
+            self._running.pop(plugin_id, None)
+            for tool_name in running.tool_names:
+                self._tool_registry.unregister(tool_name)
+        logger.warning("plugin backend exited (%s): code=%s", plugin_id, exit_code)
+
+    def _installed(self, plugin_id: str) -> InstalledPlugin:
+        installed = next(
+            (
+                item
+                for item in self._installer.list_installed()
+                if item.plugin_id == plugin_id
+            ),
+            None,
+        )
+        if installed is None:
+            raise KeyError(f"plugin is not installed: {plugin_id}")
+        return installed
+
+
+def _backend_command(entrypoint: Path) -> list[str]:
+    suffix = entrypoint.suffix.lower()
+    if suffix in {".py", ".pyz"}:
+        return [sys.executable, "-I", str(entrypoint)]
+    if suffix == ".exe" and os.name == "nt":
+        return [str(entrypoint)]
+    raise ValueError(f"unsupported plugin backend entrypoint: {entrypoint.name}")
+
+
+def _plugin_environment(plugin_id: str, data_dir: Path) -> dict[str, str]:
+    allowed_system_names = (
+        "SYSTEMROOT",
+        "WINDIR",
+        "TEMP",
+        "TMP",
+        "LANG",
+        "LC_ALL",
+    )
+    environment = {
+        name: os.environ[name] for name in allowed_system_names if name in os.environ
+    }
+    environment.update(
+        {
+            "PYTHONIOENCODING": "utf-8",
+            "PYTHONUTF8": "1",
+            "SHIORI_PLUGIN_ID": plugin_id,
+            "SHIORI_PLUGIN_DATA_DIR": str(data_dir),
+        }
+    )
+    return environment

--- a/agent/plugin_runtime/tool.py
+++ b/agent/plugin_runtime/tool.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from typing import Any
+
+from agent.mcp.client import McpClient, McpToolInfo
+from agent.plugin_packages.contracts import PluginToolDeclaration
+from agent.tools.base import Tool
+
+
+class PluginMcpTool(Tool):
+    """Exposes one manifest-allowlisted plugin MCP tool to the Agent runtime."""
+
+    def __init__(
+        self,
+        client: McpClient,
+        info: McpToolInfo,
+        declaration: PluginToolDeclaration,
+        *,
+        plugin_name: str,
+    ) -> None:
+        self._client = client
+        self._info = info
+        self._declaration = declaration
+        self._plugin_name = plugin_name
+
+    @property
+    def name(self) -> str:
+        return self._declaration.name
+
+    @property
+    def description(self) -> str:
+        return f"[{self._plugin_name}] {self._info.description}".strip()
+
+    @property
+    def parameters(self) -> dict[str, Any]:
+        return self._info.input_schema
+
+    async def execute(self, **kwargs: Any) -> str:
+        """Forwards one tool call to the isolated plugin MCP process."""
+
+        return await self._client.call(self._declaration.remote_name, kwargs)

--- a/bootstrap/tools.py
+++ b/bootstrap/tools.py
@@ -7,6 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 
 if TYPE_CHECKING:
     from agent.plugin_packages import PluginPackageService
+    from agent.plugin_runtime import PluginRuntimeManager
     from agent.plugins.manager import PluginManager
 
 from agent.config_models import Config, WiringConfig
@@ -95,12 +96,15 @@ class CoreRuntime:
     image_sync_service: ExternalImageSyncService | None = None
     agent_provider: LLMProvider | None = None
     plugin_packages: "PluginPackageService | None" = None
+    plugin_runtime: "PluginRuntimeManager | None" = None
     plugin_manager: "PluginManager | None" = None
     memory_optimizer: Any | None = None
     screen_observation: ScreenObservationService | None = None
 
     async def start(self) -> None:
         self.mcp_registry.start_connect_all_background()
+        if self.plugin_runtime is not None:
+            await self.plugin_runtime.start_all()
         if self.plugin_manager is not None:
             await self.plugin_manager.load_all()
             logger.info("插件加载完成: %d 个", self.plugin_manager.loaded_count)
@@ -244,6 +248,8 @@ class CoreRuntime:
     async def stop(self) -> None:
         if self.plugin_manager is not None:
             await self.plugin_manager.terminate_all()
+        if self.plugin_runtime is not None:
+            await self.plugin_runtime.stop_all()
         await self.mcp_registry.shutdown()
         await self.event_bus.aclose()
 
@@ -604,15 +610,21 @@ def build_core_runtime(
         PluginPackageInstaller,
         PluginPackageService,
     )
+    from agent.plugin_runtime import PluginRuntimeManager
 
+    plugin_installer = PluginPackageInstaller(
+        workspace,
+        http_resources.external_default,
+    )
     plugin_packages = PluginPackageService(
         GitHubPluginCatalog(
             http_resources.external_default,
             organization=config.plugin_distribution.organization,
             api_version=config.plugin_distribution.api_version,
         ),
-        PluginPackageInstaller(workspace, http_resources.external_default),
+        plugin_installer,
     )
+    plugin_runtime = PluginRuntimeManager(workspace, plugin_installer, tools)
     plugin_light_provider, plugin_light_model = _resolve_plugin_llm_dependencies(
         config,
         provider,
@@ -653,6 +665,7 @@ def build_core_runtime(
         relationship_runtime=relationship_runtime,
         role_world_registry=role_world_registry,
         plugin_packages=plugin_packages,
+        plugin_runtime=plugin_runtime,
         plugin_manager=plugin_manager,
         screen_observation=screen_observation,
     )

--- a/desktop/src/electron-shim.d.ts
+++ b/desktop/src/electron-shim.d.ts
@@ -35,6 +35,7 @@ declare module "electron" {
     alwaysOnTop?: boolean;
     hasShadow?: boolean;
     backgroundColor?: string;
+    show?: boolean;
     webPreferences?: {
       preload?: string;
       contextIsolation?: boolean;

--- a/desktop/src/ipc.ts
+++ b/desktop/src/ipc.ts
@@ -40,6 +40,7 @@ type RegisterDesktopIpcOptions = {
   voicePlayback: BrowserVoicePlayback;
   onVoiceSettingsChanged?: () => void;
   onPetVisibilityChanged?: () => void;
+  onPluginPackagesChanged?: () => Promise<void> | void;
 };
 
 function assetTransport<T>(value: T, assets: LocalAssetReference[]): LocalAssetTransport<T> {
@@ -94,6 +95,7 @@ export function registerDesktopIpc({
   voicePlayback,
   onVoiceSettingsChanged,
   onPetVisibilityChanged,
+  onPluginPackagesChanged,
 }: RegisterDesktopIpcOptions): void {
   const dragPreviewIconPath = resolve(desktopRoot, "..", "assets", "drag-file-icon.png");
 
@@ -102,6 +104,12 @@ export function registerDesktopIpc({
       throw new Error("observation bridge methods are restricted to the main process");
     }
     const response = await bridge.invoke(request);
+    if (
+      !response.error
+      && ["plugins.install", "plugins.uninstall", "plugins.enable", "plugins.disable"].includes(request.method)
+    ) {
+      await onPluginPackagesChanged?.();
+    }
     return assetTransport(response, localAssets.grantTrustedPayload(response.payload));
   });
   ipcMain.on("desktop:start-attachment-drag", (event: IpcMainInvokeEvent, request?: { path?: unknown }) => {

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -8,7 +8,11 @@ import { logDesktopDiagnostic } from "./diagnostics.js";
 import { registerDesktopIpc } from "./ipc.js";
 import { openGrantedLocalAsset } from "./localAssetOpen.js";
 import { LocalAssetRegistry, localAssetScheme } from "./localAssetRegistry.js";
-import { desktopRoot } from "./paths.js";
+import { desktopRoot, pluginPreloadScript } from "./paths.js";
+import { PluginDesktopHost } from "./plugins/host.js";
+import { registerPluginHostIpc } from "./plugins/ipc.js";
+import { pluginResourceSchemePrivileges, registerPluginResourceProtocol } from "./plugins/protocol.js";
+import { pluginResourceScheme } from "./plugins/resourceRegistry.js";
 import { createDesktopTray } from "./tray.js";
 import { createDesktopWindow, showDesktopWindow } from "./window.js";
 import {
@@ -36,6 +40,7 @@ app.commandLine.appendSwitch("autoplay-policy", "no-user-gesture-required");
 
 const bridge = new DesktopBridgeClient();
 const localAssets = new LocalAssetRegistry();
+const pluginHost = new PluginDesktopHost(pluginPreloadScript);
 const trayLifecycleEnabled = process.platform === "win32";
 const hasSingleInstanceLock = app.requestSingleInstanceLock();
 let desktopWindow: BrowserWindow | null = null;
@@ -59,6 +64,10 @@ protocol.registerSchemesAsPrivileged([
   {
     scheme: localAssetScheme,
     privileges: localAssetSchemePrivileges,
+  },
+  {
+    scheme: pluginResourceScheme,
+    privileges: pluginResourceSchemePrivileges,
   },
 ]);
 
@@ -272,7 +281,11 @@ void app.whenReady().then(() => {
     process.env.MIRA_RENDERER_DEV_SERVER_URL,
   );
   registerLocalAssetProtocol(protocol, localAssets);
-  void startBridge(bridge);
+  registerPluginResourceProtocol(protocol, pluginHost.resources);
+  registerPluginHostIpc(pluginHost, bridge);
+  void startBridge(bridge).then(() => pluginHost.syncFromBridge(bridge)).catch((error) => {
+    logDesktopDiagnostic({ scope: "main", event: "plugin-host.sync.failed", payload: { error } });
+  });
   desktopPet = new DesktopPetController({
     getSettings: () => desktopPetSettings,
     saveSettings: persistDesktopPetSettings,
@@ -370,6 +383,9 @@ void app.whenReady().then(() => {
     voicePlayback: activeVoicePlayback,
     onVoiceSettingsChanged: reloadVoiceSettings,
     onPetVisibilityChanged: syncVoiceAvailability,
+    onPluginPackagesChanged: async () => {
+      await pluginHost.syncFromBridge(bridge);
+    },
   });
   getOrCreateDesktopWindow();
   if (trayLifecycleEnabled) {
@@ -429,6 +445,7 @@ app.on("before-quit", (event) => {
   voiceController?.dispose();
   voicePlayback?.dispose();
   voiceRecorder?.dispose();
+  pluginHost.shutdown();
   if (bridgeShutdownStarted || !bridge.isRunning()) {
     return;
   }

--- a/desktop/src/paths.ts
+++ b/desktop/src/paths.ts
@@ -28,3 +28,6 @@ export const rendererDevServerUrl = process.env.MIRA_RENDERER_DEV_SERVER_URL;
 
 /** Absolute path to the compiled preload script loaded by Electron. */
 export const preloadScript = resolve(here, "preload.js");
+
+/** Absolute path to the restricted preload used by sandboxed plugin pages. */
+export const pluginPreloadScript = resolve(here, "pluginPreload.js");

--- a/desktop/src/pluginPreload.ts
+++ b/desktop/src/pluginPreload.ts
@@ -1,0 +1,17 @@
+import { contextBridge, ipcRenderer } from "electron";
+
+export type ShioriPluginApi = {
+  context(): Promise<{ pluginId: string; contributionId: string }>;
+  rpc(method: string, payload?: Record<string, unknown>): Promise<unknown>;
+};
+
+const api: ShioriPluginApi = Object.freeze({
+  context() {
+    return ipcRenderer.invoke("shiori-plugin:context") as Promise<{ pluginId: string; contributionId: string }>;
+  },
+  rpc(method, payload = {}) {
+    return ipcRenderer.invoke("shiori-plugin:rpc", { method, payload });
+  },
+});
+
+contextBridge.exposeInMainWorld("shioriPlugin", api);

--- a/desktop/src/plugins/host.ts
+++ b/desktop/src/plugins/host.ts
@@ -1,0 +1,117 @@
+import { BrowserWindow } from "electron";
+import type { DesktopBridgeClient } from "../bridgeClient.js";
+import type { InstalledDesktopPlugin, PluginOverlayContribution } from "./types.js";
+import { parseInstalledDesktopPlugins } from "./types.js";
+import { PluginResourceRegistry, pluginResourceScheme } from "./resourceRegistry.js";
+
+export type PluginPageOwner = {
+  pluginId: string;
+  contributionId: string;
+  rpcMethods: ReadonlySet<string>;
+};
+
+type HostedWindow = { window: BrowserWindow; signature: string };
+
+/** Owns sandboxed plugin windows and their trusted sender-to-plugin identity mapping. */
+export class PluginDesktopHost {
+  readonly resources = new PluginResourceRegistry();
+  private readonly windows = new Map<string, HostedWindow>();
+  private readonly owners = new Map<object, PluginPageOwner>();
+
+  constructor(private readonly preloadPath: string) {}
+
+  ownerFor(sender: object): PluginPageOwner | null {
+    return this.owners.get(sender) ?? null;
+  }
+
+  async syncFromBridge(bridge: DesktopBridgeClient): Promise<void> {
+    const response = await bridge.invoke({ method: "plugins.installed", payload: {} });
+    if (response.error) throw new Error(response.error.message);
+    await this.sync(parseInstalledDesktopPlugins(response.payload.plugins));
+  }
+
+  async sync(plugins: readonly InstalledDesktopPlugin[]): Promise<void> {
+    const enabled = plugins.filter((plugin) => plugin.enabled);
+    this.resources.replace(enabled);
+    const desired = new Map<string, { plugin: InstalledDesktopPlugin; contribution: PluginOverlayContribution; signature: string }>();
+    for (const plugin of enabled) {
+      for (const contribution of plugin.contributions) {
+        const key = `${plugin.pluginId}:${contribution.id}`;
+        desired.set(key, {
+          plugin,
+          contribution,
+          signature: JSON.stringify({ packageDir: plugin.packageDir, contribution, rpcMethods: plugin.rpcMethods }),
+        });
+      }
+    }
+    for (const [key, hosted] of this.windows) {
+      const next = desired.get(key);
+      if (!next || next.signature !== hosted.signature) {
+        hosted.window.destroy();
+        this.windows.delete(key);
+        this.owners.delete(hosted.window.webContents);
+      }
+    }
+    for (const [key, item] of desired) {
+      if (!this.windows.has(key)) this.createWindow(key, item.plugin, item.contribution, item.signature);
+    }
+  }
+
+  shutdown(): void {
+    for (const hosted of this.windows.values()) hosted.window.destroy();
+    this.windows.clear();
+    this.owners.clear();
+    this.resources.replace([]);
+  }
+
+  private createWindow(key: string, plugin: InstalledDesktopPlugin, contribution: PluginOverlayContribution, signature: string): void {
+    const window = new BrowserWindow({
+      width: contribution.width,
+      height: contribution.height,
+      frame: contribution.frame,
+      transparent: contribution.transparent,
+      resizable: contribution.resizable,
+      skipTaskbar: contribution.skipTaskbar,
+      alwaysOnTop: contribution.alwaysOnTop,
+      hasShadow: !contribution.transparent,
+      show: false,
+      webPreferences: {
+        preload: this.preloadPath,
+        contextIsolation: true,
+        nodeIntegration: false,
+        sandbox: true,
+        spellcheck: false,
+      },
+    });
+    if (contribution.alwaysOnTop) {
+      window.setAlwaysOnTop(true, "normal");
+      window.setVisibleOnAllWorkspaces(true, { visibleOnFullScreen: true });
+    }
+    this.owners.set(window.webContents, {
+      pluginId: plugin.pluginId,
+      contributionId: contribution.id,
+      rpcMethods: new Set(plugin.rpcMethods.map((method) => method.method)),
+    });
+    this.windows.set(key, { window, signature });
+    window.webContents.on("will-navigate", (event: { preventDefault(): void }, target: string) => {
+      try {
+        const requested = new URL(target);
+        if (requested.protocol === `${pluginResourceScheme}:` && requested.hostname === plugin.pluginId) return;
+      } catch {
+        // Invalid navigation is denied below.
+      }
+      event.preventDefault();
+    });
+    window.webContents.setWindowOpenHandler(() => ({ action: "deny" }));
+    window.once("ready-to-show", () => window.showInactive());
+    window.on("closed", () => {
+      if (this.windows.get(key)?.window === window) this.windows.delete(key);
+      this.owners.delete(window.webContents);
+    });
+    window.webContents.on("render-process-gone", () => {
+      this.owners.delete(window.webContents);
+      if (!window.isDestroyed()) window.destroy();
+    });
+    void window.loadURL(this.resources.entryUrl(plugin.pluginId, contribution.entrypoint));
+  }
+}

--- a/desktop/src/plugins/hostSecurity.test.ts
+++ b/desktop/src/plugins/hostSecurity.test.ts
@@ -1,0 +1,25 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { describe, it } from "node:test";
+
+const hostSource = readFileSync(new URL("./host.ts", import.meta.url), "utf-8");
+const ipcSource = readFileSync(new URL("./ipc.ts", import.meta.url), "utf-8");
+const preloadSource = readFileSync(new URL("../pluginPreload.ts", import.meta.url), "utf-8");
+
+describe("plugin desktop host security", () => {
+  it("uses a separate sandboxed preload and denies child windows", () => {
+    assert.match(hostSource, /sandbox:\s*true/);
+    assert.match(hostSource, /contextIsolation:\s*true/);
+    assert.match(hostSource, /nodeIntegration:\s*false/);
+    assert.match(hostSource, /setWindowOpenHandler\(\(\) => \(\{ action: "deny" \}\)\)/);
+  });
+
+  it("infers plugin identity from the sender and exposes no desktop bridge", () => {
+    assert.match(ipcSource, /host\.ownerFor\(event\.sender\)/);
+    assert.doesNotMatch(ipcSource, /request\.plugin_id/);
+    assert.match(preloadSource, /exposeInMainWorld\("shioriPlugin"/);
+    assert.doesNotMatch(preloadSource, /desktop:invoke/);
+  });
+});

--- a/desktop/src/plugins/ipc.ts
+++ b/desktop/src/plugins/ipc.ts
@@ -1,0 +1,31 @@
+import { ipcMain, type IpcMainInvokeEvent } from "electron";
+import type { DesktopBridgeClient } from "../bridgeClient.js";
+import type { PluginDesktopHost } from "./host.js";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+/** Registers the only IPC methods exposed to sandboxed plugin pages. */
+export function registerPluginHostIpc(host: PluginDesktopHost, bridge: DesktopBridgeClient): void {
+  ipcMain.handle("shiori-plugin:context", (event: IpcMainInvokeEvent) => {
+    const owner = host.ownerFor(event.sender);
+    if (!owner) throw new Error("plugin page is not registered");
+    return { pluginId: owner.pluginId, contributionId: owner.contributionId };
+  });
+  ipcMain.handle("shiori-plugin:rpc", async (event: IpcMainInvokeEvent, request: unknown) => {
+    const owner = host.ownerFor(event.sender);
+    if (!owner) throw new Error("plugin page is not registered");
+    if (!isRecord(request)) throw new Error("plugin RPC request must be an object");
+    const method = typeof request.method === "string" ? request.method.trim() : "";
+    const payload = request.payload === undefined ? {} : request.payload;
+    if (!method || !owner.rpcMethods.has(method)) throw new Error(`plugin RPC method is not declared: ${method}`);
+    if (!isRecord(payload)) throw new Error("plugin RPC payload must be an object");
+    const response = await bridge.invoke({
+      method: "plugins.rpc",
+      payload: { plugin_id: owner.pluginId, method, payload },
+    });
+    if (response.error) throw new Error(response.error.message);
+    return response.payload.result;
+  });
+}

--- a/desktop/src/plugins/protocol.test.ts
+++ b/desktop/src/plugins/protocol.test.ts
@@ -1,0 +1,65 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { mkdtemp, rm, symlink, unlink, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, it } from "node:test";
+import { loadPluginResource, pluginResourceSchemePrivileges } from "./protocol";
+import { PluginResourceRegistry } from "./resourceRegistry";
+
+const temporaryDirectories: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(temporaryDirectories.splice(0).map((path) => rm(path, { recursive: true, force: true })));
+});
+
+async function temporaryDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), "shiori-plugin-protocol-"));
+  temporaryDirectories.push(directory);
+  return directory;
+}
+
+describe("plugin resource protocol", () => {
+  it("serves only registered package files with a restrictive CSP", async () => {
+    const root = await temporaryDirectory();
+    await writeFile(join(root, "index.html"), "<main>plugin</main>", "utf-8");
+    const registry = new PluginResourceRegistry();
+    registry.replace([{ pluginId: "desktop-pet", packageDir: root }]);
+
+    const response = await loadPluginResource(registry, "shiori-plugin://desktop-pet/index.html");
+    const denied = await loadPluginResource(registry, "shiori-plugin://unknown/index.html");
+
+    assert.equal(response.status, 200);
+    assert.equal(await response.text(), "<main>plugin</main>");
+    assert.match(response.headers.get("Content-Security-Policy") ?? "", /connect-src 'none'/);
+    assert.equal(denied.status, 403);
+    assert.deepEqual(pluginResourceSchemePrivileges, { standard: true, secure: true, supportFetchAPI: true });
+  });
+
+  it("rejects traversal and symlink escapes from the registered package", async (testContext) => {
+    const root = await temporaryDirectory();
+    const outside = await temporaryDirectory();
+    const outsideFile = join(outside, "secret.js");
+    const link = join(root, "linked.js");
+    await writeFile(outsideFile, "secret", "utf-8");
+    try {
+      await symlink(outsideFile, link, "file");
+    } catch (error) {
+      if (["EPERM", "EACCES"].includes((error as NodeJS.ErrnoException).code ?? "")) {
+        testContext.skip("file symlinks are unavailable in this Windows environment");
+        return;
+      }
+      throw error;
+    }
+    const registry = new PluginResourceRegistry();
+    registry.replace([{ pluginId: "desktop-pet", packageDir: root }]);
+
+    const traversal = await loadPluginResource(registry, "shiori-plugin://desktop-pet/../secret.js");
+    const escaped = await loadPluginResource(registry, "shiori-plugin://desktop-pet/linked.js");
+
+    assert.notEqual(traversal.status, 200);
+    assert.equal(escaped.status, 403);
+    await unlink(link);
+  });
+});

--- a/desktop/src/plugins/protocol.ts
+++ b/desktop/src/plugins/protocol.ts
@@ -1,0 +1,116 @@
+import { readFile, realpath, stat } from "node:fs/promises";
+import { extname, relative, resolve } from "node:path";
+import { PluginResourceRegistry, pluginResourceScheme } from "./resourceRegistry.js";
+
+export const maxPluginResourceBytes = 32 * 1024 * 1024;
+export const pluginResourceSchemePrivileges = Object.freeze({
+  standard: true,
+  secure: true,
+  supportFetchAPI: true,
+});
+
+const MIME_TYPES: Readonly<Record<string, string>> = Object.freeze({
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".mp3": "audio/mpeg",
+  ".wav": "audio/wav",
+});
+
+const PLUGIN_CSP = [
+  "default-src 'self'",
+  "script-src 'self'",
+  "style-src 'self' 'unsafe-inline'",
+  "img-src 'self' data: blob:",
+  "media-src 'self' data: blob:",
+  "font-src 'self' data:",
+  "connect-src 'none'",
+  "object-src 'none'",
+  "base-uri 'none'",
+  "form-action 'none'",
+  "frame-ancestors 'none'",
+].join("; ");
+
+type ProtocolRegistrar = {
+  handle(scheme: string, handler: (request: { url: string }) => Promise<Response> | Response): void;
+};
+
+function errorResponse(message: string, status: number): Response {
+  return new Response(message, {
+    status,
+    headers: { "Cache-Control": "no-store", "X-Content-Type-Options": "nosniff" },
+  });
+}
+
+/** Serves one file contained by an installed plugin package root. */
+export async function loadPluginResource(
+  registry: PluginResourceRegistry,
+  requestUrl: string,
+): Promise<Response> {
+  let url: URL;
+  try {
+    url = new URL(requestUrl);
+  } catch {
+    return errorResponse("invalid plugin resource URL", 400);
+  }
+  if (url.protocol !== `${pluginResourceScheme}:` || url.search || url.hash) {
+    return errorResponse("invalid plugin resource URL", 400);
+  }
+  const packageRoot = registry.packageRoot(url.hostname);
+  if (!packageRoot) return errorResponse("plugin package is not registered", 403);
+  let requestedPath: string;
+  try {
+    requestedPath = decodeURIComponent(url.pathname.replace(/^\/+/, ""));
+  } catch {
+    return errorResponse("invalid plugin resource path", 400);
+  }
+  if (!requestedPath || requestedPath.includes("\\") || requestedPath.split("/").includes("..")) {
+    return errorResponse("invalid plugin resource path", 400);
+  }
+  const mimeType = MIME_TYPES[extname(requestedPath).toLowerCase()];
+  if (!mimeType) return errorResponse("plugin resource type is not allowed", 415);
+  try {
+    const canonicalRoot = await realpath(packageRoot);
+    const canonicalTarget = await realpath(resolve(canonicalRoot, requestedPath));
+    const containment = relative(canonicalRoot, canonicalTarget);
+    if (!containment || containment.startsWith("..") || resolve(canonicalRoot, containment) !== canonicalTarget) {
+      return errorResponse("plugin resource escapes package root", 403);
+    }
+    const fileStats = await stat(canonicalTarget);
+    if (!fileStats.isFile()) return errorResponse("plugin resource is not a file", 403);
+    if (fileStats.size > maxPluginResourceBytes) return errorResponse("plugin resource exceeds size limit", 413);
+    const body = await readFile(canonicalTarget);
+    return new Response(body, {
+      status: 200,
+      headers: {
+        "Cache-Control": "no-store",
+        "Content-Length": String(body.byteLength),
+        "Content-Security-Policy": PLUGIN_CSP,
+        "Content-Type": mimeType,
+        "X-Content-Type-Options": "nosniff",
+      },
+    });
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code === "ENOENT") return errorResponse("plugin resource was not found", 404);
+    if (code === "EACCES" || code === "EPERM") return errorResponse("plugin resource access was denied", 403);
+    return errorResponse("plugin resource could not be loaded", 500);
+  }
+}
+
+/** Registers the isolated plugin resource protocol. */
+export function registerPluginResourceProtocol(
+  protocol: ProtocolRegistrar,
+  registry: PluginResourceRegistry,
+): void {
+  protocol.handle(pluginResourceScheme, (request) => loadPluginResource(registry, request.url));
+}

--- a/desktop/src/plugins/resourceRegistry.ts
+++ b/desktop/src/plugins/resourceRegistry.ts
@@ -1,0 +1,27 @@
+import { isAbsolute, resolve } from "node:path";
+
+export const pluginResourceScheme = "shiori-plugin";
+
+/** Tracks package roots that the main process has accepted from installed records. */
+export class PluginResourceRegistry {
+  private readonly roots = new Map<string, string>();
+
+  replace(entries: Iterable<{ pluginId: string; packageDir: string }>): void {
+    const next = new Map<string, string>();
+    for (const entry of entries) {
+      if (isAbsolute(entry.packageDir)) {
+        next.set(entry.pluginId, resolve(entry.packageDir));
+      }
+    }
+    this.roots.clear();
+    for (const [pluginId, packageDir] of next) this.roots.set(pluginId, packageDir);
+  }
+
+  packageRoot(pluginId: string): string | null {
+    return this.roots.get(pluginId) ?? null;
+  }
+
+  entryUrl(pluginId: string, entrypoint: string): string {
+    return `${pluginResourceScheme}://${pluginId}/${entrypoint.split("/").map(encodeURIComponent).join("/")}`;
+  }
+}

--- a/desktop/src/plugins/types.test.ts
+++ b/desktop/src/plugins/types.test.ts
@@ -1,0 +1,46 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { parseInstalledDesktopPlugins } from "./types";
+
+describe("installed desktop plugin records", () => {
+  it("accepts only enabled host contracts with matching identities and declared capabilities", () => {
+    const parsed = parseInstalledDesktopPlugins([{
+      plugin_id: "desktop-pet",
+      package_dir: "C:\\plugins\\desktop-pet\\1.0.0",
+      enabled: true,
+      manifest: {
+        plugin_id: "desktop-pet",
+        name: "Desktop Pet",
+        capabilities: ["desktop.overlay", "plugin.rpc"],
+        rpc_methods: [{ method: "pet.state", remote_name: "pet_state" }],
+        desktop_contributions: [{
+          id: "pet-overlay",
+          kind: "overlay",
+          entrypoint: "desktop/index.html",
+          width: 480,
+          height: 680,
+          transparent: true,
+          always_on_top: true,
+        }],
+      },
+    }, {
+      plugin_id: "spoofed",
+      package_dir: "C:\\plugins\\spoofed",
+      enabled: true,
+      manifest: {
+        plugin_id: "different",
+        name: "Spoofed",
+        capabilities: [],
+        rpc_methods: [],
+        desktop_contributions: [],
+      },
+    }]);
+
+    assert.equal(parsed.length, 1);
+    assert.equal(parsed[0]?.pluginId, "desktop-pet");
+    assert.deepEqual([...parsed[0]!.capabilities], ["desktop.overlay", "plugin.rpc"]);
+    assert.equal(parsed[0]?.contributions[0]?.transparent, true);
+  });
+});

--- a/desktop/src/plugins/types.ts
+++ b/desktop/src/plugins/types.ts
@@ -1,0 +1,139 @@
+import { isAbsolute } from "node:path";
+
+export type PluginRpcMethod = {
+  method: string;
+  remoteName: string;
+};
+
+export type PluginOverlayContribution = {
+  id: string;
+  kind: "overlay";
+  entrypoint: string;
+  width: number;
+  height: number;
+  transparent: boolean;
+  alwaysOnTop: boolean;
+  skipTaskbar: boolean;
+  resizable: boolean;
+  frame: boolean;
+};
+
+export type InstalledDesktopPlugin = {
+  pluginId: string;
+  name: string;
+  packageDir: string;
+  enabled: boolean;
+  capabilities: ReadonlySet<string>;
+  rpcMethods: readonly PluginRpcMethod[];
+  contributions: readonly PluginOverlayContribution[];
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value && typeof value === "object" && !Array.isArray(value));
+}
+
+function requiredString(value: Record<string, unknown>, key: string): string | null {
+  const candidate = value[key];
+  return typeof candidate === "string" && candidate.trim() ? candidate.trim() : null;
+}
+
+function optionalBoolean(value: Record<string, unknown>, key: string, fallback: boolean): boolean | null {
+  const candidate = value[key];
+  if (candidate === undefined) return fallback;
+  return typeof candidate === "boolean" ? candidate : null;
+}
+
+function parseRpcMethods(value: unknown): PluginRpcMethod[] | null {
+  if (!Array.isArray(value)) return null;
+  const methods: PluginRpcMethod[] = [];
+  const publicNames = new Set<string>();
+  for (const item of value) {
+    if (!isRecord(item)) return null;
+    const method = requiredString(item, "method");
+    const remoteName = requiredString(item, "remote_name");
+    if (!method || !remoteName || publicNames.has(method)) return null;
+    publicNames.add(method);
+    methods.push({ method, remoteName });
+  }
+  return methods;
+}
+
+function parseContributions(value: unknown): PluginOverlayContribution[] | null {
+  if (!Array.isArray(value)) return null;
+  const contributions: PluginOverlayContribution[] = [];
+  const ids = new Set<string>();
+  for (const item of value) {
+    if (!isRecord(item)) return null;
+    const id = requiredString(item, "id");
+    const entrypoint = requiredString(item, "entrypoint");
+    const width = item.width;
+    const height = item.height;
+    if (
+      !id
+      || !entrypoint
+      || item.kind !== "overlay"
+      || ids.has(id)
+      || !Number.isInteger(width)
+      || !Number.isInteger(height)
+    ) return null;
+    const transparent = optionalBoolean(item, "transparent", false);
+    const alwaysOnTop = optionalBoolean(item, "always_on_top", false);
+    const skipTaskbar = optionalBoolean(item, "skip_taskbar", true);
+    const resizable = optionalBoolean(item, "resizable", false);
+    const frame = optionalBoolean(item, "frame", false);
+    if ([transparent, alwaysOnTop, skipTaskbar, resizable, frame].includes(null)) return null;
+    ids.add(id);
+    contributions.push({
+      id,
+      kind: "overlay",
+      entrypoint,
+      width: width as number,
+      height: height as number,
+      transparent: transparent as boolean,
+      alwaysOnTop: alwaysOnTop as boolean,
+      skipTaskbar: skipTaskbar as boolean,
+      resizable: resizable as boolean,
+      frame: frame as boolean,
+    });
+  }
+  return contributions;
+}
+
+/** Parses bridge data into the strict subset consumed by the Electron plugin host. */
+export function parseInstalledDesktopPlugins(value: unknown): InstalledDesktopPlugin[] {
+  if (!Array.isArray(value)) return [];
+  const plugins: InstalledDesktopPlugin[] = [];
+  for (const item of value) {
+    if (!isRecord(item) || !isRecord(item.manifest)) continue;
+    const pluginId = requiredString(item, "plugin_id");
+    const packageDir = requiredString(item, "package_dir");
+    const name = requiredString(item.manifest, "name");
+    const manifestPluginId = requiredString(item.manifest, "plugin_id");
+    if (
+      !pluginId
+      || pluginId !== manifestPluginId
+      || !packageDir
+      || !isAbsolute(packageDir)
+      || !name
+      || typeof item.enabled !== "boolean"
+      || !Array.isArray(item.manifest.capabilities)
+      || !item.manifest.capabilities.every((capability) => typeof capability === "string")
+    ) continue;
+    const rpcMethods = parseRpcMethods(item.manifest.rpc_methods);
+    const contributions = parseContributions(item.manifest.desktop_contributions);
+    if (!rpcMethods || !contributions) continue;
+    const capabilities = new Set(item.manifest.capabilities as string[]);
+    if (rpcMethods.length > 0 && !capabilities.has("plugin.rpc")) continue;
+    if (contributions.length > 0 && !capabilities.has("desktop.overlay")) continue;
+    plugins.push({
+      pluginId,
+      name,
+      packageDir,
+      enabled: item.enabled,
+      capabilities,
+      rpcMethods,
+      contributions,
+    });
+  }
+  return plugins;
+}

--- a/desktop/tsconfig.main.json
+++ b/desktop/tsconfig.main.json
@@ -8,6 +8,7 @@
   },
   "include": [
     "src/main.ts",
+    "src/plugins/**/*.ts",
     "src/pet/**/*.ts",
     "src/observation/**/*.ts",
     "src/voice/**/*.ts",

--- a/desktop/tsconfig.preload.json
+++ b/desktop/tsconfig.preload.json
@@ -6,5 +6,5 @@
     "rootDir": "./src",
     "types": ["node"]
   },
-  "include": ["src/preload.ts", "src/shared.ts", "src/electron-shim.d.ts"]
+  "include": ["src/preload.ts", "src/pluginPreload.ts", "src/shared.ts", "src/electron-shim.d.ts"]
 }

--- a/desktop_bridge/plugin_package_requests.py
+++ b/desktop_bridge/plugin_package_requests.py
@@ -3,13 +3,19 @@ from __future__ import annotations
 from typing import Any
 
 from agent.plugin_packages import PluginPackageService
+from agent.plugin_runtime import PluginRuntimeManager
 
 
 class DesktopPluginPackageRequestHandler:
     """Handles package catalog and installation RPCs for the desktop client."""
 
-    def __init__(self, service: PluginPackageService) -> None:
+    def __init__(
+        self,
+        service: PluginPackageService,
+        runtime: PluginRuntimeManager | None = None,
+    ) -> None:
         self._service = service
+        self._runtime = runtime
 
     async def handle(
         self,
@@ -29,6 +35,12 @@ class DesktopPluginPackageRequestHandler:
             if not repository:
                 raise ValueError("repository is required")
             installed = await self._service.install(repository)
+            if self._runtime is not None and installed.enabled:
+                try:
+                    await self._runtime.start(installed.plugin_id)
+                except Exception:
+                    self._service.set_enabled(installed.plugin_id, False)
+                    raise
             return {"plugin": installed.to_dict()}
         if method == "plugins.uninstall":
             plugin_id = str(payload.get("plugin_id") or "").strip()
@@ -37,10 +49,51 @@ class DesktopPluginPackageRequestHandler:
             purge_data = payload.get("purge_data", False)
             if not isinstance(purge_data, bool):
                 raise ValueError("purge_data must be a boolean")
+            if self._runtime is not None:
+                await self._runtime.stop(plugin_id)
             return {
                 "removed": self._service.uninstall(
                     plugin_id,
                     purge_data=purge_data,
                 )
             }
+        if method == "plugins.enable":
+            plugin_id = _required_plugin_id(payload)
+            plugin = self._service.set_enabled(plugin_id, True)
+            if self._runtime is not None:
+                try:
+                    await self._runtime.start(plugin_id)
+                except Exception:
+                    self._service.set_enabled(plugin_id, False)
+                    raise
+            return {"plugin": plugin}
+        if method == "plugins.disable":
+            plugin_id = _required_plugin_id(payload)
+            if self._runtime is not None:
+                await self._runtime.stop(plugin_id)
+            return {"plugin": self._service.set_enabled(plugin_id, False)}
+        if method == "plugins.rpc":
+            if self._runtime is None:
+                raise RuntimeError("plugin runtime is unavailable")
+            plugin_id = _required_plugin_id(payload)
+            rpc_method = str(payload.get("method") or "").strip()
+            if not rpc_method:
+                raise ValueError("method is required")
+            rpc_payload = payload.get("payload", {})
+            if not isinstance(rpc_payload, dict):
+                raise ValueError("payload must be an object")
+            return {
+                "result": await self._runtime.call_rpc(
+                    plugin_id,
+                    rpc_method,
+                    rpc_payload,
+                )
+            }
         raise ValueError(f"unknown plugin package method: {method}")
+
+
+def _required_plugin_id(payload: dict[str, Any]) -> str:
+    plugin_id = str(payload.get("plugin_id") or "").strip()
+    if not plugin_id:
+        raise ValueError("plugin_id is required")
+    return plugin_id

--- a/desktop_bridge/server.py
+++ b/desktop_bridge/server.py
@@ -55,6 +55,7 @@ class DesktopBridgeServer:
             role_world_registry=getattr(runtime, "role_world_registry", None),
             image_tool=image_tool,
             plugin_packages=getattr(runtime, "plugin_packages", None),
+            plugin_runtime=getattr(runtime, "plugin_runtime", None),
         )
         self._pet_action_handler = self._handle_pet_action
         runtime.event_bus.on(DesktopPetActionRequested, self._pet_action_handler)

--- a/desktop_bridge/service.py
+++ b/desktop_bridge/service.py
@@ -7,6 +7,7 @@ from typing import Any, cast
 
 from agent.looping.core import AgentLoop
 from agent.plugin_packages import PluginPackageService
+from agent.plugin_runtime import PluginRuntimeManager
 from agent.tools.message_push import MessagePushTool
 from bus.event_bus import EventBus
 from bus.events_lifecycle import (
@@ -102,6 +103,7 @@ class DesktopBridgeService:
         story_director: Any | None = None,
         image_tool: Any | None = None,
         plugin_packages: PluginPackageService | None = None,
+        plugin_runtime: PluginRuntimeManager | None = None,
     ) -> None:
         self.workspace = workspace
         self.role_store = role_store
@@ -242,7 +244,7 @@ class DesktopBridgeService:
             stories=self.story_simulation,
             observation=observation_service,
             plugin_packages=(
-                DesktopPluginPackageRequestHandler(plugin_packages)
+                DesktopPluginPackageRequestHandler(plugin_packages, plugin_runtime)
                 if plugin_packages is not None
                 else None
             ),

--- a/tests/agent/plugin_packages/test_catalog.py
+++ b/tests/agent/plugin_packages/test_catalog.py
@@ -21,6 +21,13 @@ def _manifest(*, api_version: int = 1) -> dict[str, object]:
         "entrypoints": {"backend": "backend/main.py"},
         "capabilities": ["agent.tool"],
         "permissions": [],
+        "tools": [
+            {
+                "remote_name": "pet_action",
+                "name": "pet_action",
+                "always_on": True,
+            }
+        ],
         "release": {
             "asset": "desktop-pet.zip",
             "checksums_asset": "checksums.json",

--- a/tests/agent/plugin_packages/test_contracts.py
+++ b/tests/agent/plugin_packages/test_contracts.py
@@ -18,8 +18,31 @@ def _manifest(**overrides: object) -> dict[str, object]:
             "backend": "backend/main.py",
             "desktop": "desktop/index.html",
         },
-        "capabilities": ["agent.tool", "desktop.overlay"],
+        "capabilities": ["agent.tool", "desktop.overlay", "plugin.rpc"],
         "permissions": ["plugin.storage"],
+        "tools": [
+            {
+                "remote_name": "pet_action",
+                "name": "pet_action",
+                "risk": "external-side-effect",
+                "always_on": True,
+                "search_hint": "desktop pet action",
+            }
+        ],
+        "rpc_methods": [
+            {"method": "pet.state", "remote_name": "pet_state"},
+        ],
+        "desktop_contributions": [
+            {
+                "id": "pet-overlay",
+                "kind": "overlay",
+                "entrypoint": "desktop/index.html",
+                "width": 480,
+                "height": 680,
+                "transparent": True,
+                "always_on_top": True,
+            }
+        ],
         "release": {
             "asset": "desktop-pet-1.0.0-win32-x64.zip",
             "checksums_asset": "checksums.json",
@@ -35,6 +58,9 @@ def test_manifest_validates_host_and_serializes_contract() -> None:
     assert manifest.supports_host(os_name="win32", arch="x64", api_version=1)
     assert not manifest.supports_host(os_name="linux", arch="x64", api_version=1)
     assert manifest.to_dict()["plugin_id"] == "desktop-pet"
+    assert manifest.tools[0].name == "pet_action"
+    assert manifest.rpc_methods[0].method == "pet.state"
+    assert manifest.desktop_contributions[0].entrypoint == "desktop/index.html"
 
 
 @pytest.mark.parametrize(
@@ -61,5 +87,26 @@ def test_manifest_rejects_duplicate_capabilities() -> None:
     with pytest.raises(PluginManifestError, match="duplicate capabilities"):
         PluginManifest.from_mapping(
             _manifest(capabilities=["agent.tool", "agent.tool"]),
+            source="test",
+        )
+
+
+def test_manifest_rejects_tools_without_the_agent_tool_capability() -> None:
+    with pytest.raises(PluginManifestError, match="agent.tool"):
+        PluginManifest.from_mapping(
+            _manifest(capabilities=["desktop.overlay"]),
+            source="test",
+        )
+
+
+def test_manifest_rejects_desktop_and_rpc_contracts_without_capabilities() -> None:
+    with pytest.raises(PluginManifestError, match="plugin.rpc"):
+        PluginManifest.from_mapping(
+            _manifest(capabilities=["agent.tool", "desktop.overlay"]),
+            source="test",
+        )
+    with pytest.raises(PluginManifestError, match="desktop.overlay"):
+        PluginManifest.from_mapping(
+            _manifest(capabilities=["agent.tool", "plugin.rpc"]),
             source="test",
         )

--- a/tests/agent/plugin_packages/test_installer.py
+++ b/tests/agent/plugin_packages/test_installer.py
@@ -32,8 +32,29 @@ def _manifest(*, version: str = "1.0.0") -> PluginManifest:
                 "backend": "backend/main.py",
                 "desktop": "desktop/index.html",
             },
-            "capabilities": ["agent.tool", "desktop.overlay"],
+            "capabilities": ["agent.tool", "desktop.overlay", "plugin.rpc"],
             "permissions": ["plugin.storage"],
+            "tools": [
+                {
+                    "remote_name": "pet_action",
+                    "name": "pet_action",
+                    "always_on": True,
+                }
+            ],
+            "rpc_methods": [
+                {"method": "pet.state", "remote_name": "pet_state"},
+            ],
+            "desktop_contributions": [
+                {
+                    "id": "pet-overlay",
+                    "kind": "overlay",
+                    "entrypoint": "desktop/index.html",
+                    "width": 480,
+                    "height": 680,
+                    "transparent": True,
+                    "always_on_top": True,
+                }
+            ],
             "release": {
                 "asset": "desktop-pet.zip",
                 "checksums_asset": "checksums.json",
@@ -115,6 +136,7 @@ async def test_installer_atomically_selects_release_and_preserves_data_on_uninst
         tmp_path / "plugins" / "desktop-pet" / "versions" / "1.0.0"
     )
     assert installer.list_installed()[0].version == "1.0.0"
+    assert installer.set_enabled("desktop-pet", False).enabled is False
     assert installer.uninstall("desktop-pet") is True
     assert data_file.is_file()
 

--- a/tests/agent/plugin_runtime/__init__.py
+++ b/tests/agent/plugin_runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for isolated plugin runtime hosting."""

--- a/tests/agent/plugin_runtime/test_manager.py
+++ b/tests/agent/plugin_runtime/test_manager.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from agent.mcp.client import McpToolInfo
+from agent.plugin_packages import InstalledPlugin, PluginManifest
+from agent.plugin_runtime import PluginRuntimeManager
+from agent.tools.registry import ToolRegistry
+
+
+def _manifest() -> PluginManifest:
+    return PluginManifest.from_mapping(
+        {
+            "schema_version": 1,
+            "plugin_id": "desktop-pet",
+            "name": "Desktop Pet",
+            "description": "Desktop overlay pet",
+            "version": "1.0.0",
+            "plugin_api_version": 1,
+            "platforms": [{"os": "win32", "arch": "x64"}],
+            "entrypoints": {"backend": "backend/main.py"},
+            "capabilities": ["agent.tool", "plugin.rpc"],
+            "permissions": ["plugin.storage"],
+            "tools": [
+                {
+                    "remote_name": "pet_action",
+                    "name": "pet_action",
+                    "risk": "external-side-effect",
+                    "always_on": True,
+                    "search_hint": "desktop pet action",
+                }
+            ],
+            "rpc_methods": [
+                {"method": "pet.state", "remote_name": "pet_state"},
+            ],
+            "release": {
+                "asset": "desktop-pet.zip",
+                "checksums_asset": "checksums.json",
+            },
+        },
+        source="test",
+    )
+
+
+class FakeInstaller:
+    def __init__(self, installed: InstalledPlugin) -> None:
+        self._installed = installed
+
+    def list_installed(self) -> list[InstalledPlugin]:
+        return [self._installed]
+
+
+class FakeClient:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+        self.disconnected = False
+        self.exited = asyncio.Event()
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.tools = [
+            McpToolInfo(
+                name="pet_action",
+                description="Move the desktop pet",
+                input_schema={
+                    "type": "object",
+                    "properties": {"target": {"type": "string"}},
+                },
+            ),
+            McpToolInfo(
+                name="undeclared_tool",
+                description="Must stay hidden",
+                input_schema={"type": "object", "properties": {}},
+            ),
+            McpToolInfo(
+                name="pet_state",
+                description="Read plugin state",
+                input_schema={"type": "object", "properties": {}},
+            ),
+        ]
+
+    async def connect(self) -> list[McpToolInfo]:
+        return self.tools
+
+    async def call(self, name: str, arguments: dict[str, Any]) -> str:
+        self.calls.append((name, arguments))
+        return "ok"
+
+    async def disconnect(self) -> None:
+        self.disconnected = True
+        self.exited.set()
+
+    async def wait_until_exit(self) -> int:
+        await self.exited.wait()
+        return 9
+
+
+def _installed(tmp_path: Path, *, enabled: bool = True) -> InstalledPlugin:
+    package_dir = tmp_path / "plugins" / "desktop-pet" / "versions" / "1.0.0"
+    backend = package_dir / "backend" / "main.py"
+    backend.parent.mkdir(parents=True)
+    backend.write_text("print('plugin')", encoding="utf-8")
+    return InstalledPlugin(
+        plugin_id="desktop-pet",
+        version="1.0.0",
+        package_dir=package_dir,
+        manifest=_manifest(),
+        enabled=enabled,
+    )
+
+
+@pytest.mark.asyncio
+async def test_runtime_registers_only_manifest_allowlisted_tools(
+    tmp_path: Path,
+) -> None:
+    registry = ToolRegistry()
+    clients: list[FakeClient] = []
+
+    def factory(**kwargs: Any) -> FakeClient:
+        client = FakeClient(**kwargs)
+        clients.append(client)
+        return client
+
+    manager = PluginRuntimeManager(
+        tmp_path,
+        FakeInstaller(_installed(tmp_path)),  # type: ignore[arg-type]
+        registry,
+        client_factory=factory,  # type: ignore[arg-type]
+    )
+
+    assert await manager.start("desktop-pet") is True
+
+    assert registry.has_tool("pet_action")
+    assert not registry.has_tool("undeclared_tool")
+    assert registry.get_always_on_names() == {"pet_action"}
+    assert clients[0].kwargs["inherit_env"] is False
+    assert "SHIORI_PLUGIN_DATA_DIR" in clients[0].kwargs["env"]
+    assert "GITHUB_TOKEN" not in clients[0].kwargs["env"]
+    assert await registry.execute("pet_action", {"target": "center"}) == "ok"
+    assert clients[0].calls == [("pet_action", {"target": "center"})]
+
+    assert await manager.stop("desktop-pet") is True
+    assert not registry.has_tool("pet_action")
+    assert clients[0].disconnected is True
+
+
+@pytest.mark.asyncio
+async def test_runtime_unregisters_tools_when_plugin_process_exits(
+    tmp_path: Path,
+) -> None:
+    registry = ToolRegistry()
+    clients: list[FakeClient] = []
+
+    def factory(**kwargs: Any) -> FakeClient:
+        client = FakeClient(**kwargs)
+        clients.append(client)
+        return client
+
+    manager = PluginRuntimeManager(
+        tmp_path,
+        FakeInstaller(_installed(tmp_path)),  # type: ignore[arg-type]
+        registry,
+        client_factory=factory,  # type: ignore[arg-type]
+    )
+    await manager.start("desktop-pet")
+
+    clients[0].exited.set()
+    for _ in range(10):
+        if not registry.has_tool("pet_action"):
+            break
+        await asyncio.sleep(0)
+
+    assert manager.running_plugin_ids == ()
+    assert not registry.has_tool("pet_action")
+
+
+@pytest.mark.asyncio
+async def test_runtime_refuses_disabled_plugin(tmp_path: Path) -> None:
+    manager = PluginRuntimeManager(
+        tmp_path,
+        FakeInstaller(_installed(tmp_path, enabled=False)),  # type: ignore[arg-type]
+        ToolRegistry(),
+        client_factory=FakeClient,  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(ValueError, match="disabled"):
+        await manager.start("desktop-pet")
+
+
+@pytest.mark.asyncio
+async def test_runtime_allows_only_manifest_declared_desktop_rpc(
+    tmp_path: Path,
+) -> None:
+    registry = ToolRegistry()
+    clients: list[FakeClient] = []
+
+    def factory(**kwargs: Any) -> FakeClient:
+        client = FakeClient(**kwargs)
+        clients.append(client)
+        return client
+
+    manager = PluginRuntimeManager(
+        tmp_path,
+        FakeInstaller(_installed(tmp_path)),  # type: ignore[arg-type]
+        registry,
+        client_factory=factory,  # type: ignore[arg-type]
+    )
+    await manager.start("desktop-pet")
+
+    assert await manager.call_rpc("desktop-pet", "pet.state", {"role_id": "r1"}) == "ok"
+    assert clients[0].calls[-1] == ("pet_state", {"role_id": "r1"})
+    with pytest.raises(PermissionError, match="not declared"):
+        await manager.call_rpc("desktop-pet", "secret.dump", {})

--- a/tests/desktop_bridge/test_plugin_package_requests.py
+++ b/tests/desktop_bridge/test_plugin_package_requests.py
@@ -55,3 +55,65 @@ async def test_plugin_package_handler_rejects_invalid_mutation_payloads() -> Non
             "plugins.uninstall",
             {"plugin_id": "desktop-pet", "purge_data": "yes"},
         )
+
+
+@pytest.mark.asyncio
+async def test_plugin_package_handler_coordinates_runtime_enable_disable_and_rpc() -> (
+    None
+):
+    service = SimpleNamespace(
+        set_enabled=Mock(
+            side_effect=lambda plugin_id, enabled: {
+                "plugin_id": plugin_id,
+                "enabled": enabled,
+            }
+        ),
+    )
+    runtime = SimpleNamespace(
+        start=AsyncMock(return_value=True),
+        stop=AsyncMock(return_value=True),
+        call_rpc=AsyncMock(return_value="ready"),
+    )
+    handler = DesktopPluginPackageRequestHandler(service, runtime)
+
+    enabled = await handler.handle("plugins.enable", {"plugin_id": "desktop-pet"})
+    rpc = await handler.handle(
+        "plugins.rpc",
+        {
+            "plugin_id": "desktop-pet",
+            "method": "pet.state",
+            "payload": {"role_id": "r1"},
+        },
+    )
+    disabled = await handler.handle("plugins.disable", {"plugin_id": "desktop-pet"})
+
+    assert enabled == {"plugin": {"plugin_id": "desktop-pet", "enabled": True}}
+    assert rpc == {"result": "ready"}
+    assert disabled == {"plugin": {"plugin_id": "desktop-pet", "enabled": False}}
+    runtime.start.assert_awaited_once_with("desktop-pet")
+    runtime.call_rpc.assert_awaited_once_with(
+        "desktop-pet", "pet.state", {"role_id": "r1"}
+    )
+    runtime.stop.assert_awaited_once_with("desktop-pet")
+
+
+@pytest.mark.asyncio
+async def test_plugin_enable_rolls_back_when_runtime_start_fails() -> None:
+    service = SimpleNamespace(
+        set_enabled=Mock(
+            side_effect=lambda plugin_id, enabled: {
+                "plugin_id": plugin_id,
+                "enabled": enabled,
+            }
+        ),
+    )
+    runtime = SimpleNamespace(start=AsyncMock(side_effect=RuntimeError("boom")))
+    handler = DesktopPluginPackageRequestHandler(service, runtime)
+
+    with pytest.raises(RuntimeError, match="boom"):
+        await handler.handle("plugins.enable", {"plugin_id": "desktop-pet"})
+
+    assert service.set_enabled.call_args_list == [
+        (("desktop-pet", True),),
+        (("desktop-pet", False),),
+    ]


### PR DESCRIPTION
Part of #36
Closes #73

## 变更摘要
- 新增每插件独立 MCP 子进程运行时，使用隔离环境变量和 manifest 工具/RPC 白名单
- 新增插件启用、禁用、安装启动、卸载停止和崩溃后的确定性工具注销
- 新增 `shiori-plugin:` 安全资源协议、独立 sandbox preload 和通用 overlay BrowserWindow host
- 插件 IPC 身份由 Electron sender 映射推断，不接受页面传入 plugin_id
- 安装、卸载、启用或禁用后同步桌面 contribution 生命周期

## 实际验证
- `24 passed`: plugin package/runtime/bridge focused tests
- `34 passed`: bootstrap/runtime/desktop bridge regression
- `9 passed`: MCP I/O regression
- Desktop unit tests: 493 tests, 491 passed, 2 skipped (Windows symlink permission)
- `npm run typecheck`
- `npm run build:main` and `npm run build:preload`
- ESLint, Ruff and Pyright: no errors
- `graphify update .`: 8325 nodes / 21814 edges

## 已知阻塞
- Stacked on #72 / PR #75. This PR must not merge before the package installer base.
- Desktop pet migration and real Release installation are tracked by #74.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an isolated per-plugin runtime and a sandboxed desktop capability host. Plugins now run backends as separate MCP subprocesses, declare allowed tools/RPCs, and render secure overlay UIs via `shiori-plugin:`.

- **New Features**
  - Added `agent.plugin_runtime` with `PluginRuntimeManager` to start/stop per-plugin MCP subprocesses, register only manifest-allowlisted tools, and auto-unregister on exit.
  - Persisted enable/disable state; new bridge methods: `plugins.enable`, `plugins.disable`, `plugins.rpc`. Install/uninstall now start/stop runtime and keep desktop host in sync.
  - Manifest schema adds `tools`, `rpc_methods`, `desktop_contributions`; validated against `agent.tool`, `plugin.rpc`, and `desktop.overlay`. Installer verifies all entrypoints; `InstalledPlugin.enabled` is stored.
  - Desktop host: `shiori-plugin:` resource protocol with CSP, sandboxed overlay windows using a dedicated `pluginPreload.js`, and a trusted sender-to-plugin identity map. Host auto-syncs after install/uninstall/enable/disable.

- **Security**
  - Runtime isolation: no environment inheritance, limited allowed env, per-plugin data dir.
  - Desktop isolation: `sandbox: true`, `contextIsolation: true`, `nodeIntegration: false`, deny window opens; navigation restricted to `shiori-plugin:`.
  - No `plugin_id` from pages; identity inferred from Electron sender; RPC access is manifest-allowlisted only.
  - Protocol hardening: MIME allowlist, strict size caps, CSP with `connect-src 'none'`, and traversal/symlink escape prevention.

<sup>Written for commit 955acf08755ff9c4a92c90813bcc6903625f364f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/76?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

