### PR TITLE
fix: restore pet package preview images

### DIFF
--- a/core/roles/pet_packages.py
+++ b/core/roles/pet_packages.py
@@ -80,9 +80,10 @@ class RolePetPackageService:
                 raise ValueError(f"桌宠包已存在: {package_id}")
             self._validate_atlas(archive.read(self._archive_entry(root, sprite_name)))
             preview_data = None
+            preview_extension = None
             if preview_name is not None:
                 preview_data = archive.read(self._archive_entry(root, preview_name))
-                self._validate_preview(preview_data)
+                preview_extension = self._validate_preview(preview_data)
             destination = self._role_store.assets_dir / role_id / "pets" / package_id
             if destination.exists():
                 raise ValueError(f"桌宠包目录已存在: {package_id}")
@@ -92,8 +93,8 @@ class RolePetPackageService:
                 (temporary / "pet.json").write_bytes(archive.read(self._archive_entry(root, "pet.json")))
                 (temporary / "spritesheet.webp").write_bytes(archive.read(self._archive_entry(root, sprite_name)))
                 preview_filename = None
-                if preview_name is not None and preview_data is not None:
-                    preview_filename = f"preview{PurePosixPath(preview_name).suffix.lower()}"
+                if preview_data is not None and preview_extension is not None:
+                    preview_filename = f"preview{preview_extension}"
                     (temporary / preview_filename).write_bytes(preview_data)
                 os.replace(temporary, destination)
             except Exception:
@@ -202,13 +203,15 @@ class RolePetPackageService:
                 if column >= count and occupied:
                     raise ValueError("桌宠精灵图未使用单元必须透明")
 
-    def _validate_preview(self, data: bytes) -> None:
+    def _validate_preview(self, data: bytes) -> str:
         try:
             with Image.open(io.BytesIO(data)) as image:
                 if image.format not in {"PNG", "WEBP"}:
                     raise ValueError("桌宠预览图必须是 PNG 或 WebP")
+                extension = ".png" if image.format == "PNG" else ".webp"
                 width, height = image.size
         except OSError as error:
             raise ValueError("桌宠预览图无效") from error
         if not 64 <= width <= 2048 or not 64 <= height <= 2048:
             raise ValueError("桌宠预览图尺寸必须在 64 到 2048 像素之间")
+        return extension

--- a/desktop/src/localAssetPolicy.test.ts
+++ b/desktop/src/localAssetPolicy.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { collectTrustedLocalAssetPaths } from "./localAssetPolicy.js";
+
+test("pet package renderer assets are collected from trusted bridge payloads", () => {
+  const previewPath = "C:\\workspace\\roles\\assets\\role-1\\pets\\pet-1\\preview.png";
+  const spritesheetPath = "C:\\workspace\\roles\\assets\\role-1\\pets\\pet-1\\spritesheet.webp";
+
+  const paths = collectTrustedLocalAssetPaths({
+    pet_packages: [{
+      preview_abs: previewPath,
+      spritesheet_abs: spritesheetPath,
+    }],
+  });
+
+  assert.deepEqual(paths, [previewPath, spritesheetPath]);
+});

--- a/desktop/src/localAssetPolicy.ts
+++ b/desktop/src/localAssetPolicy.ts
@@ -18,6 +18,8 @@ const trustedSinglePathFields = new Set([
   "base_image_path",
   "chat_background_abs",
   "image_path",
+  "preview_abs",
+  "spritesheet_abs",
   // Story-owned background and CG resources expose their generated asset as path.
   "path",
 ]);

--- a/tests/test_role_pet_packages.py
+++ b/tests/test_role_pet_packages.py
@@ -1,10 +1,12 @@
 from __future__ import annotations
 
+import io
 import json
 import zipfile
 from pathlib import Path
 
 import pytest
+from PIL import Image
 
 from core.roles import RolePetPackageService, RoleStore
 
