### PR TITLE
fix(desktop): refresh tray after pet sync

### DIFF
--- a/desktop/src/main.test.ts
+++ b/desktop/src/main.test.ts
@@ -1,0 +1,17 @@
+import assert from "node:assert/strict";
+import { readFile } from "node:fs/promises";
+import test from "node:test";
+
+const mainSource = await readFile(new URL("./main.ts", import.meta.url), "utf-8");
+
+test("desktop pet visibility changes refresh tray and voice state", () => {
+  const refreshStart = mainSource.indexOf("function syncDesktopPetRuntimeState");
+  const refreshEnd = mainSource.indexOf("\n}", refreshStart);
+  assert.notEqual(refreshStart, -1, "desktop pet runtime refresh must exist");
+  assert.notEqual(refreshEnd, -1, "desktop pet runtime refresh must have a body");
+  const refreshSource = mainSource.slice(refreshStart, refreshEnd);
+
+  assert.match(refreshSource, /desktopTray\?\.refresh\(\)/);
+  assert.match(refreshSource, /syncVoiceAvailability\(\)/);
+  assert.match(mainSource, /onPetVisibilityChanged:\s*syncDesktopPetRuntimeState/);
+});

--- a/desktop/src/main.ts
+++ b/desktop/src/main.ts
@@ -203,6 +203,11 @@ function syncVoiceAvailability(): void {
   voiceController?.cancel();
 }
 
+function syncDesktopPetRuntimeState(): void {
+  desktopTray?.refresh();
+  syncVoiceAvailability();
+}
+
 function reloadVoiceSettings(): void {
   voiceSettings = loadSettingsData().formData.voice;
   voiceHotkey?.setHotkey(voiceSettings.hotkey);
@@ -211,13 +216,13 @@ function reloadVoiceSettings(): void {
 
 async function hideDesktopPet(): Promise<void> {
   await desktopPet?.hide();
-  syncVoiceAvailability();
+  syncDesktopPetRuntimeState();
   await desktopObservation?.restore();
 }
 
 async function showDesktopPet(): Promise<void> {
   await desktopPet?.show();
-  syncVoiceAvailability();
+  syncDesktopPetRuntimeState();
   await desktopObservation?.restore();
 }
 
@@ -369,7 +374,7 @@ void app.whenReady().then(() => {
     voiceController: activeVoiceController,
     voicePlayback: activeVoicePlayback,
     onVoiceSettingsChanged: reloadVoiceSettings,
-    onPetVisibilityChanged: syncVoiceAvailability,
+    onPetVisibilityChanged: syncDesktopPetRuntimeState,
   });
   getOrCreateDesktopWindow();
   if (trayLifecycleEnabled) {
@@ -392,8 +397,7 @@ void app.whenReady().then(() => {
       },
     });
     void desktopPet.restore().then(async () => {
-      desktopTray?.refresh();
-      syncVoiceAvailability();
+      syncDesktopPetRuntimeState();
       await desktopObservation?.restore();
     }).catch((error) => {
       logDesktopDiagnostic({ scope: "main", event: "desktop-pet.restore.failed", payload: { error } });


### PR DESCRIPTION
Closes #79

## 变更摘要
- 新增统一的桌宠运行态刷新入口，同时重建托盘菜单并同步语音可用性
- 桌宠显示、隐藏、角色页同步和启动恢复统一调用该入口
- 添加主进程装配回归测试，防止桌宠启动后托盘菜单保留 disabled 状态

## 实际验证
- 主进程 IPC、桌宠控制器、设置与新增回归测试：17 passed
- npm run desktop:typecheck
- npx eslint desktop/src/main.ts desktop/src/main.test.ts
- git diff --check
- graphify update .

## 已知阻塞项
- 无

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Refreshes the tray whenever the desktop pet syncs or changes visibility, using a single runtime sync entry. Fixes the disabled tray state and keeps voice controls in sync.

- **Bug Fixes**
  - Added one runtime sync that refreshes the tray and voice availability; used on show/hide, restore, and visibility change.
  - Added a main-process regression test to prevent the tray staying disabled after startup.

<sup>Written for commit 0a36914213a24f06574b5239f7cf2ed0da3f0a47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/80?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

