### PR TITLE
fix(release): resolve Windows artifact output path

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -12,8 +12,10 @@ permissions:
 jobs:
   package:
     runs-on: windows-latest
+    # npm --prefix desktop runs scripts with desktop/ as cwd, so this path
+    # resolves to desktop/release/installer in the repository root.
     env:
-      SHIORI_RELEASE_OUTPUT: desktop/release/installer
+      SHIORI_RELEASE_OUTPUT: release/installer
     steps:
       - name: Check out repository
         uses: actions/checkout@v4


### PR DESCRIPTION
修复 Windows release workflow 的输出目录。
pm --prefix desktop 以 desktop/ 为工作目录，SHIORI_RELEASE_OUTPUT 应为 release/installer，否则实际产物写入 desktop/desktop/release/installer，后续 checksum、artifact 和 GitHub Release 步骤找不到文件。\n\n关联 Issue: #68\n\n验证：本地路径解析确认输出为 desktop/release/installer；原 v0.1.0 workflow 已确认构建和 checksum 生成通过，仅在路径校验阶段失败。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Windows release output path so artifacts land in desktop/release/installer. Previously the workflow set SHIORI_RELEASE_OUTPUT to desktop/release/installer while running `npm --prefix desktop`, which wrote to desktop/desktop/release/installer and broke checksum, artifact upload, and GitHub Release steps.

- **Review notes**
  - Set `SHIORI_RELEASE_OUTPUT` to `release/installer` so it resolves to `desktop/release/installer` from the `desktop/` cwd.
  - CI-only change; no artifact naming or contents change.
  - Verify checksum and upload steps read from `desktop/release/installer`.

<sup>Written for commit ce901dac084ec5be4b5475a7591ef8646dcc1ddc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/98?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