@@ -31,7 +33,7 @@ def test_import_pet_package_accepts_a_single_wrapper_directory(tmp_path: Path, m
     role = store.create_role(name="菲比", system_prompt="fixture")
     service = RolePetPackageService(store)
     monkeypatch.setattr(service, "_validate_atlas", lambda _data: None)
-    monkeypatch.setattr(service, "_validate_preview", lambda _data: None)
+    monkeypatch.setattr(service, "_validate_preview", lambda _data: ".webp")
 
     package = service.import_package(role.id, archive_path)
 
@@ -118,6 +120,40 @@ def test_import_pet_package_accepts_a_package_without_preview(tmp_path: Path, mo
     assert (store.roles_dir / package.manifest_path).is_file()
 
 
+def test_import_pet_package_uses_the_preview_image_format_for_its_extension(
+    tmp_path: Path,
+    monkeypatch,
+) -> None:
+    preview = io.BytesIO()
+    Image.new("RGBA", (64, 64), (255, 0, 0, 255)).save(preview, format="PNG")
+    archive_path = tmp_path / "png-preview.zip"
+    with zipfile.ZipFile(archive_path, "w") as archive:
+        archive.writestr(
+            "pet.json",
+            json.dumps(
+                {
+                    "id": "png-preview",
+                    "displayName": "PNG preview",
+                    "description": "fixture",
+                    "spritesheetPath": "spritesheet.webp",
+                    "previewPath": "preview.webp",
+                }
+            ),
+        )
+        archive.writestr("spritesheet.webp", b"fixture")
+        archive.writestr("preview.webp", preview.getvalue())
+    store = RoleStore(tmp_path / "workspace")
+    role = store.create_role(name="PNG preview", system_prompt="fixture")
+    service = RolePetPackageService(store)
+    monkeypatch.setattr(service, "_validate_atlas", lambda _data: None)
+
+    package = service.import_package(role.id, archive_path)
+
+    assert package.preview_path is not None
+    assert package.preview_path.endswith("/preview.png")
+    assert (store.roles_dir / package.preview_path).read_bytes() == preview.getvalue()
+
+
 def test_selecting_a_pet_package_is_role_local_and_removal_clears_selection(
     tmp_path: Path,
     monkeypatch,
@@ -126,7 +162,7 @@ def test_selecting_a_pet_package_is_role_local_and_removal_clears_selection(
     role = store.create_role(name="菲比", system_prompt="fixture")
     service = RolePetPackageService(store)
     monkeypatch.setattr(service, "_validate_atlas", lambda _data: None)
-    monkeypatch.setattr(service, "_validate_preview", lambda _data: None)
+    monkeypatch.setattr(service, "_validate_preview", lambda _data: ".webp")
 
     for package_id in ("idle", "wave"):
         archive_path = tmp_path / f"{package_id}.zip"


### PR DESCRIPTION
Closes #77

## 变更摘要
- 将桌宠包 preview_abs 与 spritesheet_abs 纳入桌面本地素材协议白名单
- 按预览图实际字节格式保存为 preview.png 或 preview.webp，避免扩展名与 MIME 不一致
- 添加本地素材白名单和 PNG 预览导入回归测试

## 实际验证
- node node_modules/tsx/dist/cli.mjs --tsconfig desktop/renderer/tsconfig.json --test desktop/src/localAssetPolicy.test.ts
- .\.venv\Scripts\python.exe -m pytest tests/test_role_pet_packages.py -q (6 passed)
- npm run desktop:typecheck
- npx eslint desktop/src/localAssetPolicy.ts desktop/src/localAssetPolicy.test.ts
- 实际工作区 RoleStore + DesktopRolePresenter 校验 preview.png 路径存在，且未选择、未启用桌宠
- graphify update .

## 已知阻塞项
- 无

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores pet package preview rendering in Desktop. Fixes local asset path whitelisting and saves preview files with the correct extension to match their actual format.

- **Bug Fixes**
  - Added `preview_abs` and `spritesheet_abs` to trusted fields in `localAssetPolicy` so Desktop can load pet preview and spritesheet files.
  - Validated preview MIME and saved as `preview.png` or `preview.webp` based on actual image format to avoid extension/MIME mismatches.
  - Added regression tests for local asset whitelist and PNG preview import behavior.

<sup>Written for commit 9beb7b602d8ac25d4082f2db49fb14a15f93d6cc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/78?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

