### PR TITLE
refactor(desktop): extract role creation controller (#86)

### DIFF
--- a/apps/desktop/renderer/src/app/appState.ts
+++ b/apps/desktop/renderer/src/app/appState.ts
@@ -22,6 +22,15 @@ export const sidebarAnimationDurationMs = 480;
 export const sidebarAutoCollapseWindowWidth = 980;
 export const minRoleCardBusyMs = 600;
 
+/** Keeps optimistic role-card actions visible long enough for the transition to be perceived. */
+export async function waitForMinimumRoleCardBusy(startedAt: number): Promise<void> {
+  const elapsed = Date.now() - startedAt;
+  if (elapsed >= minRoleCardBusyMs) {
+    return;
+  }
+  await new Promise((resolve) => window.setTimeout(resolve, minRoleCardBusyMs - elapsed));
+}
+
 export type SearchableSessionRecord = {
   roleId: string;
   roleName: string;

--- a/apps/desktop/renderer/src/app/useRoleCreationController.test.ts
+++ b/apps/desktop/renderer/src/app/useRoleCreationController.test.ts
@@ -1,0 +1,197 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import type React from "react";
+import type { BridgeResponse } from "../../../src/bridge/shared";
+import type { AppMainView, NewRoleFormState, PendingRoleCardAction, RoleRecord } from "../shared/types";
+import type { NavigationEntry } from "./appState";
+import {
+  cancelRoleCreation,
+  resetRoleCreationForm,
+  runRoleCreation,
+  type RoleCreationWorkflowArgs,
+} from "./useRoleCreationController";
+
+function createRole(overrides: Partial<RoleRecord> = {}): RoleRecord {
+  return {
+    id: overrides.id ?? "mira",
+    name: overrides.name ?? "Mira",
+    description: overrides.description ?? "A role",
+    system_prompt: overrides.system_prompt ?? "Be helpful",
+    runtime_config: overrides.runtime_config ?? {},
+    channel_bindings: overrides.channel_bindings ?? [],
+    proactive: overrides.proactive,
+    avatar: overrides.avatar ?? null,
+    avatar_abs: overrides.avatar_abs ?? null,
+    chat_background: overrides.chat_background ?? null,
+    chat_background_abs: overrides.chat_background_abs ?? null,
+    illustrations: overrides.illustrations ?? [],
+    illustrations_abs: overrides.illustrations_abs ?? [],
+    asset_categories: overrides.asset_categories ?? [{ id: "default", name: "Default", allow_role_send: false }],
+    asset_category_bindings: overrides.asset_category_bindings ?? {},
+    created_at: overrides.created_at ?? "2026-08-30T00:00:00Z",
+    updated_at: overrides.updated_at ?? "2026-08-30T00:00:00Z",
+  };
+}
+
+function createForm(overrides: Partial<NewRoleFormState> = {}): NewRoleFormState {
+  return {
+    name: overrides.name ?? "  Mira  ",
+    description: overrides.description ?? "A role",
+    systemPrompt: overrides.systemPrompt ?? "  Be helpful  ",
+  };
+}
+
+function createResponse(payload: Record<string, unknown> = {}, error: BridgeResponse["error"] = null): BridgeResponse {
+  return { id: "request-1", type: "response", method: "roles.create", payload, error };
+}
+
+function createHarness({
+  invoke = async () => createResponse({ role: createRole() }),
+  loadedRoles = [createRole()],
+}: {
+  invoke?: (request: { method: string; payload: Record<string, unknown> }) => Promise<BridgeResponse>;
+  loadedRoles?: RoleRecord[] | null;
+} = {}) {
+  let roles = [createRole({ id: "existing", name: "Existing" })];
+  let activeRoleId = "existing";
+  let creating = false;
+  let pendingAction: PendingRoleCardAction = null;
+  let error = "";
+  let feedback: { tone: "success" | "error"; message: string } | null = null;
+  const activeRoleIdRef = { current: activeRoleId };
+  const views: AppMainView[] = [];
+  const navigationEntries: NavigationEntry[] = [];
+  const snapshots: RoleRecord[] = [];
+  const requests: Array<{ method: string; payload: Record<string, unknown> }> = [];
+  const openedRoles: string[] = [];
+
+  const apply = <T>(current: T, next: T | ((value: T) => T)): T => (
+    typeof next === "function" ? (next as (value: T) => T)(current) : next
+  );
+
+  const args: RoleCreationWorkflowArgs = {
+      activeRoleIdRef,
+      setPendingRoleCardAction: (next: React.SetStateAction<PendingRoleCardAction>) => { pendingAction = apply(pendingAction, next); },
+      setWorkspaceFeedback: (next: React.SetStateAction<{ tone: "success" | "error"; message: string } | null>) => { feedback = apply(feedback, next); },
+      setError: (next: React.SetStateAction<string>) => { error = apply(error, next); },
+      setRoles: (next: React.SetStateAction<RoleRecord[]>) => { roles = apply(roles, next); },
+      setActiveRoleId: (next: React.SetStateAction<string>) => { activeRoleId = apply(activeRoleId, next); },
+      openRoleWorkspace: (view: Extract<AppMainView, { kind: "roles-list" | "role-create" | "role-detail" | "role-assets" }>) => { views.push(view); },
+      buildNavigationEntry: (view: AppMainView, roleId = "") => ({ view, activeRoleId: roleId, settingsSection: "models" as const }),
+      replaceNavigationEntry: (entry: NavigationEntry) => { navigationEntries.push(entry); },
+      loadRolesFromBridge: async () => loadedRoles,
+      openRole: async (roleId: string) => { openedRoles.push(roleId); return true; },
+      applyRoleSnapshot: (role: RoleRecord) => { snapshots.push(role); },
+      setCreating: (next: React.SetStateAction<boolean>) => { creating = apply(creating, next); },
+      invoke: async (request: { method: string; payload: Record<string, unknown> }) => { requests.push(request); return invoke(request); },
+      waitForBusy: async () => undefined,
+      createPendingRoleId: () => "pending-create:test",
+  };
+
+  return {
+    args,
+    get state() {
+      return { roles, activeRoleId, activeRoleIdRef, creating, pendingAction, error, feedback, views, navigationEntries, snapshots, requests, openedRoles };
+    },
+  };
+}
+
+describe("runRoleCreation", () => {
+  it("validates required fields before calling the bridge", async () => {
+    const harness = createHarness();
+
+    const created = await runRoleCreation(
+      createForm({ name: " ", systemPrompt: "" }),
+      harness.args,
+    );
+
+    assert.equal(created, false);
+    assert.equal(harness.state.requests.length, 0);
+    assert.equal(harness.state.roles.length, 1);
+    assert.equal(harness.state.error, "角色名称和系统提示词不能为空。");
+    assert.equal(harness.state.feedback?.tone, "error");
+  });
+
+  it("creates optimistically, refreshes roles, and opens the created role", async () => {
+    const createdRole = createRole({ id: "new-role", name: "Mira" });
+    const harness = createHarness({
+      invoke: async (request) => {
+        assert.deepEqual(request, {
+          method: "roles.create",
+          payload: { name: "Mira", description: "A role", system_prompt: "Be helpful" },
+        });
+        return createResponse({ role: createdRole });
+      },
+      loadedRoles: [createdRole],
+    });
+
+    const created = await runRoleCreation(createForm(), harness.args);
+
+    assert.equal(created, true);
+    assert.equal(harness.state.creating, false);
+    assert.equal(harness.state.activeRoleId, "new-role");
+    assert.equal(harness.state.activeRoleIdRef.current, "new-role");
+    assert.deepEqual(harness.state.roles.map((role) => role.id), ["new-role", "existing"]);
+    assert.deepEqual(harness.state.openedRoles, ["new-role"]);
+    assert.equal(harness.state.snapshots[0]?.id, "pending-create:test");
+    assert.equal(harness.state.snapshots.at(-1)?.id, "new-role");
+    assert.equal(harness.state.pendingAction, null);
+    assert.equal(harness.state.feedback?.message, "角色创建成功。");
+    assert.deepEqual(harness.state.views.map((view) => view.kind), ["roles-list", "roles-list"]);
+    assert.equal(harness.state.navigationEntries.at(-1)?.activeRoleId, "new-role");
+  });
+
+  it("removes the optimistic card and restores the create route after a bridge failure", async () => {
+    const harness = createHarness({
+      invoke: async () => createResponse({}, { code: "create_failed", message: "保存失败" }),
+    });
+
+    const created = await runRoleCreation(createForm(), harness.args);
+
+    assert.equal(created, false);
+    assert.equal(harness.state.creating, false);
+    assert.deepEqual(harness.state.roles.map((role) => role.id), ["existing"]);
+    assert.equal(harness.state.activeRoleId, "existing");
+    assert.equal(harness.state.activeRoleIdRef.current, "existing");
+    assert.equal(harness.state.pendingAction, null);
+    assert.equal(harness.state.error, "保存失败");
+    assert.equal(harness.state.feedback?.message, "角色创建失败：保存失败");
+    assert.deepEqual(harness.state.views.map((view) => view.kind), ["roles-list", "role-create"]);
+    assert.equal(harness.state.navigationEntries.at(-1)?.view.kind, "role-create");
+  });
+});
+
+describe("role creation form actions", () => {
+  it("resets the draft and reports success", () => {
+    let form: NewRoleFormState = createForm();
+    let feedback: { tone: "success" | "error"; message: string } | null = null;
+    resetRoleCreationForm({
+      updateNewRoleForm: (next) => { form = next; },
+      setWorkspaceFeedback: (next) => { feedback = typeof next === "function" ? next(feedback) : next; },
+      openRoleWorkspace: () => undefined,
+    });
+
+    assert.deepEqual(form, { name: "", description: "", systemPrompt: "" });
+    assert.deepEqual(feedback, { tone: "success", message: "新建角色表单已重置。" });
+  });
+
+  it("cancels only when creation is idle", () => {
+    let form: NewRoleFormState = createForm();
+    let feedback: { tone: "success" | "error"; message: string } | null = { tone: "error", message: "old" };
+    const views: AppMainView[] = [];
+    const action = {
+      updateNewRoleForm: (next: NewRoleFormState) => { form = next; },
+      setWorkspaceFeedback: (next: React.SetStateAction<typeof feedback>) => { feedback = typeof next === "function" ? next(feedback) : next; },
+      openRoleWorkspace: (view: Extract<AppMainView, { kind: "roles-list" | "role-create" | "role-detail" | "role-assets" }>) => { views.push(view); },
+    };
+
+    assert.equal(cancelRoleCreation({ ...action, creating: true }), false);
+    assert.equal(views.length, 0);
+    assert.equal(cancelRoleCreation({ ...action, creating: false }), true);
+    assert.deepEqual(form, { name: "", description: "", systemPrompt: "" });
+    assert.equal(feedback, null);
+    assert.deepEqual(views, [{ kind: "roles-list" }]);
+  });
+});

--- a/apps/desktop/renderer/src/app/useRoleCreationController.ts
+++ b/apps/desktop/renderer/src/app/useRoleCreationController.ts
@@ -1,0 +1,211 @@
+import { useState } from "react";
+import type React from "react";
+import { createEmptyNewRoleForm, createPendingRoleRecord, waitForMinimumRoleCardBusy } from "./appState";
+import type { AppMainView, NewRoleFormState, PendingRoleCardAction, RoleRecord } from "../shared/types";
+import type { NavigationEntry } from "./appState";
+import { useLatestRef } from "../shared/useLatestRef";
+import type { BridgeResponse } from "../../../src/bridge/shared";
+
+/** Dependencies shared by the React controller and its role-creation workflow. */
+export type RoleCreationControllerArgs = {
+  activeRoleIdRef: React.MutableRefObject<string>;
+  setPendingRoleCardAction: React.Dispatch<React.SetStateAction<PendingRoleCardAction>>;
+  setWorkspaceFeedback: React.Dispatch<React.SetStateAction<{ tone: "success" | "error"; message: string } | null>>;
+  setError: React.Dispatch<React.SetStateAction<string>>;
+  setRoles: React.Dispatch<React.SetStateAction<RoleRecord[]>>;
+  setActiveRoleId: React.Dispatch<React.SetStateAction<string>>;
+  openRoleWorkspace: (
+    nextView: Extract<AppMainView, { kind: "roles-list" | "role-create" | "role-detail" | "role-assets" }>,
+    options?: { recordHistory?: boolean },
+  ) => void;
+  buildNavigationEntry: (view: AppMainView, roleId?: string) => NavigationEntry;
+  replaceNavigationEntry: (entry: NavigationEntry) => void;
+  loadRolesFromBridge: () => Promise<RoleRecord[] | null>;
+  openRole: (roleId: string, roleOverride?: RoleRecord | null, options?: { recordHistory?: boolean }) => Promise<boolean>;
+  applyRoleSnapshot: (role: RoleRecord) => void;
+};
+
+/** Dependencies required to execute the role-creation workflow. */
+export type RoleCreationWorkflowArgs = RoleCreationControllerArgs & {
+  setCreating: React.Dispatch<React.SetStateAction<boolean>>;
+  invoke: (request: { method: string; payload: Record<string, unknown> }) => Promise<BridgeResponse>;
+  waitForBusy?: (startedAt: number) => Promise<void>;
+  createPendingRoleId?: () => string;
+};
+
+type RoleCreationFormActionArgs = {
+  updateNewRoleForm: (next: NewRoleFormState) => void;
+  setWorkspaceFeedback: React.Dispatch<React.SetStateAction<{ tone: "success" | "error"; message: string } | null>>;
+  openRoleWorkspace: RoleCreationControllerArgs["openRoleWorkspace"];
+};
+
+/** Resets the new-role draft and reports the action to the workspace shell. */
+export function resetRoleCreationForm({ updateNewRoleForm, setWorkspaceFeedback }: RoleCreationFormActionArgs): void {
+  updateNewRoleForm(createEmptyNewRoleForm());
+  setWorkspaceFeedback({ tone: "success", message: "新建角色表单已重置。" });
+}
+
+/** Cancels role creation when no create request is in flight. */
+export function cancelRoleCreation({
+  creating,
+  updateNewRoleForm,
+  setWorkspaceFeedback,
+  openRoleWorkspace,
+}: RoleCreationFormActionArgs & { creating: boolean }): boolean {
+  if (creating) {
+    return false;
+  }
+  updateNewRoleForm(createEmptyNewRoleForm());
+  setWorkspaceFeedback(null);
+  openRoleWorkspace({ kind: "roles-list" });
+  return true;
+}
+
+/** Runs the role-create side effects independently of React so the contract remains directly testable. */
+export async function runRoleCreation(
+  form: NewRoleFormState,
+  {
+    activeRoleIdRef,
+    setPendingRoleCardAction,
+    setWorkspaceFeedback,
+    setError,
+    setRoles,
+    setActiveRoleId,
+    openRoleWorkspace,
+    buildNavigationEntry,
+    replaceNavigationEntry,
+    loadRolesFromBridge,
+    openRole,
+    applyRoleSnapshot,
+    setCreating,
+    invoke,
+    waitForBusy = waitForMinimumRoleCardBusy,
+    createPendingRoleId = () => `pending-create:${Date.now()}`,
+  }: RoleCreationWorkflowArgs,
+): Promise<boolean> {
+  const name = form.name.trim();
+  const systemPrompt = form.systemPrompt.trim();
+  if (!name || !systemPrompt) {
+    const message = "角色名称和系统提示词不能为空。";
+    setError(message);
+    setWorkspaceFeedback({ tone: "error", message: `角色创建失败：${message}` });
+    return false;
+  }
+
+  const pendingRoleId = createPendingRoleId();
+  const pendingRole = createPendingRoleRecord(pendingRoleId, form);
+  const previousActiveRoleId = activeRoleIdRef.current;
+  const startedAt = Date.now();
+  setCreating(true);
+  setError("");
+  setWorkspaceFeedback(null);
+  setPendingRoleCardAction({ roleId: pendingRoleId, action: "create" });
+  setRoles((current) => [pendingRole, ...current]);
+  applyRoleSnapshot(pendingRole);
+  openRoleWorkspace({ kind: "roles-list" }, { recordHistory: false });
+  replaceNavigationEntry(buildNavigationEntry({ kind: "roles-list" }, pendingRoleId));
+
+  const res = await invoke({
+    method: "roles.create",
+    payload: { name, description: form.description, system_prompt: systemPrompt },
+  });
+  await waitForBusy(startedAt);
+  setCreating(false);
+  if (res.error) {
+    setPendingRoleCardAction(null);
+    setRoles((current) => current.filter((item) => item.id !== pendingRoleId));
+    setActiveRoleId(previousActiveRoleId);
+    activeRoleIdRef.current = previousActiveRoleId;
+    openRoleWorkspace({ kind: "role-create" }, { recordHistory: false });
+    replaceNavigationEntry(buildNavigationEntry({ kind: "role-create" }, previousActiveRoleId));
+    setError(res.error.message);
+    setWorkspaceFeedback({ tone: "error", message: `角色创建失败：${res.error.message}` });
+    return false;
+  }
+
+  const role = res.payload.role as RoleRecord;
+  activeRoleIdRef.current = role.id;
+  setActiveRoleId(role.id);
+  setPendingRoleCardAction({ roleId: role.id, action: "create" });
+  setRoles((current) => {
+    const withoutPending = current.filter((item) => item.id !== pendingRoleId);
+    return [role, ...withoutPending.filter((item) => item.id !== role.id)];
+  });
+  applyRoleSnapshot(role);
+  const nextRoles = await loadRolesFromBridge();
+  const resolvedRole = nextRoles?.find((item) => item.id === role.id) ?? role;
+  if (!nextRoles?.some((item) => item.id === role.id)) {
+    setRoles((current) => [resolvedRole, ...current.filter((item) => item.id !== role.id)]);
+  }
+  await openRole(role.id, resolvedRole, { recordHistory: false });
+  openRoleWorkspace({ kind: "roles-list" }, { recordHistory: false });
+  replaceNavigationEntry(buildNavigationEntry({ kind: "roles-list" }, resolvedRole.id));
+  setPendingRoleCardAction(null);
+  setWorkspaceFeedback({ tone: "success", message: "角色创建成功。" });
+  return true;
+}
+
+/** Owns new-role form state and the full create/cancel/recovery workflow. */
+export function useRoleCreationController({
+  activeRoleIdRef,
+  setPendingRoleCardAction,
+  setWorkspaceFeedback,
+  setError,
+  setRoles,
+  setActiveRoleId,
+  openRoleWorkspace,
+  buildNavigationEntry,
+  replaceNavigationEntry,
+  loadRolesFromBridge,
+  openRole,
+  applyRoleSnapshot,
+}: RoleCreationControllerArgs) {
+  const [newRoleForm, setNewRoleForm] = useState(createEmptyNewRoleForm);
+  const [creating, setCreating] = useState(false);
+  const newRoleFormRef = useLatestRef(newRoleForm);
+
+  function updateNewRoleForm(next: React.SetStateAction<NewRoleFormState>): void {
+    setNewRoleForm((current) => {
+      const resolved = typeof next === "function" ? next(current) : next;
+      newRoleFormRef.current = resolved;
+      return resolved;
+    });
+  }
+
+  function resetNewRoleForm(): void {
+    resetRoleCreationForm({ updateNewRoleForm, setWorkspaceFeedback, openRoleWorkspace });
+  }
+
+  async function createRole(): Promise<void> {
+    const created = await runRoleCreation(newRoleFormRef.current, {
+      activeRoleIdRef,
+      setPendingRoleCardAction,
+      setWorkspaceFeedback,
+      setError,
+      setRoles,
+      setActiveRoleId,
+      openRoleWorkspace,
+      buildNavigationEntry,
+      replaceNavigationEntry,
+      loadRolesFromBridge,
+      openRole,
+      applyRoleSnapshot,
+      setCreating,
+      invoke: window.miraDesktop.invoke,
+    });
+    if (created) {
+      updateNewRoleForm(createEmptyNewRoleForm());
+    }
+  }
+
+  function cancelCreateRole(): void {
+    cancelRoleCreation({
+      creating,
+      updateNewRoleForm,
+      setWorkspaceFeedback,
+      openRoleWorkspace,
+    });
+  }
+
+  return { creating, newRoleForm, updateNewRoleForm, resetNewRoleForm, cancelCreateRole, createRole };
+}

--- a/apps/desktop/renderer/src/app/useRoleManagement.ts
+++ b/apps/desktop/renderer/src/app/useRoleManagement.ts
@@ -1,6 +1,6 @@
 import type React from "react";
-import { createEmptyNewRoleForm, createPendingRoleRecord, minRoleCardBusyMs } from "./appState";
-import type { RoleAssetCategory, RoleRecord, RoleFormState, NewRoleFormState, PendingRoleCardAction, SessionPayload } from "../shared/types";
+import { waitForMinimumRoleCardBusy } from "./appState";
+import type { RoleAssetCategory, RoleRecord, RoleFormState, PendingRoleCardAction, SessionPayload } from "../shared/types";
 import type { AppMainView } from "../shared/types";
 import type { NavigationEntry } from "./appState";
 import { writeRoleMoodConfigToRuntimeConfig } from "../roles/roleMoodConfig";
@@ -15,9 +15,6 @@ type UseRoleManagementArgs = {
   selectedAvatarAsset: string;
   selectedChatBackground: string;
   roleFormRef: React.MutableRefObject<RoleFormState>;
-  newRoleFormRef: React.MutableRefObject<NewRoleFormState>;
-  activeRoleIdRef: React.MutableRefObject<string>;
-  setCreating: React.Dispatch<React.SetStateAction<boolean>>;
   setSavingRole: React.Dispatch<React.SetStateAction<boolean>>;
   setSavingRoleAssets: React.Dispatch<React.SetStateAction<boolean>>;
   setDeletingRole: React.Dispatch<React.SetStateAction<boolean>>;
@@ -31,7 +28,6 @@ type UseRoleManagementArgs = {
   setSelectedChatBackground: React.Dispatch<React.SetStateAction<string>>;
   setActiveIllustration: React.Dispatch<React.SetStateAction<string>>;
   updateRoleForm: (next: React.SetStateAction<RoleFormState>) => void;
-  updateNewRoleForm: (next: React.SetStateAction<NewRoleFormState>) => void;
   openRoleWorkspace: (
     nextView: Extract<AppMainView, { kind: "roles-list" | "role-create" | "role-detail" | "role-assets" }>,
     options?: { recordHistory?: boolean },
@@ -50,15 +46,7 @@ type UseRoleManagementArgs = {
   roleAssetSaveRequestIdRef: React.MutableRefObject<number>;
 };
 
-async function waitForMinimumRoleCardBusy(startedAt: number): Promise<void> {
-  const elapsed = Date.now() - startedAt;
-  if (elapsed >= minRoleCardBusyMs) {
-    return;
-  }
-  await new Promise((resolve) => window.setTimeout(resolve, minRoleCardBusyMs - elapsed));
-}
-
-/** Owns role CRUD and role asset operations so the root app only composes them. */
+/** Owns persisted role editing, deletion, and asset operations. */
 export function useRoleManagement({
   activeRoleId,
   detailRoleId,
@@ -67,9 +55,6 @@ export function useRoleManagement({
   selectedAvatarAsset,
   selectedChatBackground,
   roleFormRef,
-  newRoleFormRef,
-  activeRoleIdRef,
-  setCreating,
   setSavingRole,
   setSavingRoleAssets,
   setDeletingRole,
@@ -83,7 +68,6 @@ export function useRoleManagement({
   setSelectedChatBackground,
   setActiveIllustration,
   updateRoleForm,
-  updateNewRoleForm,
   openRoleWorkspace,
   buildNavigationEntry,
   replaceNavigationEntry,
@@ -114,78 +98,6 @@ export function useRoleManagement({
   function navigateToRolesList(roleId: string): void {
     openRoleWorkspace({ kind: "roles-list" }, { recordHistory: false });
     replaceNavigationEntry(buildNavigationEntry({ kind: "roles-list" }, roleId));
-  }
-
-  async function createRole(): Promise<void> {
-    const name = newRoleFormRef.current.name.trim();
-    const systemPrompt = newRoleFormRef.current.systemPrompt.trim();
-    if (!name || !systemPrompt) {
-      const message = "角色名称和系统提示词不能为空。";
-      setError(message);
-      setWorkspaceFeedback({ tone: "error", message: `角色创建失败：${message}` });
-      return;
-    }
-    const pendingRoleId = `pending-create:${Date.now()}`;
-    const pendingRole = createPendingRoleRecord(pendingRoleId, newRoleFormRef.current);
-    const previousActiveRoleId = activeRoleIdRef.current;
-    const startedAt = Date.now();
-    setCreating(true);
-    setError("");
-    setWorkspaceFeedback(null);
-    setPendingRoleCardAction({ roleId: pendingRoleId, action: "create" });
-    setRoles((current) => [pendingRole, ...current]);
-    applyRoleSnapshot(pendingRole);
-    openRoleWorkspace({ kind: "roles-list" }, { recordHistory: false });
-    replaceNavigationEntry(buildNavigationEntry({ kind: "roles-list" }, pendingRoleId));
-    const res = await window.miraDesktop.invoke({
-      method: "roles.create",
-      payload: {
-        name,
-        description: newRoleFormRef.current.description,
-        system_prompt: systemPrompt,
-      },
-    });
-    await waitForMinimumRoleCardBusy(startedAt);
-    setCreating(false);
-    if (res.error) {
-      setPendingRoleCardAction(null);
-      setRoles((current) => current.filter((item) => item.id !== pendingRoleId));
-      setActiveRoleId(previousActiveRoleId);
-      activeRoleIdRef.current = previousActiveRoleId;
-      openRoleWorkspace({ kind: "role-create" }, { recordHistory: false });
-      replaceNavigationEntry(buildNavigationEntry({ kind: "role-create" }, previousActiveRoleId));
-      setError(res.error.message);
-      setWorkspaceFeedback({ tone: "error", message: `角色创建失败：${res.error.message}` });
-      return;
-    }
-    const role = res.payload.role as RoleRecord;
-    activeRoleIdRef.current = role.id;
-    setActiveRoleId(role.id);
-    setPendingRoleCardAction({ roleId: role.id, action: "create" });
-    setRoles((current) => {
-      const withoutPending = current.filter((item) => item.id !== pendingRoleId);
-      const existing = withoutPending.find((item) => item.id === role.id);
-      if (existing) {
-        return [role, ...withoutPending.filter((item) => item.id !== role.id)];
-      }
-      return [role, ...withoutPending];
-    });
-    applyRoleSnapshot(role);
-    const { resolvedRole, nextRoles } = await refreshRolesAndResolveRole(role);
-    if (!nextRoles?.some((item) => item.id === role.id)) {
-      setRoles((current) => {
-        const existing = current.find((item) => item.id === role.id);
-        if (existing) {
-          return [resolvedRole, ...current.filter((item) => item.id !== role.id)];
-        }
-        return [resolvedRole, ...current];
-      });
-    }
-    await openRole(role.id, resolvedRole, { recordHistory: false });
-    navigateToRolesList(resolvedRole.id);
-    setPendingRoleCardAction(null);
-    updateNewRoleForm(createEmptyNewRoleForm());
-    setWorkspaceFeedback({ tone: "success", message: "角色创建成功。" });
   }
 
   async function saveRole(): Promise<void> {
@@ -488,7 +400,6 @@ export function useRoleManagement({
   }
 
   return {
-    createRole,
     saveRole,
     saveRoleAssets,
     confirmDeleteRole,

--- a/apps/desktop/renderer/src/main.tsx
+++ b/apps/desktop/renderer/src/main.tsx
@@ -6,7 +6,6 @@ import {
   chatLatestImageSidebarDefaultWidth,
   chatLatestImageSidebarMaxWidth,
   chatLatestImageSidebarMinWidth,
-  createEmptyNewRoleForm,
   createEmptyRoleForm,
   historySidebarDefaultWidth,
   historySidebarMaxWidth,
@@ -28,6 +27,7 @@ import { useChatImageState } from "./app/useChatImageState";
 import { useChatInteractions } from "./app/useChatInteractions";
 import { useNavigationHistory } from "./app/useNavigationHistory";
 import { useRoleManagement } from "./app/useRoleManagement";
+import { useRoleCreationController } from "./app/useRoleCreationController";
 import { useRoleSearch } from "./app/roleSearch";
 import { buildDesktopViewModel } from "./app/desktopSelectors";
 import { useRolePresentation } from "./app/useRolePresentation";
@@ -83,7 +83,6 @@ function App(): React.ReactElement {
   const [activeSession, setActiveSession] = useState<SessionPayload | null>(null);
   const [, setError] = useState("");
   const [notice, setNotice] = useState("");
-  const [creating, setCreating] = useState(false);
   const [savingRole, setSavingRole] = useState(false);
   const [savingRoleAssets, setSavingRoleAssets] = useState(false);
   const [deletingRole, setDeletingRole] = useState(false);
@@ -107,7 +106,6 @@ function App(): React.ReactElement {
   const [selectedAvatarAsset, setSelectedAvatarAsset] = useState("");
   const [selectedChatBackground, setSelectedChatBackground] = useState("");
   const [roleForm, setRoleForm] = useState(createEmptyRoleForm);
-  const [newRoleForm, setNewRoleForm] = useState(createEmptyNewRoleForm);
   const [settingsSearch, setSettingsSearch] = useState("");
   const [settingsSection, setSettingsSection] = useState<SettingsSectionId>("models");
   const [, setSettingsConfigPath] = useState("");
@@ -142,7 +140,6 @@ function App(): React.ReactElement {
   const sendingSessionsRef = useLatestRef(sendingSessions);
   const unreadCountsRef = useLatestRef(unreadCounts);
   const roleFormRef = useLatestRef(roleForm);
-  const newRoleFormRef = useLatestRef(newRoleForm);
   const lastNonSettingsViewRef = useDesktopViewSynchronization({
     mainView,
     activeRoleId,
@@ -168,11 +165,9 @@ function App(): React.ReactElement {
     activeRole: roles.find((role) => role.id === activeRoleId) ?? null,
     roles,
   });
-  const { updateRoleForm, updateNewRoleForm } = useRoleFormAdapters({
+  const { updateRoleForm } = useRoleFormAdapters({
     roleFormRef,
-    newRoleFormRef,
     setRoleForm,
-    setNewRoleForm,
   });
 
   function queueMessageNavigation(roleId: string, messageKey: string): void {
@@ -371,8 +366,22 @@ function App(): React.ReactElement {
     setNotice,
   });
 
+  const roleCreation = useRoleCreationController({
+    activeRoleIdRef,
+    setPendingRoleCardAction,
+    setWorkspaceFeedback,
+    setError,
+    setRoles,
+    setActiveRoleId,
+    openRoleWorkspace,
+    buildNavigationEntry,
+    replaceNavigationEntry,
+    loadRolesFromBridge,
+    openRole,
+    applyRoleSnapshot,
+  });
+
   const {
-    createRole,
     saveRole,
     saveRoleAssets,
     confirmDeleteRole,
@@ -390,9 +399,6 @@ function App(): React.ReactElement {
     selectedAvatarAsset,
     selectedChatBackground,
     roleFormRef,
-    newRoleFormRef,
-    activeRoleIdRef,
-    setCreating,
     setSavingRole,
     setSavingRoleAssets,
     setDeletingRole,
@@ -406,7 +412,6 @@ function App(): React.ReactElement {
     setSelectedChatBackground,
     setActiveIllustration,
     updateRoleForm,
-    updateNewRoleForm,
     openRoleWorkspace,
     buildNavigationEntry,
     replaceNavigationEntry,
@@ -476,11 +481,6 @@ function App(): React.ReactElement {
     if (!detailRole) return;
     updateRoleForm(createRoleFormFromRole(detailRole));
     setNotice("角色表单已重置。");
-  }
-
-  function resetNewRoleForm(): void {
-    updateNewRoleForm(createEmptyNewRoleForm());
-    setWorkspaceFeedback({ tone: "success", message: "新建角色表单已重置。" });
   }
 
   if (mainView.kind === "story") {
@@ -576,12 +576,12 @@ function App(): React.ReactElement {
       pendingRoleCardAction={pendingRoleCardAction}
       onOpenRoleManagementDetail={(roleId) => void openRoleDetail(roleId)}
       onRequestDeleteRole={setPendingDeleteRoleId}
-      creating={creating}
-      newRoleForm={newRoleForm}
-      onBackToRoleList={() => openRoleWorkspace({ kind: "roles-list" })}
-      onCreateNewRole={() => void createRole()}
-      onResetNewRoleForm={resetNewRoleForm}
-      onUpdateNewRoleForm={updateNewRoleForm}
+      creating={roleCreation.creating}
+      newRoleForm={roleCreation.newRoleForm}
+      onBackToRoleList={roleCreation.cancelCreateRole}
+      onCreateNewRole={() => void roleCreation.createRole()}
+      onResetNewRoleForm={roleCreation.resetNewRoleForm}
+      onUpdateNewRoleForm={roleCreation.updateNewRoleForm}
       detailRoleId={detailRoleId}
       activeIllustration={activeIllustration}
       previewAvatar={previewAvatar}

--- a/apps/desktop/renderer/src/roles/useRoleFormAdapters.ts
+++ b/apps/desktop/renderer/src/roles/useRoleFormAdapters.ts
@@ -1,21 +1,17 @@
 import type React from "react";
-import type { NewRoleFormState, RoleFormState } from "../shared/types";
+import type { RoleFormState } from "../shared/types";
 
 type MutableValue<T> = { current: T };
 
 type UseRoleFormAdaptersArgs = {
   roleFormRef: MutableValue<RoleFormState>;
-  newRoleFormRef: MutableValue<NewRoleFormState>;
   setRoleForm: React.Dispatch<React.SetStateAction<RoleFormState>>;
-  setNewRoleForm: React.Dispatch<React.SetStateAction<NewRoleFormState>>;
 };
 
 /** Adapts role form state setters while keeping async consumers' latest-value refs synchronized. */
 export function useRoleFormAdapters({
   roleFormRef,
-  newRoleFormRef,
   setRoleForm,
-  setNewRoleForm,
 }: UseRoleFormAdaptersArgs) {
   function updateRoleForm(next: React.SetStateAction<RoleFormState>): void {
     const resolved = typeof next === "function" ? next(roleFormRef.current) : next;
@@ -23,11 +19,5 @@ export function useRoleFormAdapters({
     setRoleForm(resolved);
   }
 
-  function updateNewRoleForm(next: React.SetStateAction<NewRoleFormState>): void {
-    const resolved = typeof next === "function" ? next(newRoleFormRef.current) : next;
-    newRoleFormRef.current = resolved;
-    setNewRoleForm(resolved);
-  }
-
-  return { updateRoleForm, updateNewRoleForm };
+  return { updateRoleForm };
 }


### PR DESCRIPTION
## 关联 Issue

Closes #86

## 变更摘要

- 将新建角色表单状态与创建流程从 `useRoleManagement` 拆分到 `useRoleCreationController`
- 保留 `roles.create` Bridge 契约、乐观角色卡、成功刷新与失败回滚语义
- 将角色卡忙碌态等待逻辑复用到创建和删除流程
- 收窄 `useRoleFormAdapters` 与 `useRoleManagement` 职责
- 新增创建成功、创建失败、空字段校验、取消和重置测试

## 实际验证

- `pnpm --filter shiori-desktop run typecheck`
- 相关 renderer ESLint 检查
- `useRoleCreationController.test.ts`、`appState.test.ts`、`roleFormState.test.ts`
- 共 16 项测试通过
- `git diff --check`

## 已知阻塞项

无。后续聊天访谈入口属于依赖此任务的 Issue #87，不包含在本 PR。
