### PR TITLE
feat(chat): 支持中止流式角色回复

### DIFF
--- a/apps/backend/agent/context.py
+++ b/apps/backend/agent/context.py
@@ -32,6 +32,7 @@ from agent.plugins.role_prompt import (
     build_role_system_section,
 )
 from agent.skills import SkillsLoader
+from session.manager.models import INTERRUPTED_TURN_METADATA_KEY
 from prompts.agent import (
     build_agent_static_identity_prompt,
     build_current_message_time_envelope,
@@ -278,10 +279,18 @@ class ContextBuilder:
         self,
         *,
         turn_injection_prompt: str | None = None,
+        session_metadata: dict[str, Any] | None = None,
     ) -> dict[str, str]:
-        if not turn_injection_prompt:
-            return {}
-        return {"turn_injection": turn_injection_prompt}
+        context: dict[str, str] = {}
+        if turn_injection_prompt:
+            context["turn_injection"] = turn_injection_prompt
+        if isinstance((session_metadata or {}).get(INTERRUPTED_TURN_METADATA_KEY), dict):
+            context["interrupted_turn"] = (
+                "上一轮助手回复因用户主动中断而未完成。已保留的 assistant "
+                "content 和 reasoning_content 只是中断时的原始快照，不能视为完整结论，"
+                "也不要续写或改写其中的 reasoning_content；请基于当前用户消息自然回应。"
+            )
+        return context
 
     def render(
         self,
@@ -309,7 +318,8 @@ class ContextBuilder:
             insert_index = 1 if role_cache_prefix is not None else 0
             merged_top.insert(insert_index, role_section)
         turn_injection_context = self.build_turn_injection_context(
-            turn_injection_prompt=request.turn_injection_prompt
+            turn_injection_prompt=request.turn_injection_prompt,
+            session_metadata=session_metadata,
         )
         assembled = self._assembler.assemble(
             history=request.history,

--- a/apps/backend/agent/lifecycle/phases/after_reasoning.py
+++ b/apps/backend/agent/lifecycle/phases/after_reasoning.py
@@ -6,6 +6,7 @@ from typing import TYPE_CHECKING, Any, TypeAlias, cast
 
 from agent.core.mood_resolver import resolve_role_mood
 from agent.core.passive_support import update_session_runtime_metadata
+from session.manager.models import INTERRUPTED_TURN_METADATA_KEY
 from agent.core.response_parser import parse_response
 from agent.lifecycle.phase import (
     PhaseFrame,
@@ -303,6 +304,8 @@ class _UpdateSessionMetadataModule:
         if raw_session is None:
             raise RuntimeError("AfterReasoning requires TurnState.session")
         session = cast("Session", raw_session)
+        # A normally committed assistant reply closes any older interrupted snapshot.
+        _ = session.metadata.pop(INTERRUPTED_TURN_METADATA_KEY, None)
         update_session_runtime_metadata(
             session,
             tools_used=list(ctx.tools_used),

--- a/apps/backend/agent/looping/core/interrupts.py
+++ b/apps/backend/agent/looping/core/interrupts.py
@@ -46,11 +46,15 @@ class _InterruptMixin:
                 session_key=session_key,
                 original_user_message="",
             )
-        self._interrupt_states[session_key] = replace(
+        snapshot = replace(
             active_state,
+            original_metadata=dict(active_state.original_metadata),
+            tools_used=list(active_state.tools_used),
+            tool_chain_partial=list(active_state.tool_chain_partial),
             interrupted_by=command,
             interrupted_at=time.monotonic(),
         )
+        self._interrupt_states[session_key] = snapshot
         task.cancel()
         logger.info(
             f"Turn interrupted  session_key={session_key}  "
@@ -60,7 +64,18 @@ class _InterruptMixin:
             status="interrupted",
             session_key=session_key,
             message="本轮已中断。你可以继续补充要求，我会接着这件事处理。",
+            state=snapshot,
         )
+
+    def discard_interrupt_state(
+        self,
+        session_key: str,
+        state: TurnInterruptState,
+    ) -> None:
+        """Drops a snapshot after its channel has durably persisted it."""
+
+        if self._interrupt_states.get(session_key) is state:
+            _ = self._interrupt_states.pop(session_key, None)
 
     def _get_interrupt_state(self, session_key: str) -> TurnInterruptState | None:
         """读取中断态（含 TTL 过期检查），不提前消费。"""
@@ -101,6 +116,10 @@ class _InterruptMixin:
     ) -> tuple[InboundItem, bool]:
         # 1. 只有普通入站消息参与续跑，内部工作项不消费中断态。
         if not isinstance(msg, InboundMessage):
+            return msg, False
+        # Desktop persists the partial assistant trace and exposes the interruption
+        # as a separate session context frame; never duplicate it in user content.
+        if msg.channel == "desktop":
             return msg, False
         interrupted = self._get_interrupt_state(key)
         if interrupted is None:

--- a/apps/backend/agent/looping/interrupt.py
+++ b/apps/backend/agent/looping/interrupt.py
@@ -17,7 +17,7 @@ _DEFAULT_TTL_S = 1800  # 30 分钟
 
 @dataclass
 class TurnInterruptState:
-    """一个被中断的 turn 的快照，纯内存态，不落库。"""
+    """一个被中断的 turn 的快照，供控制面和持久化边界共同使用。"""
 
     session_key: str
     original_user_message: str
@@ -42,6 +42,7 @@ class InterruptResult:
     status: str  # "interrupted" | "idle"
     session_key: str = ""
     message: str = ""
+    state: TurnInterruptState | None = None
 
 
 class InterruptController(Protocol):

--- a/apps/backend/desktop_bridge/chat_requests.py
+++ b/apps/backend/desktop_bridge/chat_requests.py
@@ -46,7 +46,7 @@ class DesktopChatRequestHandler:
                 payload, request_id=request_id, emit_event=emit_event
             )
         if method == "chat.cancel":
-            result = self._chat_service.cancel_chat_turn(
+            result = await self._chat_service.cancel_chat_turn_async(
                 str(payload.get("session_key") or "").strip(),
                 str(payload.get("turn_id") or "").strip(),
             )

--- a/apps/backend/desktop_bridge/chat_requests.py
+++ b/apps/backend/desktop_bridge/chat_requests.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import Any
 
-from agent.looping.core import AgentLoop
 from core.roles import RoleAggregateService
 from infra.channels.reply_context import build_inbound_text_with_reply_context
 
@@ -25,7 +24,6 @@ class DesktopChatRequestHandler:
         chat_service: DesktopChatService,
         start_chat_turn: Callable[..., None],
         session_presenter: DesktopSessionPresenter,
-        agent_loop: AgentLoop,
         sanitize_voice_metrics: Callable[[object], dict[str, str | int] | None],
     ) -> None:
         self._role_service = role_service
@@ -33,7 +31,6 @@ class DesktopChatRequestHandler:
         self._chat_service = chat_service
         self._start_chat_turn = start_chat_turn
         self._session_presenter = session_presenter
-        self._agent_loop = agent_loop
         self._sanitize_voice_metrics = sanitize_voice_metrics
 
     async def handle(
@@ -49,18 +46,15 @@ class DesktopChatRequestHandler:
                 payload, request_id=request_id, emit_event=emit_event
             )
         if method == "chat.cancel":
-            aggregate = await self._role_service.open_role_async(
-                str(payload.get("role_id") or "").strip()
-            )
-            result = self._agent_loop.request_interrupt(
-                self._role_service.sessions.derive_session_key(aggregate.role.id),
-                sender="desktop",
-                command="/cancel",
+            result = self._chat_service.cancel_chat_turn(
+                str(payload.get("session_key") or "").strip(),
+                str(payload.get("turn_id") or "").strip(),
             )
             return {
                 "status": result.status,
                 "message": result.message,
                 "session_key": result.session_key,
+                "turn_id": result.turn_id,
             }
         return None
 
@@ -72,6 +66,9 @@ class DesktopChatRequestHandler:
         emit_event: EventEmitter,
     ) -> dict[str, Any]:
         role_id = str(payload.get("role_id") or "").strip()
+        turn_id = str(
+            payload.get("turn_id") or payload.get("client_message_id") or request_id
+        ).strip()
         content = str(payload.get("content") or "").strip()
         raw_media = payload.get("media")
         media = (
@@ -81,6 +78,8 @@ class DesktopChatRequestHandler:
         )
         if not content and not media:
             raise ValueError("content 和 media 不能同时为空")
+        if not turn_id:
+            raise ValueError("turn_id 不能为空")
         aggregate = await self._role_service.open_role_async(role_id)
         session = aggregate.session
         if self._chat_service.is_busy(session.key):
@@ -112,6 +111,7 @@ class DesktopChatRequestHandler:
         )
         self._start_chat_turn(
             request_id=request_id,
+            turn_id=turn_id,
             session_key=session.key,
             content=inbound_content,
             media=media,
@@ -119,7 +119,11 @@ class DesktopChatRequestHandler:
             omit_user_turn=True,
             emit_event=emit_event,
         )
-        return {"session": self._session_presenter.serialize(session), "events": []}
+        return {
+            "session": self._session_presenter.serialize(session),
+            "turn_id": turn_id,
+            "events": [],
+        }
 
     def _build_metadata(
         self,
@@ -134,6 +138,9 @@ class DesktopChatRequestHandler:
         client_message_id = str(payload.get("client_message_id") or "").strip()
         if client_message_id:
             metadata["client_message_id"] = client_message_id
+        turn_id = str(payload.get("turn_id") or client_message_id or request_id).strip()
+        if turn_id:
+            metadata["turn_id"] = turn_id
         if str(payload.get("input_method") or "").strip() == "voice":
             metadata["input_method"] = "voice"
             voice_turn_id = str(payload.get("voice_turn_id") or "").strip()

--- a/apps/backend/desktop_bridge/chat_service.py
+++ b/apps/backend/desktop_bridge/chat_service.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any, Protocol
 
 from agent.looping.core import AgentLoop
+from agent.looping.interrupt import TurnInterruptState
 from bus.event_bus import EventBus
 from bus.events_lifecycle import (
     StreamDeltaReady,
@@ -20,6 +21,7 @@ from desktop_bridge.tool_call_preview import truncate_desktop_tool_result
 from desktop_bridge.voice.tts_coordinator import TtsTurnCoordinator
 from desktop_bridge.voice.voice_service import VoiceService
 from session.manager import Session, SessionManager
+from session.manager.models import INTERRUPTED_TURN_METADATA_KEY
 
 logger = logging.getLogger("desktop.bridge.chat")
 
@@ -106,7 +108,11 @@ class DesktopChatService:
         turn = self._tasks_by_session.get(session_key)
         return turn is not None and not turn.task.done()
 
-    def cancel_chat_turn(self, session_key: str, turn_id: str) -> ChatTurnCancelResult:
+    def cancel_chat_turn(
+        self,
+        session_key: str,
+        turn_id: str,
+    ) -> ChatTurnCancelResult:
         """Interrupts exactly one active renderer chat turn when its identity matches."""
 
         normalized_session_key = session_key.strip()
@@ -129,32 +135,202 @@ class DesktopChatService:
                 message="当前会话正在执行另一个回合",
             )
 
-        result = self._agent_loop.request_interrupt(
+        result, interrupt_state = self._prepare_cancel(
             normalized_session_key,
-            sender="desktop",
-            command="/cancel",
         )
-        # The direct AgentLoop task may not have registered yet. Cancelling the
-        # desktop-owned wrapper closes that narrow race without touching other sessions.
-        active_turn.task.cancel()
-        # Release the renderer-owned session slot before the cancellation task
-        # finishes so a follow-up message can start immediately.
-        _ = self._tasks_by_session.pop(normalized_session_key, None)
-        if active_turn.voice_turn_id and self._voice_turn_tasks.get(active_turn.voice_turn_id) == (
-            normalized_session_key,
-            active_turn.task,
-        ):
-            _ = self._voice_turn_tasks.pop(active_turn.voice_turn_id, None)
-        if active_turn.voice_turn_id:
-            coordinator = self._tts_coordinators.pop(active_turn.voice_turn_id, None)
-            if coordinator is not None:
-                coordinator.cancel()
+        self._schedule_interrupted_persistence(
+            session_key=normalized_session_key,
+            turn_id=normalized_turn_id,
+            state=interrupt_state,
+        )
         return ChatTurnCancelResult(
             status="interrupted",
             session_key=normalized_session_key,
             turn_id=normalized_turn_id,
             message=result.message if result.status == "interrupted" else "已中止当前回复",
         )
+
+    async def cancel_chat_turn_async(
+        self,
+        session_key: str,
+        turn_id: str,
+    ) -> ChatTurnCancelResult:
+        """Cancels a turn and waits for its partial reply to be durable."""
+
+        normalized_session_key = session_key.strip()
+        normalized_turn_id = turn_id.strip()
+        if not normalized_session_key or not normalized_turn_id:
+            raise ValueError("session_key 和 turn_id 不能为空")
+        active_turn = self._tasks_by_session.get(normalized_session_key)
+        if active_turn is None or active_turn.task.done():
+            return ChatTurnCancelResult(
+                status="idle",
+                session_key=normalized_session_key,
+                turn_id=normalized_turn_id,
+                message="当前回合已经结束",
+            )
+        if active_turn.turn_id != normalized_turn_id:
+            return ChatTurnCancelResult(
+                status="mismatch",
+                session_key=normalized_session_key,
+                turn_id=normalized_turn_id,
+                message="当前会话正在执行另一个回合",
+            )
+        result, interrupt_state = self._prepare_cancel(
+            normalized_session_key,
+            normalized_turn_id=normalized_turn_id,
+        )
+        if result.status == "interrupted" and isinstance(
+            interrupt_state, TurnInterruptState
+        ):
+            await self._persist_interrupted_turn(
+                session_key=normalized_session_key,
+                turn_id=normalized_turn_id,
+                state=interrupt_state,
+            )
+            discard = getattr(self._agent_loop, "discard_interrupt_state", None)
+            if callable(discard):
+                discard(normalized_session_key, interrupt_state)
+        return result
+
+    async def _persist_and_discard_interrupted_turn(
+        self,
+        *,
+        session_key: str,
+        turn_id: str,
+        state: TurnInterruptState,
+    ) -> None:
+        await self._persist_interrupted_turn(
+            session_key=session_key,
+            turn_id=turn_id,
+            state=state,
+        )
+        discard = getattr(self._agent_loop, "discard_interrupt_state", None)
+        if callable(discard):
+            discard(session_key, state)
+
+    def _schedule_interrupted_persistence(
+        self,
+        *,
+        session_key: str,
+        turn_id: str,
+        state: TurnInterruptState | None,
+    ) -> None:
+        """Schedules compatibility-path persistence when no async caller can await it."""
+
+        if state is None:
+            return
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        loop.create_task(
+            self._persist_and_discard_interrupted_turn(
+                session_key=session_key,
+                turn_id=turn_id,
+                state=state,
+            )
+        )
+
+    def _prepare_cancel(
+        self,
+        session_key: str,
+        normalized_turn_id: str | None = None,
+    ) -> tuple[ChatTurnCancelResult, TurnInterruptState | None]:
+        """Stops renderer-owned work and returns the immutable interrupt snapshot."""
+
+        active_turn = self._tasks_by_session.get(session_key)
+        turn_id = normalized_turn_id or (active_turn.turn_id if active_turn else "")
+        raw_result = self._agent_loop.request_interrupt(
+            session_key,
+            sender="desktop",
+            command="/cancel",
+        )
+        interrupt_state = getattr(raw_result, "state", None)
+        active_turn.task.cancel() if active_turn is not None else None
+        _ = self._tasks_by_session.pop(session_key, None)
+        if active_turn is not None and active_turn.voice_turn_id and self._voice_turn_tasks.get(
+            active_turn.voice_turn_id
+        ) == (session_key, active_turn.task):
+            _ = self._voice_turn_tasks.pop(active_turn.voice_turn_id, None)
+        if active_turn is not None and active_turn.voice_turn_id:
+            coordinator = self._tts_coordinators.pop(active_turn.voice_turn_id, None)
+            if coordinator is not None:
+                coordinator.cancel()
+        return (
+            ChatTurnCancelResult(
+                status="interrupted",
+                session_key=session_key,
+                turn_id=turn_id,
+                message=(
+                    raw_result.message
+                    if raw_result.status == "interrupted"
+                    else "已中止当前回合"
+                ),
+            ),
+            interrupt_state if isinstance(interrupt_state, TurnInterruptState) else None,
+        )
+
+    async def _persist_interrupted_turn(
+        self,
+        *,
+        session_key: str,
+        turn_id: str,
+        state: TurnInterruptState,
+    ) -> None:
+        """Persists one cancelled desktop reply before its session can be reused."""
+
+        session = self._session_manager.get_or_create(session_key)
+        if self._has_completed_turn(session, turn_id):
+            return
+        has_trace = bool(
+            state.partial_reply
+            or state.partial_thinking
+            or state.tools_used
+            or state.tool_chain_partial
+        )
+        assistant_metadata = {
+            "interrupted_reply": True,
+            "turn_id": turn_id,
+            "interrupted_by": state.interrupted_by,
+        }
+        assistant_kwargs: dict[str, Any] = {
+            "metadata": assistant_metadata,
+            "tools_used": list(state.tools_used) if state.tools_used else None,
+            "tool_chain": (
+                list(state.tool_chain_partial) if state.tool_chain_partial else None
+            ),
+        }
+        if state.partial_thinking is not None:
+            assistant_kwargs["reasoning_content"] = state.partial_thinking
+        assistant_message: dict[str, Any] | None = None
+        if has_trace:
+            session.add_message("assistant", state.partial_reply, **assistant_kwargs)
+            assistant_message = session.messages[-1]
+        session.metadata[INTERRUPTED_TURN_METADATA_KEY] = {
+            "turn_id": turn_id,
+            "interrupted_by": state.interrupted_by,
+        }
+        await self._session_manager.append_messages(
+            session,
+            [assistant_message] if assistant_message is not None else [],
+        )
+        role_id = self._role_id_from_session_key(session_key)
+        if role_id:
+            self._sync_desktop_session_thread(session, role_id=role_id)
+
+    @staticmethod
+    def _has_completed_turn(session: Session, turn_id: str) -> bool:
+        for message in reversed(session.messages):
+            if message.get("role") != "assistant":
+                continue
+            metadata = message.get("metadata")
+            if not isinstance(metadata, dict):
+                continue
+            if metadata.get("turn_id") != turn_id:
+                continue
+            return True
+        return False
 
     def cancel_voice_turn(self, turn_id: str) -> bool:
         """Cancels chat and synthesis work owned by one voice input turn."""
@@ -163,20 +339,32 @@ class DesktopChatService:
         if not normalized_turn_id:
             return False
         cancelled = False
-        coordinator = self._tts_coordinators.pop(normalized_turn_id, None)
-        if coordinator is not None:
-            coordinator.cancel()
-            cancelled = True
         owner = self._voice_turn_tasks.get(normalized_turn_id)
         if owner is not None:
             session_key, task = owner
-            if not task.done():
+            active_turn = self._tasks_by_session.get(session_key)
+            if active_turn is not None and active_turn.task is task and not task.done():
+                _, interrupt_state = self._prepare_cancel(
+                    session_key,
+                    normalized_turn_id=active_turn.turn_id,
+                )
+                self._schedule_interrupted_persistence(
+                    session_key=session_key,
+                    turn_id=active_turn.turn_id,
+                    state=interrupt_state,
+                )
+                cancelled = True
+            elif not task.done():
                 _ = self._agent_loop.request_interrupt(
                     session_key,
                     sender="desktop",
                     command="/cancel",
                 )
                 cancelled = True
+        coordinator = self._tts_coordinators.pop(normalized_turn_id, None)
+        if coordinator is not None:
+            coordinator.cancel()
+            cancelled = True
         return cancelled
 
     async def run_chat_turn(

--- a/apps/backend/desktop_bridge/chat_service.py
+++ b/apps/backend/desktop_bridge/chat_service.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
 from typing import Any, Protocol
 
 from agent.looping.core import AgentLoop
@@ -47,6 +48,25 @@ class ChatTurnBusyError(RuntimeError):
     """Raised when a desktop session already owns an active chat turn."""
 
 
+@dataclass(frozen=True)
+class ChatTurnCancelResult:
+    """Result of a session-scoped desktop chat cancellation request."""
+
+    status: str
+    session_key: str
+    turn_id: str
+    message: str
+
+
+@dataclass(frozen=True)
+class _DesktopChatTurn:
+    """Tracks one renderer-owned turn without sharing state across sessions."""
+
+    task: asyncio.Task[None]
+    turn_id: str
+    voice_turn_id: str
+
+
 class DesktopChatService:
     """Runs desktop chat turns and bridges lifecycle events back to the bridge stream."""
 
@@ -75,7 +95,7 @@ class DesktopChatService:
         self._emit_session_updated = emit_session_updated
         self._tts_service = tts_service
         self._streaming_enabled = bool(streaming_enabled)
-        self._tasks_by_session: dict[str, asyncio.Task[None]] = {}
+        self._tasks_by_session: dict[str, _DesktopChatTurn] = {}
         self._voice_turn_tasks: dict[str, tuple[str, asyncio.Task[None]]] = {}
         self._tts_tasks: set[asyncio.Task[None]] = set()
         self._tts_coordinators: dict[str, TtsTurnCoordinator] = {}
@@ -83,8 +103,58 @@ class DesktopChatService:
     def is_busy(self, session_key: str) -> bool:
         """Returns whether the session already has an active desktop turn."""
 
-        task = self._tasks_by_session.get(session_key)
-        return task is not None and not task.done()
+        turn = self._tasks_by_session.get(session_key)
+        return turn is not None and not turn.task.done()
+
+    def cancel_chat_turn(self, session_key: str, turn_id: str) -> ChatTurnCancelResult:
+        """Interrupts exactly one active renderer chat turn when its identity matches."""
+
+        normalized_session_key = session_key.strip()
+        normalized_turn_id = turn_id.strip()
+        if not normalized_session_key or not normalized_turn_id:
+            raise ValueError("session_key 和 turn_id 不能为空")
+        active_turn = self._tasks_by_session.get(normalized_session_key)
+        if active_turn is None or active_turn.task.done():
+            return ChatTurnCancelResult(
+                status="idle",
+                session_key=normalized_session_key,
+                turn_id=normalized_turn_id,
+                message="当前回合已经结束",
+            )
+        if active_turn.turn_id != normalized_turn_id:
+            return ChatTurnCancelResult(
+                status="mismatch",
+                session_key=normalized_session_key,
+                turn_id=normalized_turn_id,
+                message="当前会话正在执行另一个回合",
+            )
+
+        result = self._agent_loop.request_interrupt(
+            normalized_session_key,
+            sender="desktop",
+            command="/cancel",
+        )
+        # The direct AgentLoop task may not have registered yet. Cancelling the
+        # desktop-owned wrapper closes that narrow race without touching other sessions.
+        active_turn.task.cancel()
+        # Release the renderer-owned session slot before the cancellation task
+        # finishes so a follow-up message can start immediately.
+        _ = self._tasks_by_session.pop(normalized_session_key, None)
+        if active_turn.voice_turn_id and self._voice_turn_tasks.get(active_turn.voice_turn_id) == (
+            normalized_session_key,
+            active_turn.task,
+        ):
+            _ = self._voice_turn_tasks.pop(active_turn.voice_turn_id, None)
+        if active_turn.voice_turn_id:
+            coordinator = self._tts_coordinators.pop(active_turn.voice_turn_id, None)
+            if coordinator is not None:
+                coordinator.cancel()
+        return ChatTurnCancelResult(
+            status="interrupted",
+            session_key=normalized_session_key,
+            turn_id=normalized_turn_id,
+            message=result.message if result.status == "interrupted" else "已中止当前回复",
+        )
 
     def cancel_voice_turn(self, turn_id: str) -> bool:
         """Cancels chat and synthesis work owned by one voice input turn."""
@@ -119,7 +189,9 @@ class DesktopChatService:
         metadata: dict[str, object] | None,
         omit_user_turn: bool,
         emit_event: EventEmitter,
+        turn_id: str | None = None,
     ) -> tuple[Session, list[BridgeEvent]]:
+        turn_id = turn_id or request_id
         collected: list[BridgeEvent] = []
         tts = self._create_tts_coordinator(
             request_id=request_id,
@@ -162,6 +234,7 @@ class DesktopChatService:
                 method="chat.delta",
                 payload={
                     "session_key": event.session_key,
+                    "turn_id": turn_id,
                     "content_delta": event.content_delta,
                     "thinking_delta": event.thinking_delta,
                 },
@@ -181,6 +254,7 @@ class DesktopChatService:
                 method="chat.done",
                 payload={
                     "session_key": event.session_key,
+                    "turn_id": turn_id,
                     "role_id": self._role_id_from_session_key(event.session_key),
                     "reply": event.assistant_response,
                     "thinking": event.thinking,
@@ -213,6 +287,7 @@ class DesktopChatService:
                 method="chat.tool.started",
                 payload={
                     "session_key": event.session_key,
+                    "turn_id": turn_id,
                     "iteration": event.iteration,
                     "call_id": call_id,
                     "tool_name": tool_name,
@@ -235,6 +310,7 @@ class DesktopChatService:
                 method="chat.tool.completed",
                 payload={
                     "session_key": event.session_key,
+                    "turn_id": turn_id,
                     "iteration": event.iteration,
                     "call_id": call_id,
                     "tool_name": tool_name,
@@ -299,6 +375,7 @@ class DesktopChatService:
                 method="chat.error",
                 payload={
                     "session_key": session_key,
+                    "turn_id": turn_id,
                     "message": str(exc),
                 },
             )
@@ -322,7 +399,9 @@ class DesktopChatService:
         metadata: dict[str, object] | None,
         omit_user_turn: bool,
         emit_event: EventEmitter,
+        turn_id: str | None = None,
     ) -> None:
+        turn_id = turn_id or request_id
         if self.is_busy(session_key):
             raise ChatTurnBusyError(f"会话 {session_key} 已有正在执行的聊天任务")
 
@@ -330,6 +409,7 @@ class DesktopChatService:
             try:
                 _ = await self.run_chat_turn(
                     request_id=request_id,
+                    turn_id=turn_id,
                     session_key=session_key,
                     content=content,
                     media=media,
@@ -337,15 +417,21 @@ class DesktopChatService:
                     omit_user_turn=omit_user_turn,
                     emit_event=emit_event,
                 )
+            except asyncio.CancelledError:
+                return
             except Exception:
                 logger.exception("desktop chat turn failed: %s", session_key)
 
-        task = asyncio.create_task(_runner(), name=f"desktop-chat:{session_key}")
-        self._tasks_by_session[session_key] = task
         voice_turn_id = (
             str(metadata.get("voice_turn_id") or "").strip()
             if isinstance(metadata, dict) and metadata.get("input_method") == "voice"
             else ""
+        )
+        task = asyncio.create_task(_runner(), name=f"desktop-chat:{session_key}")
+        self._tasks_by_session[session_key] = _DesktopChatTurn(
+            task=task,
+            turn_id=turn_id,
+            voice_turn_id=voice_turn_id,
         )
         if voice_turn_id:
             self._voice_turn_tasks[voice_turn_id] = (session_key, task)
@@ -360,7 +446,7 @@ class DesktopChatService:
     async def aclose(self) -> None:
         """Cancels and awaits every desktop-owned chat turn."""
 
-        tasks = list(self._tasks_by_session.values())
+        tasks = [turn.task for turn in self._tasks_by_session.values()]
         for task in tasks:
             if not task.done():
                 _ = task.cancel()
@@ -466,7 +552,8 @@ class DesktopChatService:
         task: asyncio.Task[None],
         voice_turn_id: str,
     ) -> None:
-        if self._tasks_by_session.get(session_key) is task:
+        active_turn = self._tasks_by_session.get(session_key)
+        if active_turn is not None and active_turn.task is task:
             _ = self._tasks_by_session.pop(session_key, None)
         if voice_turn_id and self._voice_turn_tasks.get(voice_turn_id) == (
             session_key,

--- a/apps/backend/desktop_bridge/chat_service.py
+++ b/apps/backend/desktop_bridge/chat_service.py
@@ -142,12 +142,13 @@ class DesktopChatService:
             session_key=normalized_session_key,
             turn_id=normalized_turn_id,
             state=interrupt_state,
+            task=active_turn.task,
         )
         return ChatTurnCancelResult(
-            status="interrupted",
+            status=result.status,
             session_key=normalized_session_key,
             turn_id=normalized_turn_id,
-            message=result.message if result.status == "interrupted" else "已中止当前回复",
+            message=result.message,
         )
 
     async def cancel_chat_turn_async(
@@ -180,9 +181,9 @@ class DesktopChatService:
             normalized_session_key,
             normalized_turn_id=normalized_turn_id,
         )
-        if result.status == "interrupted" and isinstance(
-            interrupt_state, TurnInterruptState
-        ):
+        if active_turn is not None:
+            await self._await_turn_cleanup(normalized_session_key, active_turn)
+        if result.status == "interrupted" and isinstance(interrupt_state, TurnInterruptState):
             await self._persist_interrupted_turn(
                 session_key=normalized_session_key,
                 turn_id=normalized_turn_id,
@@ -215,6 +216,7 @@ class DesktopChatService:
         session_key: str,
         turn_id: str,
         state: TurnInterruptState | None,
+        task: asyncio.Task[None] | None = None,
     ) -> None:
         """Schedules compatibility-path persistence when no async caller can await it."""
 
@@ -225,11 +227,30 @@ class DesktopChatService:
         except RuntimeError:
             return
         loop.create_task(
-            self._persist_and_discard_interrupted_turn(
+            self._persist_after_turn_cleanup(
                 session_key=session_key,
                 turn_id=turn_id,
                 state=state,
+                task=task,
             )
+        )
+
+    async def _persist_after_turn_cleanup(
+        self,
+        *,
+        session_key: str,
+        turn_id: str,
+        state: TurnInterruptState,
+        task: asyncio.Task[None] | None,
+    ) -> None:
+        if task is not None:
+            active_turn = self._tasks_by_session.get(session_key)
+            if active_turn is not None and active_turn.task is task:
+                await self._await_turn_cleanup(session_key, active_turn)
+        await self._persist_and_discard_interrupted_turn(
+            session_key=session_key,
+            turn_id=turn_id,
+            state=state,
         )
 
     def _prepare_cancel(
@@ -247,19 +268,17 @@ class DesktopChatService:
             command="/cancel",
         )
         interrupt_state = getattr(raw_result, "state", None)
-        active_turn.task.cancel() if active_turn is not None else None
-        _ = self._tasks_by_session.pop(session_key, None)
-        if active_turn is not None and active_turn.voice_turn_id and self._voice_turn_tasks.get(
-            active_turn.voice_turn_id
-        ) == (session_key, active_turn.task):
-            _ = self._voice_turn_tasks.pop(active_turn.voice_turn_id, None)
+        # Keep a naturally completed wrapper alive when AgentLoop reports idle;
+        # it still needs to publish its final session update.
+        if active_turn is not None and raw_result.status == "interrupted":
+            _ = active_turn.task.cancel()
         if active_turn is not None and active_turn.voice_turn_id:
             coordinator = self._tts_coordinators.pop(active_turn.voice_turn_id, None)
             if coordinator is not None:
                 coordinator.cancel()
         return (
             ChatTurnCancelResult(
-                status="interrupted",
+                status=str(getattr(raw_result, "status", "interrupted")),
                 session_key=session_key,
                 turn_id=turn_id,
                 message=(
@@ -270,6 +289,17 @@ class DesktopChatService:
             ),
             interrupt_state if isinstance(interrupt_state, TurnInterruptState) else None,
         )
+
+    async def _await_turn_cleanup(
+        self,
+        session_key: str,
+        active_turn: _DesktopChatTurn,
+    ) -> None:
+        try:
+            await active_turn.task
+        except asyncio.CancelledError:
+            pass
+        self._discard_task(session_key, active_turn.task, active_turn.voice_turn_id)
 
     async def _persist_interrupted_turn(
         self,
@@ -352,6 +382,7 @@ class DesktopChatService:
                     session_key=session_key,
                     turn_id=active_turn.turn_id,
                     state=interrupt_state,
+                    task=task,
                 )
                 cancelled = True
             elif not task.done():

--- a/apps/backend/desktop_bridge/service.py
+++ b/apps/backend/desktop_bridge/service.py
@@ -228,7 +228,6 @@ class DesktopBridgeService:
                 chat_service=self.chat_service,
                 start_chat_turn=lambda **kwargs: self._start_chat_turn(**kwargs),
                 session_presenter=self.session_presenter,
-                agent_loop=agent_loop,
                 sanitize_voice_metrics=_sanitize_voice_metrics,
             ),
             images=DesktopImageRequestHandler(
@@ -378,6 +377,7 @@ class DesktopBridgeService:
         self,
         *,
         request_id: str,
+        turn_id: str,
         session_key: str,
         content: str,
         media: list[str],
@@ -387,6 +387,7 @@ class DesktopBridgeService:
     ) -> None:
         self.chat_service.start_chat_turn(
             request_id=request_id,
+            turn_id=turn_id,
             session_key=session_key,
             content=content,
             media=media,

--- a/apps/backend/session/manager/models.py
+++ b/apps/backend/session/manager/models.py
@@ -16,6 +16,9 @@ from .helpers import (
 )
 
 
+INTERRUPTED_TURN_METADATA_KEY = "interrupted_turn"
+
+
 @dataclass
 class Session:
     """单次对话中的 session。"""

--- a/apps/desktop/renderer/src/app/DesktopAppFrame.tsx
+++ b/apps/desktop/renderer/src/app/DesktopAppFrame.tsx
@@ -109,6 +109,7 @@ type DesktopAppFrameProps = {
   highlightedMessageKey: string;
   notice: string;
   isVisibleChatSending: boolean;
+  isVisibleChatCancelling: boolean;
   visibleIllustrationUrl: string;
   windowVisible: boolean;
   onGoToNextChatImage: () => void;
@@ -120,6 +121,7 @@ type DesktopAppFrameProps = {
   onBeginAttachmentDrag: (path: string) => void;
   onCopyMessage: (content: string) => void;
   onSendMessage: (request: ChatSendRequest) => Promise<boolean>;
+  onCancelChat: () => void;
   imageHistorySidebar: RightSidebarViewState;
   detailRole: RoleRecord | null;
   pendingRoleCardAction: PendingRoleCardAction;
@@ -244,6 +246,7 @@ export function DesktopAppFrame({
   highlightedMessageKey,
   notice,
   isVisibleChatSending,
+  isVisibleChatCancelling,
   visibleIllustrationUrl,
   windowVisible,
   onGoToNextChatImage,
@@ -255,6 +258,7 @@ export function DesktopAppFrame({
   onBeginAttachmentDrag,
   onCopyMessage,
   onSendMessage,
+  onCancelChat,
   imageHistorySidebar,
   detailRole,
   pendingRoleCardAction,
@@ -456,6 +460,7 @@ export function DesktopAppFrame({
               highlightedMessageKey={highlightedMessageKey}
               notice={notice}
               sending={isVisibleChatSending}
+              cancelling={isVisibleChatCancelling}
               visibleIllustrationUrl={visibleIllustrationUrl}
               windowVisible={windowVisible}
               onBeginChatLatestImageSidebarResize={chatLatestImageSidebar.beginResize}
@@ -468,6 +473,7 @@ export function DesktopAppFrame({
               onBeginAttachmentDrag={onBeginAttachmentDrag}
               onCopyMessage={onCopyMessage}
               onSendMessage={onSendMessage}
+              onCancelChat={onCancelChat}
               onToggleChatLatestImageSidebar={chatLatestImageSidebar.toggle}
             />
           ) : null}

--- a/apps/desktop/renderer/src/app/desktopSelectors.test.ts
+++ b/apps/desktop/renderer/src/app/desktopSelectors.test.ts
@@ -75,6 +75,7 @@ describe("desktopSelectors", () => {
       selectedChatImageKey: "",
       health: "online",
       sendingSessions: {},
+      cancellingSessions: {},
     });
 
     assert.equal(viewModel.roleFormDirty, true);
@@ -91,10 +92,12 @@ describe("desktopSelectors", () => {
       selectedChatImageKey: "",
       health: "online",
       sendingSessions: { "role:mira": "mira" },
+      cancellingSessions: { "role:mira": "mira" },
     });
 
     assert.equal(viewModel.headerTitle, "正在输入中...");
     assert.equal(viewModel.bridgeReady, true);
+    assert.equal(viewModel.isVisibleChatCancelling, true);
   });
 
   it("keeps duplicate latest images distinct when selection uses the history entry key", () => {
@@ -124,6 +127,7 @@ describe("desktopSelectors", () => {
       selectedChatImageKey: "message-2:0",
       health: "online",
       sendingSessions: {},
+      cancellingSessions: {},
     });
 
     assert.equal(viewModel.selectedChatImageIndex, 1);
@@ -152,6 +156,7 @@ describe("desktopSelectors", () => {
       selectedChatImageKey: "",
       health: "online",
       sendingSessions: {},
+      cancellingSessions: {},
     });
 
     assert.equal(viewModel.currentMood, "开心");
@@ -182,6 +187,7 @@ describe("desktopSelectors", () => {
       selectedChatImageKey: "",
       health: "online",
       sendingSessions: {},
+      cancellingSessions: {},
     });
 
     assert.equal(viewModel.moodIllustration, "D:\\roles\\mira\\happy.png");
@@ -228,6 +234,7 @@ describe("desktopSelectors", () => {
       selectedChatImageKey: "",
       health: "online",
       sendingSessions: {},
+      cancellingSessions: {},
     });
 
     assert.equal(viewModel.roleSelfView, "我最近会不自觉地去想你会不会来找我。");
@@ -273,6 +280,7 @@ describe("desktopSelectors", () => {
       selectedChatImageKey: "",
       health: "online",
       sendingSessions: {},
+      cancellingSessions: {},
     });
 
     assert.equal(viewModel.roleSelfView, "我还是会留意你有没有想起我。");
@@ -305,6 +313,7 @@ describe("desktopSelectors", () => {
       selectedChatImageKey: "",
       health: "online",
       sendingSessions: {},
+      cancellingSessions: {},
     });
 
     assert.equal(viewModel.roleSelfView, "");

--- a/apps/desktop/renderer/src/app/desktopSelectors.ts
+++ b/apps/desktop/renderer/src/app/desktopSelectors.ts
@@ -27,6 +27,7 @@ type BuildDesktopViewModelArgs = {
   selectedChatImageKey: string;
   health: string;
   sendingSessions: Record<string, string>;
+  cancellingSessions: Record<string, string>;
 };
 
 /** Builds the derived desktop view model from persisted app state. */
@@ -40,6 +41,7 @@ export function buildDesktopViewModel({
   selectedChatImageKey,
   health,
   sendingSessions,
+  cancellingSessions,
 }: BuildDesktopViewModelArgs) {
   const activeRole = roles.find((role) => role.id === activeRoleId) ?? null;
   const detailRoleId = mainView.kind === "role-detail" ? mainView.roleId : activeRoleId;
@@ -71,6 +73,7 @@ export function buildDesktopViewModel({
   const activeSessionKey = activeSession?.key ?? "";
   const visibleChatSessionKey = resolveVisibleChatSessionKey(activeRoleId, activeSessionKey);
   const isVisibleChatSending = Boolean(visibleChatSessionKey && sendingSessions[visibleChatSessionKey]);
+  const isVisibleChatCancelling = Boolean(visibleChatSessionKey && cancellingSessions[visibleChatSessionKey]);
   const headerTitle = resolveChatHeaderTitle({
     activeRoleName: activeRole?.name ?? null,
     activeSessionKey: visibleChatSessionKey,
@@ -125,6 +128,7 @@ export function buildDesktopViewModel({
     activeSessionKey,
     visibleChatSessionKey,
     isVisibleChatSending,
+    isVisibleChatCancelling,
     headerTitle,
     chatImageHistory,
     resolvedChatImagePath,

--- a/apps/desktop/renderer/src/app/useDesktopBridgeLifecycle.ts
+++ b/apps/desktop/renderer/src/app/useDesktopBridgeLifecycle.ts
@@ -30,6 +30,9 @@ type UseDesktopBridgeLifecycleArgs = {
   cacheRoleSession: (roleId: string, session: SessionPayload) => void;
   clearAllSendingSessions: () => void;
   clearSessionSending: (sessionKey: string) => void;
+  completeChatTurn: (sessionKey: string, turnId: string) => void;
+  isCurrentChatTurn: (sessionKey: string, turnId: string) => boolean;
+  isChatTurnCancelling: (sessionKey: string, turnId: string) => boolean;
   commitActiveSession: (nextSession: SessionPayload | null) => void;
   updateCommittedActiveSession: (updater: (current: SessionPayload | null) => SessionPayload | null) => void;
   appendSessionErrorMessage: (sessionKey: string, message: string) => void;
@@ -59,6 +62,9 @@ export function useDesktopBridgeLifecycle({
   cacheRoleSession,
   clearAllSendingSessions,
   clearSessionSending,
+  completeChatTurn,
+  isCurrentChatTurn,
+  isChatTurnCancelling,
   commitActiveSession,
   updateCommittedActiveSession,
   appendSessionErrorMessage,
@@ -74,6 +80,9 @@ export function useDesktopBridgeLifecycle({
     chooseIllustration,
     clearAllSendingSessions,
     clearSessionSending,
+    completeChatTurn,
+    isCurrentChatTurn,
+    isChatTurnCancelling,
     commitActiveSession,
     loadRolesFromBridge,
     openRole,
@@ -200,6 +209,9 @@ export function useDesktopBridgeLifecycle({
         }
 
         const eventSessionKey = String(event.payload.session_key ?? "");
+        const eventTurnId = String(event.payload.turn_id ?? "");
+        if (["chat.delta", "chat.tool.started", "chat.tool.completed", "chat.done", "chat.error"].includes(event.method)
+          && !callbacks.isCurrentChatTurn(eventSessionKey, eventTurnId)) return;
         if (event.method === "chat.delta") {
           const currentSession = activeSessionRef.current;
           if (!currentSession || eventSessionKey !== currentSession.key) return;
@@ -253,7 +265,6 @@ export function useDesktopBridgeLifecycle({
         }
 
         if (event.method === "chat.done") {
-          callbacks.clearSessionSending(eventSessionKey);
           callbacks.updateCommittedActiveSession((current) => {
             if (!current || current.key !== eventSessionKey) return current;
             return finishChatStream(current, parseChatTurnMetrics({
@@ -261,16 +272,19 @@ export function useDesktopBridgeLifecycle({
               thinking_duration_ms: event.payload.thinking_duration_ms,
             }));
           });
+          callbacks.completeChatTurn(eventSessionKey, eventTurnId);
           return;
         }
 
         if (event.method === "chat.error") {
-          callbacks.clearSessionSending(eventSessionKey);
+          const cancelling = callbacks.isChatTurnCancelling(eventSessionKey, eventTurnId);
           const currentSession = activeSessionRef.current;
-          if (!currentSession || eventSessionKey !== currentSession.key) return;
-          const message = String(event.payload.message ?? "对话失败");
-          setError(message);
-          callbacks.appendSessionErrorMessage(currentSession.key, message);
+          if (!cancelling && currentSession && eventSessionKey === currentSession.key) {
+            const message = String(event.payload.message ?? "对话失败");
+            setError(message);
+            callbacks.appendSessionErrorMessage(currentSession.key, message);
+          }
+          callbacks.completeChatTurn(eventSessionKey, eventTurnId);
         }
       };
 

--- a/apps/desktop/renderer/src/app/useDesktopSessionState.ts
+++ b/apps/desktop/renderer/src/app/useDesktopSessionState.ts
@@ -1,4 +1,5 @@
 import { useEffect, useRef } from "react";
+import { finishChatStream } from "../chat/chatStreamingState";
 import { buildOptimisticUserChatMessage, normalizeChatAttachmentPaths } from "../chat/chatComposerState";
 import { ensureChatMessageRenderId, reconcileSessionMessageRenderIds } from "../chat/chatMessageIdentity";
 import {
@@ -38,6 +39,7 @@ type UseDesktopSessionStateArgs = {
   setSelectedChatBackground: React.Dispatch<React.SetStateAction<string>>;
   setActiveIllustration: React.Dispatch<React.SetStateAction<string>>;
   setSendingSessions: React.Dispatch<React.SetStateAction<Record<string, string>>>;
+  setCancellingSessions: React.Dispatch<React.SetStateAction<Record<string, string>>>;
   chooseIllustration: (
     role: RoleRecord | null,
     session: SessionPayload | null,
@@ -57,6 +59,7 @@ type UseDesktopSessionStateArgs = {
   mainViewRef: React.MutableRefObject<AppMainView>;
   rolesRef: React.MutableRefObject<RoleRecord[]>;
   sendingSessionsRef: React.MutableRefObject<Record<string, string>>;
+  cancellingSessionsRef: React.MutableRefObject<Record<string, string>>;
   unreadCountsRef: React.MutableRefObject<Record<string, number>>;
   openRoleRequestIdRef: React.MutableRefObject<number>;
 };
@@ -111,6 +114,7 @@ export function useDesktopSessionState({
   setSelectedChatBackground,
   setActiveIllustration,
   setSendingSessions,
+  setCancellingSessions,
   chooseIllustration,
   applyRoleSnapshot,
   buildNavigationEntry,
@@ -122,6 +126,7 @@ export function useDesktopSessionState({
   mainViewRef,
   rolesRef,
   sendingSessionsRef,
+  cancellingSessionsRef,
   unreadCountsRef,
   openRoleRequestIdRef,
 }: UseDesktopSessionStateArgs) {
@@ -131,6 +136,7 @@ export function useDesktopSessionState({
   const replaceNavigationEntryRef = useRef(replaceNavigationEntry);
   const applyRoleSnapshotRef = useRef(applyRoleSnapshot);
   const pendingUserMessagesRef = useRef<Record<string, SessionMessage>>({});
+  const activeTurnIdsRef = useRef<Record<string, string>>({});
 
   useEffect(() => {
     chooseIllustrationRef.current = chooseIllustration;
@@ -288,10 +294,48 @@ export function useDesktopSessionState({
     setSendingSessions((current) => clearSendingSessionState(current, sessionKey));
   }
 
+  function markSessionCancelling(sessionKey: string, roleId: string): void {
+    cancellingSessionsRef.current = { ...cancellingSessionsRef.current, [sessionKey]: roleId };
+    setCancellingSessions((current) => current[sessionKey] === roleId ? current : { ...current, [sessionKey]: roleId });
+  }
+
+  function clearSessionCancelling(sessionKey: string): void {
+    if (!cancellingSessionsRef.current[sessionKey]) return;
+    const next = { ...cancellingSessionsRef.current };
+    delete next[sessionKey];
+    cancellingSessionsRef.current = next;
+    setCancellingSessions((current) => {
+      if (!current[sessionKey]) return current;
+      const updated = { ...current };
+      delete updated[sessionKey];
+      return updated;
+    });
+  }
+
+  function isCurrentChatTurn(sessionKey: string, turnId: string): boolean {
+    return Boolean(sessionKey && turnId && activeTurnIdsRef.current[sessionKey] === turnId);
+  }
+
+  function isChatTurnCancelling(sessionKey: string, turnId: string): boolean {
+    return isCurrentChatTurn(sessionKey, turnId)
+      && Boolean(cancellingSessionsRef.current[sessionKey]);
+  }
+
+  /** Releases renderer ownership after the matching backend turn reaches a terminal state. */
+  function completeChatTurn(sessionKey: string, turnId: string): void {
+    if (!isCurrentChatTurn(sessionKey, turnId)) return;
+    delete activeTurnIdsRef.current[sessionKey];
+    clearSessionCancelling(sessionKey);
+    clearSessionSending(sessionKey);
+  }
+
   function clearAllSendingSessions(): void {
     pendingUserMessagesRef.current = {};
+    activeTurnIdsRef.current = {};
     sendingSessionsRef.current = clearAllSendingSessionsState(sendingSessionsRef.current);
     setSendingSessions((current) => clearAllSendingSessionsState(current));
+    cancellingSessionsRef.current = {};
+    setCancellingSessions((current) => clearAllSendingSessionsState(current));
   }
 
   async function openRole(
@@ -399,6 +443,7 @@ export function useDesktopSessionState({
     if (!canSendSessionState(sendingSessionsRef.current, sessionKey)) return false;
     const persistedReplyTarget = currentReplyTarget;
     const clientMessageId = window.crypto.randomUUID();
+    const turnId = window.crypto.randomUUID();
     const pendingUserMessage = buildOptimisticUserChatMessage(
       content,
       media,
@@ -406,6 +451,7 @@ export function useDesktopSessionState({
       clientMessageId,
     );
     pendingUserMessagesRef.current[sessionKey] = pendingUserMessage;
+    activeTurnIdsRef.current[sessionKey] = turnId;
     markSessionSending(sessionKey, roleId);
     setError("");
     updateCommittedActiveSession((current) =>
@@ -427,6 +473,7 @@ export function useDesktopSessionState({
           content,
           media,
           client_message_id: clientMessageId,
+          turn_id: turnId,
           reply_to_message_id: persistedReplyTarget?.messageId ?? "",
           reply_to_content: persistedReplyTarget?.content ?? "",
           reply_to_sender: persistedReplyTarget?.sender ?? "",
@@ -435,6 +482,7 @@ export function useDesktopSessionState({
       if (res.error) {
         delete pendingUserMessagesRef.current[sessionKey];
         clearSessionSending(sessionKey);
+        delete activeTurnIdsRef.current[sessionKey];
         const { session: recoveredSession } = await fetchRoleSession(roleId);
         if (recoveredSession) {
           cacheRoleSession(roleId, recoveredSession);
@@ -456,6 +504,7 @@ export function useDesktopSessionState({
     } catch (error) {
       delete pendingUserMessagesRef.current[sessionKey];
       clearSessionSending(sessionKey);
+      delete activeTurnIdsRef.current[sessionKey];
       const { session: recoveredSession } = await fetchRoleSession(roleId);
       if (recoveredSession) {
         cacheRoleSession(roleId, recoveredSession);
@@ -473,6 +522,33 @@ export function useDesktopSessionState({
     }
   }
 
+  async function cancelChatTurn(sessionKey: string, roleId: string): Promise<boolean> {
+    const turnId = activeTurnIdsRef.current[sessionKey] ?? "";
+    if (!turnId || !sessionKey) return false;
+    if (cancellingSessionsRef.current[sessionKey]) return false;
+    markSessionCancelling(sessionKey, roleId);
+    try {
+      const res = await window.miraDesktop.invoke({
+        method: "chat.cancel",
+        payload: { session_key: sessionKey, turn_id: turnId },
+      });
+      if (res.error) throw new Error(res.error.message);
+      const status = String(res.payload.status ?? "");
+      if (status !== "interrupted" && status !== "idle") {
+        throw new Error(String(res.payload.message ?? "中止回复失败"));
+      }
+      if (isCurrentChatTurn(sessionKey, turnId)) {
+        updateCommittedActiveSession((current) => current?.key === sessionKey ? finishChatStream(current) : current);
+        completeChatTurn(sessionKey, turnId);
+      }
+      return true;
+    } catch (error) {
+      clearSessionCancelling(sessionKey);
+      window.alert(error instanceof Error ? error.message : String(error));
+      return false;
+    }
+  }
+
   return {
     cacheRoleSession,
     removeCachedRoleSession,
@@ -481,6 +557,10 @@ export function useDesktopSessionState({
     refreshSession,
     clearAllSendingSessions,
     clearSessionSending,
+    cancelChatTurn,
+    isCurrentChatTurn,
+    isChatTurnCancelling,
+    completeChatTurn,
     appendSessionErrorMessage,
     openRole,
     sendMessage,

--- a/apps/desktop/renderer/src/app/useDesktopSessionState.ts
+++ b/apps/desktop/renderer/src/app/useDesktopSessionState.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from "react";
-import { finishChatStream } from "../chat/chatStreamingState";
+import { interruptChatStream } from "../chat/chatStreamingState";
 import { buildOptimisticUserChatMessage, normalizeChatAttachmentPaths } from "../chat/chatComposerState";
 import { ensureChatMessageRenderId, reconcileSessionMessageRenderIds } from "../chat/chatMessageIdentity";
 import {
@@ -538,7 +538,7 @@ export function useDesktopSessionState({
         throw new Error(String(res.payload.message ?? "中止回复失败"));
       }
       if (isCurrentChatTurn(sessionKey, turnId)) {
-        updateCommittedActiveSession((current) => current?.key === sessionKey ? finishChatStream(current) : current);
+        updateCommittedActiveSession((current) => current?.key === sessionKey ? interruptChatStream(current) : current);
         completeChatTurn(sessionKey, turnId);
       }
       return true;

--- a/apps/desktop/renderer/src/app/useDesktopSessionState.ts
+++ b/apps/desktop/renderer/src/app/useDesktopSessionState.ts
@@ -1,5 +1,9 @@
 import { useEffect, useRef } from "react";
-import { interruptChatStream } from "../chat/chatStreamingState";
+import { finalizeChatCancellation } from "../chat/chatStreamingState";
+import {
+  isActiveChatTurn,
+  shouldSurfaceChatCancellationFailure,
+} from "../chat/chatTurnOwnership";
 import { buildOptimisticUserChatMessage, normalizeChatAttachmentPaths } from "../chat/chatComposerState";
 import { ensureChatMessageRenderId, reconcileSessionMessageRenderIds } from "../chat/chatMessageIdentity";
 import {
@@ -313,7 +317,7 @@ export function useDesktopSessionState({
   }
 
   function isCurrentChatTurn(sessionKey: string, turnId: string): boolean {
-    return Boolean(sessionKey && turnId && activeTurnIdsRef.current[sessionKey] === turnId);
+    return isActiveChatTurn(activeTurnIdsRef.current, sessionKey, turnId);
   }
 
   function isChatTurnCancelling(sessionKey: string, turnId: string): boolean {
@@ -538,13 +542,17 @@ export function useDesktopSessionState({
         throw new Error(String(res.payload.message ?? "中止回复失败"));
       }
       if (isCurrentChatTurn(sessionKey, turnId)) {
-        updateCommittedActiveSession((current) => current?.key === sessionKey ? interruptChatStream(current) : current);
+        updateCommittedActiveSession((current) => current?.key === sessionKey
+          ? finalizeChatCancellation(current, status as "interrupted" | "idle")
+          : current);
         completeChatTurn(sessionKey, turnId);
       }
       return true;
     } catch (error) {
-      clearSessionCancelling(sessionKey);
-      window.alert(error instanceof Error ? error.message : String(error));
+      if (shouldSurfaceChatCancellationFailure(activeTurnIdsRef.current, sessionKey, turnId)) {
+        clearSessionCancelling(sessionKey);
+        window.alert(error instanceof Error ? error.message : String(error));
+      }
       return false;
     }
   }

--- a/apps/desktop/renderer/src/chat/ChatComposer.test.tsx
+++ b/apps/desktop/renderer/src/chat/ChatComposer.test.tsx
@@ -6,15 +6,20 @@ import React from "react";
 import { renderToStaticMarkup } from "react-dom/server";
 import { ChatComposer } from "./ChatComposer";
 
-function renderChatComposer(): string {
+function renderChatComposer({
+  sending = false,
+  cancelling = false,
+}: { sending?: boolean; cancelling?: boolean } = {}): string {
   return renderToStaticMarkup(
     <ChatComposer
       activeRoleId="mira"
       sessionKey="role:mira"
       bridgeReady
-      sending={false}
+      sending={sending}
+      cancelling={cancelling}
       replyTarget={null}
       onSendMessage={async () => true}
+      onCancelChat={() => undefined}
       onClearReplyTarget={() => undefined}
       onJumpToMessage={() => undefined}
     />,
@@ -28,6 +33,19 @@ describe("ChatComposer", () => {
     assert.match(markup, /aria-label="添加附件"/);
     assert.match(markup, /aria-label="打开常用表情面板"/);
     assert.match(markup, /aria-label="发送消息"/);
+  });
+
+  it("replaces send with a stable stop action while a reply streams", () => {
+    const markup = renderChatComposer({ sending: true });
+
+    assert.match(markup, /aria-label="中止回复"/);
+    assert.doesNotMatch(markup, /aria-label="发送消息"/);
+  });
+
+  it("disables the stop action while cancellation is in progress", () => {
+    const markup = renderChatComposer({ sending: true, cancelling: true });
+
+    assert.match(markup, /aria-label="中止回复"[^>]*disabled=""/);
   });
 
   it("uses a contained text mirror instead of synchronous textarea measurement", () => {

--- a/apps/desktop/renderer/src/chat/ChatComposer.tsx
+++ b/apps/desktop/renderer/src/chat/ChatComposer.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useEffectEvent, useRef, useState } from "react";
+import { Stop } from "@phosphor-icons/react";
 import { ChatEmojiPicker } from "./ChatEmojiPicker";
 import { canSubmitChatMessage, normalizeChatAttachmentPaths } from "./chatComposerState";
 import { insertEmojiIntoChatDraft } from "./chatEmojiState";
@@ -14,8 +15,10 @@ type ChatComposerProps = {
   sessionKey: string;
   bridgeReady: boolean;
   sending: boolean;
+  cancelling: boolean;
   replyTarget: ChatReplyTarget | null;
   onSendMessage: (request: ChatSendRequest) => Promise<boolean>;
+  onCancelChat: () => void;
   onClearReplyTarget: () => void;
   onJumpToMessage: (messageKey: string) => void;
 };
@@ -39,8 +42,10 @@ export const ChatComposer = React.memo(function ChatComposer({
   sessionKey,
   bridgeReady,
   sending,
+  cancelling,
   replyTarget,
   onSendMessage,
+  onCancelChat,
   onClearReplyTarget,
   onJumpToMessage,
 }: ChatComposerProps) {
@@ -248,9 +253,21 @@ export const ChatComposer = React.memo(function ChatComposer({
               onSelectEmoji={handleSelectEmoji}
               onToggle={() => setEmojiPickerOpen((current) => !current)}
             />
-            <button className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-[#1f1f1f] p-0 text-white disabled:cursor-default disabled:opacity-40" type="button" aria-label="发送消息" onClick={() => void submitMessage()} disabled={!activeRoleId || !canSubmit || sending || !bridgeReady}>
-              <SendIcon className="h-[15px] w-[15px] fill-current" />
-            </button>
+            {sending ? (
+              <button
+                className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-[#1f1f1f] p-0 text-white disabled:cursor-default disabled:opacity-40"
+                type="button"
+                aria-label="中止回复"
+                onClick={onCancelChat}
+                disabled={cancelling}
+              >
+                <Stop className="h-[15px] w-[15px] fill-current" />
+              </button>
+            ) : (
+              <button className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-[#1f1f1f] p-0 text-white disabled:cursor-default disabled:opacity-40" type="button" aria-label="发送消息" onClick={() => void submitMessage()} disabled={!activeRoleId || !canSubmit || !bridgeReady}>
+                <SendIcon className="h-[15px] w-[15px] fill-current" />
+              </button>
+            )}
           </div>
         </div>
       </div>

--- a/apps/desktop/renderer/src/chat/ChatSurface.test.tsx
+++ b/apps/desktop/renderer/src/chat/ChatSurface.test.tsx
@@ -72,6 +72,7 @@ function renderChatSurface(
       highlightedMessageKey=""
       notice=""
       sending={false}
+      cancelling={false}
       visibleIllustrationUrl=""
       windowVisible={options.windowVisible ?? true}
       onBeginChatLatestImageSidebarResize={() => undefined}
@@ -84,6 +85,7 @@ function renderChatSurface(
       onBeginAttachmentDrag={() => undefined}
       onCopyMessage={() => undefined}
       onSendMessage={async () => true}
+      onCancelChat={() => undefined}
       onToggleChatLatestImageSidebar={() => undefined}
     />,
   );

--- a/apps/desktop/renderer/src/chat/ChatSurface.tsx
+++ b/apps/desktop/renderer/src/chat/ChatSurface.tsx
@@ -43,6 +43,7 @@ type ChatSurfaceProps = {
   highlightedMessageKey: string;
   notice: string;
   sending: boolean;
+  cancelling: boolean;
   visibleIllustrationUrl: string;
   windowVisible: boolean;
   onBeginChatLatestImageSidebarResize: (event: React.PointerEvent<HTMLDivElement>) => void;
@@ -55,6 +56,7 @@ type ChatSurfaceProps = {
   onBeginAttachmentDrag: (path: string) => void;
   onCopyMessage: (content: string) => void;
   onSendMessage: (request: ChatSendRequest) => Promise<boolean>;
+  onCancelChat: () => void;
   onToggleChatLatestImageSidebar: () => void;
 };
 
@@ -85,6 +87,7 @@ export function ChatSurface({
   highlightedMessageKey,
   notice,
   sending,
+  cancelling,
   visibleIllustrationUrl,
   windowVisible,
   onBeginChatLatestImageSidebarResize,
@@ -97,6 +100,7 @@ export function ChatSurface({
   onBeginAttachmentDrag,
   onCopyMessage,
   onSendMessage,
+  onCancelChat,
   onToggleChatLatestImageSidebar,
 }: ChatSurfaceProps) {
   const [visualsActive, setVisualsActive] = useState(() => (
@@ -502,8 +506,10 @@ export function ChatSurface({
           sessionKey={activeSession?.key ?? ""}
           bridgeReady={bridgeReady}
           sending={sending}
+          cancelling={cancelling}
           replyTarget={composerReplyTarget}
           onSendMessage={onSendMessage}
+          onCancelChat={onCancelChat}
           onClearReplyTarget={handleClearReplyTarget}
           onJumpToMessage={onJumpToMessage}
         />

--- a/apps/desktop/renderer/src/chat/chatSessionMerge.test.ts
+++ b/apps/desktop/renderer/src/chat/chatSessionMerge.test.ts
@@ -139,6 +139,105 @@ describe("mergeIncomingSessionDuringSend", () => {
     assert.equal(merged, incomingSession);
   });
 
+  it("keeps a cancelled local assistant trace before the newly persisted user turn", () => {
+    const pendingUserMessage: SessionMessage = {
+      role: "user",
+      content: "follow up",
+      metadata: { client_message_id: "desktop-message-follow-up" },
+    };
+    const interruptedAssistant: SessionMessage = {
+      role: "assistant",
+      content: "partial answer",
+      reasoning_content: "partial thinking",
+      metadata: { streamed_reply: true, interrupted_reply: true },
+      streaming: false,
+    };
+    const currentSession = createSession([
+      {
+        id: "role:mira:1",
+        role: "user",
+        content: "first message",
+      },
+      interruptedAssistant,
+      pendingUserMessage,
+    ]);
+    const incomingSession = createSession([
+      {
+        id: "role:mira:1",
+        role: "user",
+        content: "first message",
+      },
+      {
+        id: "role:mira:2",
+        role: "user",
+        content: "follow up",
+        metadata: { client_message_id: "desktop-message-follow-up" },
+      },
+    ]);
+
+    const merged = mergeIncomingSessionDuringSend(
+      currentSession,
+      incomingSession,
+      true,
+      pendingUserMessage,
+    );
+
+    assert.deepEqual(merged?.messages, [
+      incomingSession.messages[0],
+      interruptedAssistant,
+      incomingSession.messages[1],
+    ]);
+  });
+
+  it("preserves multiple cancelled traces in their original turn order", () => {
+    const pendingUserMessage: SessionMessage = {
+      role: "user",
+      content: "third turn",
+      metadata: { client_message_id: "desktop-message-third" },
+    };
+    const firstInterruptedAssistant: SessionMessage = {
+      role: "assistant",
+      content: "first partial answer",
+      reasoning_content: "first partial thinking",
+      metadata: { streamed_reply: true, interrupted_reply: true },
+      streaming: false,
+    };
+    const secondInterruptedAssistant: SessionMessage = {
+      role: "assistant",
+      content: "second partial answer",
+      reasoning_content: "second partial thinking",
+      metadata: { streamed_reply: true, interrupted_reply: true },
+      streaming: false,
+    };
+    const currentSession = createSession([
+      { id: "role:mira:1", role: "user", content: "first turn" },
+      firstInterruptedAssistant,
+      { id: "role:mira:2", role: "user", content: "second turn" },
+      secondInterruptedAssistant,
+      pendingUserMessage,
+    ]);
+    const incomingSession = createSession([
+      { id: "role:mira:1", role: "user", content: "first turn" },
+      { id: "role:mira:2", role: "user", content: "second turn" },
+      { id: "role:mira:4", role: "user", content: "third turn", metadata: { client_message_id: "desktop-message-third" } },
+    ]);
+
+    const merged = mergeIncomingSessionDuringSend(
+      currentSession,
+      incomingSession,
+      true,
+      pendingUserMessage,
+    );
+
+    assert.deepEqual(merged?.messages, [
+      incomingSession.messages[0],
+      firstInterruptedAssistant,
+      incomingSession.messages[1],
+      secondInterruptedAssistant,
+      incomingSession.messages[2],
+    ]);
+  });
+
   it("accepts divergent incoming snapshots instead of forcing the optimistic turn into unrelated history", () => {
     const currentSession = createSession([
       {

--- a/apps/desktop/renderer/src/chat/chatSessionMerge.ts
+++ b/apps/desktop/renderer/src/chat/chatSessionMerge.ts
@@ -9,6 +9,10 @@ function normalizeClientMessageId(message: SessionMessage): string {
   return String(message.metadata?.client_message_id ?? "").trim();
 }
 
+function isInterruptedAssistantMessage(message: SessionMessage): boolean {
+  return message.role === "assistant" && message.metadata?.interrupted_reply === true;
+}
+
 function normalizeReplyMetadata(message: SessionMessage) {
   return {
     messageId: String(message.metadata?.reply_to_message_id ?? "").trim(),
@@ -103,6 +107,94 @@ function findMissingOptimisticUserMessage(
     return areEquivalentMessagesIgnoringMissingIds(optimisticUserMessage, message);
   });
   return alreadyPersisted ? null : optimisticUserMessage;
+}
+
+function findIncomingMessageIndex(
+  message: SessionMessage,
+  incomingSession: SessionPayload,
+): number {
+  const clientMessageId = normalizeClientMessageId(message);
+  if (clientMessageId) {
+    return incomingSession.messages.findIndex((incomingMessage) => (
+      normalizeClientMessageId(incomingMessage) === clientMessageId
+    ));
+  }
+  return incomingSession.messages.findIndex((incomingMessage) => (
+    Boolean(normalizeMessageId(incomingMessage))
+      && areEquivalentMessagesIgnoringMissingIds(message, incomingMessage)
+  ));
+}
+
+function findAcknowledgedUserMessageIndex(
+  pendingUserMessage: SessionMessage,
+  incomingSession: SessionPayload,
+): number {
+  return findIncomingMessageIndex(pendingUserMessage, incomingSession);
+}
+
+function findNextIncomingMessageIndex(
+  currentMessages: SessionMessage[],
+  startIndex: number,
+  incomingSession: SessionPayload,
+): number {
+  for (let index = startIndex + 1; index < currentMessages.length; index += 1) {
+    const incomingIndex = findIncomingMessageIndex(currentMessages[index], incomingSession);
+    if (incomingIndex >= 0) return incomingIndex;
+  }
+  return -1;
+}
+
+function findCurrentPendingUserIndex(
+  currentSession: SessionPayload,
+  pendingUserMessage: SessionMessage,
+): number {
+  const clientMessageId = normalizeClientMessageId(pendingUserMessage);
+  if (clientMessageId) {
+    return currentSession.messages.findIndex((message) => (
+      normalizeClientMessageId(message) === clientMessageId
+    ));
+  }
+  return currentSession.messages.findIndex((message) => (
+    areEquivalentMessagesIgnoringMissingIds(pendingUserMessage, message)
+  ));
+}
+
+function preserveInterruptedAssistantTrace(
+  currentSession: SessionPayload,
+  incomingSession: SessionPayload,
+  pendingUserMessage: SessionMessage | null,
+): SessionPayload {
+  if (!pendingUserMessage || !isPendingUserMessageAcknowledged(pendingUserMessage, incomingSession)) {
+    return incomingSession;
+  }
+  const incomingUserIndex = findAcknowledgedUserMessageIndex(pendingUserMessage, incomingSession);
+  if (incomingUserIndex < 0) return incomingSession;
+  const currentUserIndex = findCurrentPendingUserIndex(currentSession, pendingUserMessage);
+  const interruptedMessagesByIncomingIndex = new Map<number, SessionMessage[]>();
+  currentSession.messages.forEach((message, index) => {
+    if (!isInterruptedAssistantMessage(message) || (currentUserIndex >= 0 && index >= currentUserIndex)) {
+      return;
+    }
+    if (findIncomingMessageIndex(message, incomingSession) >= 0) return;
+    const anchorIndex = findNextIncomingMessageIndex(currentSession.messages, index, incomingSession);
+    const targetIndex = anchorIndex >= 0 ? anchorIndex : incomingUserIndex;
+    const anchoredMessages = interruptedMessagesByIncomingIndex.get(targetIndex) ?? [];
+    anchoredMessages.push(message);
+    interruptedMessagesByIncomingIndex.set(targetIndex, anchoredMessages);
+  });
+  const interruptedMessages = [...interruptedMessagesByIncomingIndex.values()].flat();
+  if (interruptedMessages.length === 0) return incomingSession;
+  return {
+    ...incomingSession,
+    metadata: {
+      ...(currentSession.metadata ?? {}),
+      ...(incomingSession.metadata ?? {}),
+    },
+    messages: incomingSession.messages.flatMap((message, index) => [
+      ...(interruptedMessagesByIncomingIndex.get(index) ?? []),
+      message,
+    ]),
+  };
 }
 
 /** Returns whether an authoritative session contains the persisted form of one pending user message. */
@@ -207,6 +299,15 @@ export function mergeIncomingSessionDuringSend(
     optimisticUserMessage,
     incomingSession,
   );
+
+  const incomingWithInterruptedTrace = preserveInterruptedAssistantTrace(
+    currentSession,
+    incomingSession,
+    pendingUserMessage,
+  );
+  if (incomingWithInterruptedTrace !== incomingSession) {
+    return incomingWithInterruptedTrace;
+  }
 
   if (!sending && !missingOptimisticUserMessage) {
     return incomingSession;

--- a/apps/desktop/renderer/src/chat/chatStreamingState.test.ts
+++ b/apps/desktop/renderer/src/chat/chatStreamingState.test.ts
@@ -7,6 +7,7 @@ import {
   applyChatStreamDelta,
   applyChatToolCompleted,
   applyChatToolStarted,
+  finalizeChatCancellation,
   finishChatStream,
   interruptChatStream,
 } from "./chatStreamingState";
@@ -65,6 +66,22 @@ describe("chat streaming state", () => {
     });
     assert.equal(interrupted.messages.at(-1)?.reasoning_content, "partial thinking");
     assert.equal(interrupted.messages.at(-1)?.render_id, streaming.messages.at(-1)?.render_id);
+  });
+
+  it("keeps a naturally completed reply distinct when cancellation reports idle", () => {
+    const streaming = applyChatStreamDelta(session(), "complete answer", "complete thinking");
+    const completed = finalizeChatCancellation(streaming, "idle");
+
+    assert.equal(completed.messages.at(-1)?.streaming, false);
+    assert.equal(completed.messages.at(-1)?.metadata?.streamed_reply, true);
+    assert.equal(completed.messages.at(-1)?.metadata?.interrupted_reply, undefined);
+  });
+
+  it("marks the reply interrupted only when cancellation interrupted the active turn", () => {
+    const streaming = applyChatStreamDelta(session(), "partial answer", "partial thinking");
+    const interrupted = finalizeChatCancellation(streaming, "interrupted");
+
+    assert.equal(interrupted.messages.at(-1)?.metadata?.interrupted_reply, true);
   });
 
   it("does not alter an already finished or non-assistant session", () => {

--- a/apps/desktop/renderer/src/chat/chatStreamingState.test.ts
+++ b/apps/desktop/renderer/src/chat/chatStreamingState.test.ts
@@ -8,6 +8,7 @@ import {
   applyChatToolCompleted,
   applyChatToolStarted,
   finishChatStream,
+  interruptChatStream,
 } from "./chatStreamingState";
 
 function session(): SessionPayload {
@@ -51,6 +52,28 @@ describe("chat streaming state", () => {
       thinking_duration_ms: 6200,
     });
     assert.equal(finished.messages.at(-1)?.render_id, streaming.messages.at(-1)?.render_id);
+  });
+
+  it("marks a cancelled transient assistant reply for local trace preservation", () => {
+    const streaming = applyChatStreamDelta(session(), "partial answer", "partial thinking");
+    const interrupted = interruptChatStream(streaming);
+
+    assert.equal(interrupted.messages.at(-1)?.streaming, false);
+    assert.deepEqual(interrupted.messages.at(-1)?.metadata, {
+      streamed_reply: true,
+      interrupted_reply: true,
+    });
+    assert.equal(interrupted.messages.at(-1)?.reasoning_content, "partial thinking");
+    assert.equal(interrupted.messages.at(-1)?.render_id, streaming.messages.at(-1)?.render_id);
+  });
+
+  it("does not alter an already finished or non-assistant session", () => {
+    const original = session();
+    assert.equal(interruptChatStream(original), original);
+    const finished = finishChatStream(
+      applyChatStreamDelta(original, "complete", "thinking"),
+    );
+    assert.equal(interruptChatStream(finished), finished);
   });
 
   it("merges tool lifecycle events by call id into the transient assistant message", () => {

--- a/apps/desktop/renderer/src/chat/chatStreamingState.ts
+++ b/apps/desktop/renderer/src/chat/chatStreamingState.ts
@@ -74,6 +74,14 @@ export function interruptChatStream(session: SessionPayload): SessionPayload {
   return { ...session, messages };
 }
 
+/** Finishes cancellation according to the backend's final turn state. */
+export function finalizeChatCancellation(
+  session: SessionPayload,
+  status: "interrupted" | "idle",
+): SessionPayload {
+  return status === "interrupted" ? interruptChatStream(session) : finishChatStream(session);
+}
+
 type ToolStartedEvent = {
   iteration: number;
   callId: string;

--- a/apps/desktop/renderer/src/chat/chatStreamingState.ts
+++ b/apps/desktop/renderer/src/chat/chatStreamingState.ts
@@ -56,6 +56,24 @@ export function finishChatStream(
   return { ...session, messages };
 }
 
+/** Marks a cancelled transient assistant reply complete while retaining its local trace for the next turn. */
+export function interruptChatStream(session: SessionPayload): SessionPayload {
+  const lastIndex = session.messages.length - 1;
+  const last = session.messages[lastIndex];
+  if (!last || last.role !== "assistant" || !last.streaming) return session;
+  const messages = [...session.messages];
+  messages[lastIndex] = {
+    ...last,
+    streaming: false,
+    metadata: {
+      ...last.metadata,
+      streamed_reply: true,
+      interrupted_reply: true,
+    },
+  };
+  return { ...session, messages };
+}
+
 type ToolStartedEvent = {
   iteration: number;
   callId: string;

--- a/apps/desktop/renderer/src/chat/chatTurnOwnership.test.ts
+++ b/apps/desktop/renderer/src/chat/chatTurnOwnership.test.ts
@@ -1,0 +1,32 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import {
+  isActiveChatTurn,
+  shouldSurfaceChatCancellationFailure,
+} from "./chatTurnOwnership";
+
+describe("chat turn ownership", () => {
+  it("rejects a late event from a cancelled turn after the session starts a replacement turn", () => {
+    const activeTurns = { "role:mira": "turn-b" };
+
+    assert.equal(isActiveChatTurn(activeTurns, "role:mira", "turn-a"), false);
+    assert.equal(isActiveChatTurn(activeTurns, "role:mira", "turn-b"), true);
+  });
+
+  it("requires both the session key and turn id to match", () => {
+    const activeTurns = { "role:mira": "turn-a" };
+
+    assert.equal(isActiveChatTurn(activeTurns, "role:other", "turn-a"), false);
+    assert.equal(isActiveChatTurn(activeTurns, "role:mira", ""), false);
+  });
+
+  it("does not surface a stale cancellation failure after the turn has already completed", () => {
+    assert.equal(shouldSurfaceChatCancellationFailure({}, "role:mira", "turn-a"), false);
+    assert.equal(
+      shouldSurfaceChatCancellationFailure({ "role:mira": "turn-a" }, "role:mira", "turn-a"),
+      true,
+    );
+  });
+});

--- a/apps/desktop/renderer/src/chat/chatTurnOwnership.ts
+++ b/apps/desktop/renderer/src/chat/chatTurnOwnership.ts
@@ -1,0 +1,20 @@
+/** Active renderer turn identities keyed by the session that owns them. */
+export type ActiveChatTurns = Readonly<Record<string, string>>;
+
+/** Returns whether a bridge event still belongs to the active renderer turn. */
+export function isActiveChatTurn(
+  activeTurns: ActiveChatTurns,
+  sessionKey: string,
+  turnId: string,
+): boolean {
+  return Boolean(sessionKey && turnId && activeTurns[sessionKey] === turnId);
+}
+
+/** Prevents an older cancellation request from surfacing after its turn has ended. */
+export function shouldSurfaceChatCancellationFailure(
+  activeTurns: ActiveChatTurns,
+  sessionKey: string,
+  turnId: string,
+): boolean {
+  return isActiveChatTurn(activeTurns, sessionKey, turnId);
+}

--- a/apps/desktop/renderer/src/main.tsx
+++ b/apps/desktop/renderer/src/main.tsx
@@ -88,6 +88,7 @@ function App(): React.ReactElement {
   const [deletingRole, setDeletingRole] = useState(false);
   // Track in-flight chat turns by session so role switches don't leak typing state into other chats.
   const [sendingSessions, setSendingSessions] = useState<Record<string, string>>({});
+  const [cancellingSessions, setCancellingSessions] = useState<Record<string, string>>({});
   const [pendingRoleCardAction, setPendingRoleCardAction] = useState<PendingRoleCardAction>(null);
   const [showSearchDialog, setShowSearchDialog] = useState(false);
   const [pendingDeleteRoleId, setPendingDeleteRoleId] = useState("");
@@ -138,6 +139,7 @@ function App(): React.ReactElement {
   const mainViewRef = useLatestRef<AppMainView>(mainView);
   const rolesRef = useLatestRef(roles);
   const sendingSessionsRef = useLatestRef(sendingSessions);
+  const cancellingSessionsRef = useLatestRef(cancellingSessions);
   const unreadCountsRef = useLatestRef(unreadCounts);
   const roleFormRef = useLatestRef(roleForm);
   const lastNonSettingsViewRef = useDesktopViewSynchronization({
@@ -228,6 +230,10 @@ function App(): React.ReactElement {
     refreshSession,
     clearAllSendingSessions,
     clearSessionSending,
+    cancelChatTurn,
+    completeChatTurn,
+    isCurrentChatTurn,
+    isChatTurnCancelling,
     appendSessionErrorMessage,
     openRole,
     sendMessage,
@@ -244,6 +250,7 @@ function App(): React.ReactElement {
     setSelectedChatBackground,
     setActiveIllustration,
     setSendingSessions,
+    setCancellingSessions,
     chooseIllustration,
     applyRoleSnapshot,
     buildNavigationEntry,
@@ -255,6 +262,7 @@ function App(): React.ReactElement {
     mainViewRef,
     rolesRef,
     sendingSessionsRef,
+    cancellingSessionsRef,
     unreadCountsRef,
     openRoleRequestIdRef,
   });
@@ -278,6 +286,9 @@ function App(): React.ReactElement {
     cacheRoleSession,
     clearAllSendingSessions,
     clearSessionSending,
+    completeChatTurn,
+    isCurrentChatTurn,
+    isChatTurnCancelling,
     commitActiveSession,
     updateCommittedActiveSession,
     appendSessionErrorMessage,
@@ -316,6 +327,7 @@ function App(): React.ReactElement {
     chatBackgroundUrl,
     activeSessionKey,
     isVisibleChatSending,
+    isVisibleChatCancelling,
     headerTitle,
     chatImageHistory,
     resolvedChatImagePath,
@@ -333,6 +345,7 @@ function App(): React.ReactElement {
     selectedChatImageKey,
     health,
     sendingSessions,
+    cancellingSessions,
   });
 
   const {
@@ -560,6 +573,7 @@ function App(): React.ReactElement {
       highlightedMessageKey={highlightedMessageKey}
       notice={notice}
       isVisibleChatSending={isVisibleChatSending}
+      isVisibleChatCancelling={isVisibleChatCancelling}
       visibleIllustrationUrl={visibleIllustrationUrl}
       windowVisible={windowVisible}
       onGoToNextChatImage={selectNextChatImage}
@@ -571,6 +585,7 @@ function App(): React.ReactElement {
       onBeginAttachmentDrag={beginAttachmentDrag}
       onCopyMessage={(content) => void copyChatMessage(content)}
       onSendMessage={sendMessage}
+      onCancelChat={() => void cancelChatTurn(activeSessionKey, activeRoleId)}
       imageHistorySidebar={imageHistorySidebar}
       detailRole={detailRole}
       pendingRoleCardAction={pendingRoleCardAction}

--- a/tests/backend/agent/core/test_turn_pipelines.py
+++ b/tests/backend/agent/core/test_turn_pipelines.py
@@ -424,6 +424,37 @@ async def test_resumed_interrupt_state_completes_normally(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_desktop_interrupt_state_is_not_spliced_into_follow_up_message(tmp_path: Path):
+    loop = _make_loop(tmp_path)
+    session_key = "role:mira"
+    loop._interrupt_states[session_key] = TurnInterruptState(  # type: ignore[attr-defined]
+        session_key=session_key,
+        original_user_message="原始消息 A",
+        partial_reply="半截回答",
+    )
+    captured = {}
+
+    async def _process(msg, *_args, **_kwargs):
+        captured["msg"] = msg
+        return MagicMock(content="ok")
+
+    loop._core_runner.process = _process  # type: ignore[attr-defined]
+
+    msg = InboundMessage(
+        channel="desktop",
+        sender="user",
+        chat_id="role:mira",
+        content="补充 B",
+    )
+    outbound = await loop._process(msg)
+
+    assert outbound.content == "ok"
+    assert captured["msg"].content == "补充 B"
+    assert captured["msg"].metadata == {}
+    assert session_key in loop._interrupt_states  # persisted by desktop bridge
+
+
+@pytest.mark.asyncio
 async def test_agent_loop_afterstep_fires_with_turn_lifecycle_wiring(tmp_path: Path):
     RoleStore(tmp_path).create_role(role_id="mira", name="Mira", system_prompt="test")
     loop = _make_loop(tmp_path)

--- a/tests/backend/agent/test_context.py
+++ b/tests/backend/agent/test_context.py
@@ -1,0 +1,73 @@
+from pathlib import Path
+
+import pytest
+
+from agent.context import ContextBuilder, ContextRequest
+from core.roles import RoleStore
+from session.manager.models import INTERRUPTED_TURN_METADATA_KEY
+
+
+def test_context_builder_injects_interrupted_turn_as_separate_frame(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    class _Skills:
+        def __init__(self, workspace: Path) -> None:
+            self.workspace = workspace
+
+        def get_always_skills(self) -> list[str]:
+            return []
+
+        def load_skills_for_context(self, names: list[str]) -> str:
+            return ""
+
+        def build_skills_summary(self) -> str:
+            return ""
+
+    class _Memory:
+        def read_profile(self) -> str:
+            return ""
+
+        def read_self(self) -> str:
+            return ""
+
+        def read_recent_context(self) -> str:
+            return ""
+
+        def get_memory_context(self) -> str:
+            return ""
+
+    monkeypatch.setattr("agent.context.SkillsLoader", _Skills)
+    monkeypatch.setattr(
+        "agent.context.build_agent_static_identity_prompt", lambda **_: "identity"
+    )
+    monkeypatch.setattr(
+        "agent.context.build_skills_catalog_prompt", lambda text: text
+    )
+    RoleStore(tmp_path).create_role(
+        role_id="mira",
+        name="Mira",
+        system_prompt="test role",
+    )
+    builder = ContextBuilder(tmp_path, _Memory())  # type: ignore[arg-type]
+    result = builder.render(
+        ContextRequest(
+            history=[
+                {
+                    "role": "assistant",
+                    "content": "partial",
+                    "reasoning_content": "retain-cot",
+                }
+            ],
+            current_message="继续",
+        ),
+        session_metadata={
+            "role_id": "mira",
+            INTERRUPTED_TURN_METADATA_KEY: {"turn_id": "turn-1"},
+        },
+    )
+
+    frame = result.messages[-2]
+    assert frame["role"] == "user"
+    assert "上一轮助手回复因用户主动中断而未完成" in frame["content"]
+    assert result.messages[-3]["reasoning_content"] == "retain-cot"
+    assert "interrupted" not in result.messages[-3].get("content", "")

--- a/tests/backend/desktop_bridge/test_chat_service.py
+++ b/tests/backend/desktop_bridge/test_chat_service.py
@@ -270,9 +270,9 @@ async def test_cancel_chat_turn_interrupts_only_the_matching_session_and_turn() 
     started = asyncio.Event()
     interrupt = Mock(
         return_value=SimpleNamespace(
-            status="idle",
+            status="interrupted",
             session_key="role:role-1",
-            message="not registered yet",
+            message="cancelled",
         )
     )
 
@@ -326,8 +326,10 @@ async def test_cancel_chat_turn_interrupts_only_the_matching_session_and_turn() 
 
 
 @pytest.mark.asyncio
-async def test_cancel_chat_turn_releases_the_session_for_an_immediate_follow_up() -> None:
+async def test_cancel_chat_turn_waits_for_old_listener_cleanup_before_follow_up() -> None:
     started = asyncio.Event()
+    cleanup_started = asyncio.Event()
+    release_cleanup = asyncio.Event()
     calls = 0
 
     async def _process_direct(*_args, **_kwargs) -> None:
@@ -335,7 +337,11 @@ async def test_cancel_chat_turn_releases_the_session_for_an_immediate_follow_up(
         calls += 1
         if calls == 1:
             started.set()
-            await asyncio.Event().wait()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                cleanup_started.set()
+                await release_cleanup.wait()
 
     service = DesktopChatService(
         agent_loop=SimpleNamespace(
@@ -364,7 +370,21 @@ async def test_cancel_chat_turn_releases_the_session_for_an_immediate_follow_up(
     service.start_chat_turn(**arguments)
     await started.wait()
 
-    result = service.cancel_chat_turn("role:role-1", "turn-1")
+    cancel_task = asyncio.create_task(
+        service.cancel_chat_turn_async("role:role-1", "turn-1")
+    )
+    await cleanup_started.wait()
+
+    with pytest.raises(ChatTurnBusyError):
+        service.start_chat_turn(**{
+            **arguments,
+            "request_id": "request-2",
+            "turn_id": "turn-2",
+            "content": "follow up",
+        })
+
+    release_cleanup.set()
+    result = await cancel_task
 
     assert result.status == "interrupted"
     service.start_chat_turn(**{
@@ -375,6 +395,65 @@ async def test_cancel_chat_turn_releases_the_session_for_an_immediate_follow_up(
     })
     await asyncio.sleep(0)
     assert calls == 2
+    await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_chat_turn_keeps_naturally_completed_turn_when_interrupt_is_idle() -> None:
+    process_completed = asyncio.Event()
+    session_update_started = asyncio.Event()
+    session_update_completed = asyncio.Event()
+    release_session_update = asyncio.Event()
+
+    async def _process_direct(*_args, **_kwargs) -> None:
+        process_completed.set()
+
+    async def _emit_session_updated(**_kwargs) -> None:
+        session_update_started.set()
+        await release_session_update.wait()
+        session_update_completed.set()
+
+    service = DesktopChatService(
+        agent_loop=SimpleNamespace(
+            process_direct=_process_direct,
+            request_interrupt=Mock(
+                return_value=SimpleNamespace(
+                    status="idle",
+                    message="turn already completed",
+                )
+            ),
+        ),
+        event_bus=EventBus(),
+        session_manager=SimpleNamespace(get_or_create=Mock()),
+        role_id_from_session_key=Mock(return_value="role-1"),
+        sync_desktop_session_thread=Mock(),
+        emit_payload=AsyncMock(),
+        emit_session_updated=_emit_session_updated,
+    )
+    service.start_chat_turn(
+        request_id="request-1",
+        turn_id="turn-1",
+        session_key="role:role-1",
+        content="hello",
+        media=[],
+        metadata={},
+        omit_user_turn=True,
+        emit_event=AsyncMock(),
+    )
+    await process_completed.wait()
+    await session_update_started.wait()
+
+    cancel_task = asyncio.create_task(
+        service.cancel_chat_turn_async("role:role-1", "turn-1")
+    )
+    await asyncio.sleep(0)
+
+    assert cancel_task.done() is False
+    release_session_update.set()
+    result = await cancel_task
+
+    assert result.status == "idle"
+    assert session_update_completed.is_set()
     await service.aclose()
 
 

--- a/tests/backend/desktop_bridge/test_chat_service.py
+++ b/tests/backend/desktop_bridge/test_chat_service.py
@@ -15,6 +15,9 @@ from bus.events_lifecycle import (
 )
 from desktop_bridge.chat_service import ChatTurnBusyError, DesktopChatService
 from desktop_bridge.voice.voice_service import VoiceOperationMetrics, VoiceSynthesisResult
+from agent.looping.interrupt import TurnInterruptState
+from session.manager import Session
+from session.manager.models import INTERRUPTED_TURN_METADATA_KEY
 
 
 class _VoiceService:
@@ -427,6 +430,83 @@ async def test_cancel_chat_turn_stops_the_associated_voice_tts_coordinator() -> 
     assert result.status == "interrupted"
     coordinator.cancel.assert_called_once_with()
     await asyncio.sleep(0)
+    await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_chat_turn_persists_partial_reply_and_reasoning() -> None:
+    started = asyncio.Event()
+    session = Session("role:role-1")
+    interrupt_state = TurnInterruptState(
+        session_key=session.key,
+        original_user_message="hello",
+        partial_reply="partial answer",
+        partial_thinking="retain this reasoning",
+        tools_used=["web_search"],
+        tool_chain_partial=[
+            {
+                "text": "",
+                "calls": [
+                    {
+                        "call_id": "call-1",
+                        "name": "web_search",
+                        "arguments": {"query": "weather"},
+                        "result": "sunny",
+                    }
+                ],
+            }
+        ],
+    )
+
+    async def _process_direct(*_args, **_kwargs) -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    session_manager = SimpleNamespace(
+        get_or_create=Mock(return_value=session),
+        append_messages=AsyncMock(),
+    )
+    service = DesktopChatService(
+        agent_loop=SimpleNamespace(
+            process_direct=_process_direct,
+            request_interrupt=Mock(
+                return_value=SimpleNamespace(
+                    status="interrupted",
+                    message="cancelled",
+                    state=interrupt_state,
+                )
+            ),
+            discard_interrupt_state=Mock(),
+        ),
+        event_bus=EventBus(),
+        session_manager=session_manager,
+        role_id_from_session_key=Mock(return_value="role-1"),
+        sync_desktop_session_thread=Mock(),
+        emit_payload=AsyncMock(),
+        emit_session_updated=AsyncMock(),
+    )
+    service.start_chat_turn(
+        request_id="request-1",
+        turn_id="turn-1",
+        session_key=session.key,
+        content="hello",
+        media=[],
+        metadata={},
+        omit_user_turn=True,
+        emit_event=AsyncMock(),
+    )
+    await started.wait()
+
+    result = await service.cancel_chat_turn_async(session.key, "turn-1")
+
+    assert result.status == "interrupted"
+    assistant = session.messages[-1]
+    assert assistant["role"] == "assistant"
+    assert assistant["content"] == "partial answer"
+    assert assistant["reasoning_content"] == "retain this reasoning"
+    assert assistant["metadata"]["interrupted_reply"] is True
+    assert session.metadata[INTERRUPTED_TURN_METADATA_KEY]["turn_id"] == "turn-1"
+    session_manager.append_messages.assert_awaited_once_with(session, [assistant])
     await service.aclose()
 
 

--- a/tests/backend/desktop_bridge/test_chat_service.py
+++ b/tests/backend/desktop_bridge/test_chat_service.py
@@ -117,6 +117,7 @@ async def test_chat_service_bridges_tool_call_lifecycle_for_current_session() ->
     ]
     assert tool_events[0]["payload"] == {
         "session_key": "role:role-1",
+        "turn_id": "request-tools",
         "iteration": 1,
         "call_id": "call-1",
         "tool_name": "web_search",
@@ -259,6 +260,174 @@ async def test_chat_service_allows_only_one_turn_per_session() -> None:
 
     await service.aclose()
     assert service.is_busy("role:role-1") is False
+
+
+@pytest.mark.asyncio
+async def test_cancel_chat_turn_interrupts_only_the_matching_session_and_turn() -> None:
+    started = asyncio.Event()
+    interrupt = Mock(
+        return_value=SimpleNamespace(
+            status="idle",
+            session_key="role:role-1",
+            message="not registered yet",
+        )
+    )
+
+    async def _process_direct(*_args, **_kwargs) -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    service = DesktopChatService(
+        agent_loop=SimpleNamespace(
+            process_direct=_process_direct,
+            request_interrupt=interrupt,
+        ),
+        event_bus=EventBus(),
+        session_manager=SimpleNamespace(get_or_create=Mock()),
+        role_id_from_session_key=Mock(return_value="role-1"),
+        sync_desktop_session_thread=Mock(),
+        emit_payload=AsyncMock(),
+        emit_session_updated=AsyncMock(),
+    )
+    service.start_chat_turn(
+        request_id="request-1",
+        turn_id="turn-current",
+        session_key="role:role-1",
+        content="hello",
+        media=[],
+        metadata={},
+        omit_user_turn=True,
+        emit_event=AsyncMock(),
+    )
+    await started.wait()
+
+    wrong_session = service.cancel_chat_turn("role:other", "turn-current")
+    wrong_turn = service.cancel_chat_turn("role:role-1", "turn-old")
+
+    assert wrong_session.status == "idle"
+    assert wrong_turn.status == "mismatch"
+    assert service.is_busy("role:role-1") is True
+    interrupt.assert_not_called()
+
+    result = service.cancel_chat_turn("role:role-1", "turn-current")
+
+    assert result.status == "interrupted"
+    interrupt.assert_called_once_with(
+        "role:role-1",
+        sender="desktop",
+        command="/cancel",
+    )
+    await asyncio.sleep(0)
+    assert service.is_busy("role:role-1") is False
+    await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_chat_turn_releases_the_session_for_an_immediate_follow_up() -> None:
+    started = asyncio.Event()
+    calls = 0
+
+    async def _process_direct(*_args, **_kwargs) -> None:
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            started.set()
+            await asyncio.Event().wait()
+
+    service = DesktopChatService(
+        agent_loop=SimpleNamespace(
+            process_direct=_process_direct,
+            request_interrupt=Mock(
+                return_value=SimpleNamespace(status="interrupted", message="cancelled")
+            ),
+        ),
+        event_bus=EventBus(),
+        session_manager=SimpleNamespace(get_or_create=Mock()),
+        role_id_from_session_key=Mock(return_value="role-1"),
+        sync_desktop_session_thread=Mock(),
+        emit_payload=AsyncMock(),
+        emit_session_updated=AsyncMock(),
+    )
+    arguments = {
+        "request_id": "request-1",
+        "turn_id": "turn-1",
+        "session_key": "role:role-1",
+        "content": "first",
+        "media": [],
+        "metadata": {},
+        "omit_user_turn": True,
+        "emit_event": AsyncMock(),
+    }
+    service.start_chat_turn(**arguments)
+    await started.wait()
+
+    result = service.cancel_chat_turn("role:role-1", "turn-1")
+
+    assert result.status == "interrupted"
+    service.start_chat_turn(**{
+        **arguments,
+        "request_id": "request-2",
+        "turn_id": "turn-2",
+        "content": "follow up",
+    })
+    await asyncio.sleep(0)
+    assert calls == 2
+    await service.aclose()
+
+
+@pytest.mark.asyncio
+async def test_cancel_chat_turn_stops_the_associated_voice_tts_coordinator() -> None:
+    started = asyncio.Event()
+
+    async def _process_direct(*_args, **_kwargs) -> None:
+        started.set()
+        await asyncio.Event().wait()
+
+    service = DesktopChatService(
+        agent_loop=SimpleNamespace(
+            process_direct=_process_direct,
+            request_interrupt=Mock(
+                return_value=SimpleNamespace(status="interrupted", message="cancelled")
+            ),
+        ),
+        event_bus=EventBus(),
+        session_manager=SimpleNamespace(
+            get_or_create=Mock(
+                return_value=SimpleNamespace(
+                    metadata={"role_runtime_config": {"tts": {"voice_id": "mira"}}}
+                )
+            )
+        ),
+        role_id_from_session_key=Mock(return_value="role-1"),
+        sync_desktop_session_thread=Mock(),
+        emit_payload=AsyncMock(),
+        emit_session_updated=AsyncMock(),
+        tts_service=SimpleNamespace(
+            tts_enabled=True,
+            tts_provider="minimax",
+            stream_synthesize_result=Mock(),
+        ),
+    )
+    service.start_chat_turn(
+        request_id="request-voice-1",
+        turn_id="turn-voice",
+        session_key="role:role-1",
+        content="hello",
+        media=[],
+        metadata={"input_method": "voice", "voice_turn_id": "voice-turn-1"},
+        omit_user_turn=True,
+        emit_event=AsyncMock(),
+    )
+    await started.wait()
+    coordinator = Mock()
+    service._tts_coordinators["voice-turn-1"] = coordinator
+
+    result = service.cancel_chat_turn("role:role-1", "turn-voice")
+
+    assert result.status == "interrupted"
+    coordinator.cancel.assert_called_once_with()
+    await asyncio.sleep(0)
+    await service.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/backend/desktop_bridge/test_chat_service_integration.py
+++ b/tests/backend/desktop_bridge/test_chat_service_integration.py
@@ -55,9 +55,10 @@ async def test_desktop_chat_service_emits_chat_error_event(tmp_path):
             "id": "1",
             "type": "event",
             "method": "chat.error",
-            "payload": {
-                "session_key": "role:mira",
-                "message": "boom",
-            },
+                "payload": {
+                    "session_key": "role:mira",
+                    "turn_id": "1",
+                    "message": "boom",
+                },
         }
     ]

--- a/tests/backend/desktop_bridge/test_chat_service_integration.py
+++ b/tests/backend/desktop_bridge/test_chat_service_integration.py
@@ -1,10 +1,16 @@
 from __future__ import annotations
 
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
 import pytest
 
+from agent.looping.interrupt import TurnInterruptState
 from bus.event_bus import EventBus
 from desktop_bridge.chat_service import DesktopChatService
 from session.manager import SessionManager
+from session.manager.models import INTERRUPTED_TURN_METADATA_KEY
 
 
 @pytest.mark.asyncio
@@ -62,3 +68,67 @@ async def test_desktop_chat_service_emits_chat_error_event(tmp_path):
                 },
         }
     ]
+
+
+@pytest.mark.asyncio
+async def test_cancelled_reply_survives_session_manager_reload(tmp_path):
+    session_manager = SessionManager(tmp_path)
+    session_key = "role:mira"
+    _ = session_manager.get_or_create(session_key)
+    started = asyncio.Event()
+    state = TurnInterruptState(
+        session_key=session_key,
+        original_user_message="hello",
+        partial_reply="partial answer",
+        partial_thinking="retain this reasoning",
+        tools_used=["web_search"],
+        tool_chain_partial=[{"text": "", "calls": [{"name": "web_search"}]}],
+    )
+
+    async def _process_direct(*_args, **_kwargs):
+        started.set()
+        await asyncio.Event().wait()
+
+    service = DesktopChatService(
+        agent_loop=SimpleNamespace(
+            process_direct=_process_direct,
+            request_interrupt=Mock(
+                return_value=SimpleNamespace(
+                    status="interrupted",
+                    message="cancelled",
+                    state=state,
+                )
+            ),
+            discard_interrupt_state=Mock(),
+        ),
+        event_bus=EventBus(),
+        session_manager=session_manager,
+        role_id_from_session_key=lambda _key: "mira",
+        sync_desktop_session_thread=lambda _session, *, role_id: None,
+        emit_payload=lambda _emit, _payload: asyncio.sleep(0),
+        emit_session_updated=lambda **_kwargs: asyncio.sleep(0),
+    )
+    service.start_chat_turn(
+        request_id="request-1",
+        turn_id="turn-1",
+        session_key=session_key,
+        content="hello",
+        media=[],
+        metadata={},
+        omit_user_turn=True,
+        emit_event=lambda _payload: None,
+    )
+    await started.wait()
+
+    result = await service.cancel_chat_turn_async(session_key, "turn-1")
+
+    assert result.status == "interrupted"
+    reloaded = SessionManager(tmp_path).get_or_create(session_key)
+    assert reloaded.metadata[INTERRUPTED_TURN_METADATA_KEY]["turn_id"] == "turn-1"
+    assistant = reloaded.messages[-1]
+    assert assistant["content"] == "partial answer"
+    assert assistant["reasoning_content"] == "retain this reasoning"
+    assert assistant["tool_chain"] == state.tool_chain_partial
+    assert assistant["metadata"]["interrupted_reply"] is True
+
+    await service.aclose()

--- a/tests/backend/desktop_bridge/test_integration.py
+++ b/tests/backend/desktop_bridge/test_integration.py
@@ -235,6 +235,7 @@ async def test_desktop_bridge_chat_send_merges_reply_context_for_agent(tmp_path:
     assert seen["metadata"] == {
         "request_id": "1",
         "delivery_key": "1",
+        "turn_id": "1",
         "reply_to_message_id": "message-1",
         "reply_to_sender": "Mira",
         "reply_to_content": "她沉默了很久。",
@@ -1391,8 +1392,14 @@ async def test_desktop_bridge_chat_cancel_uses_interrupt_controller(tmp_path: Pa
         system_prompt="you are mira",
     )
     session_manager = SessionManager(tmp_path)
+    started = asyncio.Event()
+
+    async def _process_direct(*_args, **_kwargs) -> None:
+        started.set()
+        await asyncio.Event().wait()
+
     loop = SimpleNamespace(
-        process_direct=AsyncMock(),
+        process_direct=_process_direct,
         request_interrupt=lambda session_key, sender="", command="/stop": SimpleNamespace(
             status="interrupted",
             session_key=session_key,
@@ -1407,11 +1414,26 @@ async def test_desktop_bridge_chat_cancel_uses_interrupt_controller(tmp_path: Pa
         event_bus=EventBus(),
     )
 
-    response = await service.handle(
+    sent = await service.handle(
         {
             "id": "1",
+            "method": "chat.send",
+            "payload": {
+                "role_id": role.id,
+                "content": "please wait",
+                "turn_id": "turn-cancel",
+            },
+        },
+        emit_event=lambda payload: None,
+    )
+    assert sent.error is None
+    await started.wait()
+
+    response = await service.handle(
+        {
+            "id": "2",
             "method": "chat.cancel",
-            "payload": {"role_id": role.id},
+            "payload": {"session_key": "role:mira", "turn_id": "turn-cancel"},
         },
         emit_event=lambda payload: None,
     )
@@ -1419,6 +1441,8 @@ async def test_desktop_bridge_chat_cancel_uses_interrupt_controller(tmp_path: Pa
     assert response.error is None
     assert response.payload["status"] == "interrupted"
     assert response.payload["session_key"] == "role:mira"
+    assert response.payload["turn_id"] == "turn-cancel"
+    await service.aclose()
 
 
 @pytest.mark.asyncio

--- a/tests/backend/test_support_modules.py
+++ b/tests/backend/test_support_modules.py
@@ -11,6 +11,7 @@ import pytest
 
 from agent.context import ContextBuilder, ContextRequest
 from agent.prompting import SYSTEM_CONTEXT_FRAME_MARKER
+from session.manager.models import INTERRUPTED_TURN_METADATA_KEY
 from agent.tools.base import Tool
 from agent.tools.memorize import MemorizeTool
 from agent.tools.message_push import MessagePushTool
@@ -713,6 +714,72 @@ def test_context_builder_builds_prompt_messages_and_assistant_blocks(
     role_prefix = role_prompt.split("## Active Role: Mira", 1)[0]
     role_prefix_cross_channel = role_prompt_cross_channel.split("## Active Role: Mira", 1)[0]
     assert role_prefix == role_prefix_cross_channel
+
+
+def test_context_builder_injects_interrupted_turn_as_separate_frame(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+):
+    class _Skills:
+        def __init__(self, workspace: Path) -> None:
+            self.workspace = workspace
+
+        def get_always_skills(self) -> list[str]:
+            return []
+
+        def load_skills_for_context(self, names: list[str]) -> str:
+            return ""
+
+        def build_skills_summary(self) -> str:
+            return ""
+
+    class _Memory:
+        def read_profile(self) -> str:
+            return ""
+
+        def read_self(self) -> str:
+            return ""
+
+        def read_recent_context(self) -> str:
+            return ""
+
+        def get_memory_context(self) -> str:
+            return ""
+
+    monkeypatch.setattr("agent.context.SkillsLoader", _Skills)
+    monkeypatch.setattr(
+        "agent.context.build_agent_static_identity_prompt", lambda **_: "identity"
+    )
+    monkeypatch.setattr(
+        "agent.context.build_skills_catalog_prompt", lambda text: text
+    )
+    RoleStore(tmp_path).create_role(
+        role_id="mira",
+        name="Mira",
+        system_prompt="test role",
+    )
+    builder = ContextBuilder(tmp_path, _Memory())  # type: ignore[arg-type]
+    result = builder.render(
+        ContextRequest(
+            history=[
+                {
+                    "role": "assistant",
+                    "content": "partial",
+                    "reasoning_content": "retain-cot",
+                }
+            ],
+            current_message="继续",
+        ),
+        session_metadata={
+            "role_id": "mira",
+            INTERRUPTED_TURN_METADATA_KEY: {"turn_id": "turn-1"},
+        },
+    )
+
+    frame = result.messages[-2]
+    assert frame["role"] == "user"
+    assert "上一轮助手回复因用户主动中断而未完成" in frame["content"]
+    assert result.messages[-3]["reasoning_content"] == "retain-cot"
+    assert "interrupted" not in result.messages[-3].get("content", "")
 
 
 def test_context_builder_reproduces_temporal_conflict_baseline(

--- a/tests/backend/test_support_modules.py
+++ b/tests/backend/test_support_modules.py
@@ -11,7 +11,6 @@ import pytest
 
 from agent.context import ContextBuilder, ContextRequest
 from agent.prompting import SYSTEM_CONTEXT_FRAME_MARKER
-from session.manager.models import INTERRUPTED_TURN_METADATA_KEY
 from agent.tools.base import Tool
 from agent.tools.memorize import MemorizeTool
 from agent.tools.message_push import MessagePushTool
@@ -714,72 +713,6 @@ def test_context_builder_builds_prompt_messages_and_assistant_blocks(
     role_prefix = role_prompt.split("## Active Role: Mira", 1)[0]
     role_prefix_cross_channel = role_prompt_cross_channel.split("## Active Role: Mira", 1)[0]
     assert role_prefix == role_prefix_cross_channel
-
-
-def test_context_builder_injects_interrupted_turn_as_separate_frame(
-    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
-):
-    class _Skills:
-        def __init__(self, workspace: Path) -> None:
-            self.workspace = workspace
-
-        def get_always_skills(self) -> list[str]:
-            return []
-
-        def load_skills_for_context(self, names: list[str]) -> str:
-            return ""
-
-        def build_skills_summary(self) -> str:
-            return ""
-
-    class _Memory:
-        def read_profile(self) -> str:
-            return ""
-
-        def read_self(self) -> str:
-            return ""
-
-        def read_recent_context(self) -> str:
-            return ""
-
-        def get_memory_context(self) -> str:
-            return ""
-
-    monkeypatch.setattr("agent.context.SkillsLoader", _Skills)
-    monkeypatch.setattr(
-        "agent.context.build_agent_static_identity_prompt", lambda **_: "identity"
-    )
-    monkeypatch.setattr(
-        "agent.context.build_skills_catalog_prompt", lambda text: text
-    )
-    RoleStore(tmp_path).create_role(
-        role_id="mira",
-        name="Mira",
-        system_prompt="test role",
-    )
-    builder = ContextBuilder(tmp_path, _Memory())  # type: ignore[arg-type]
-    result = builder.render(
-        ContextRequest(
-            history=[
-                {
-                    "role": "assistant",
-                    "content": "partial",
-                    "reasoning_content": "retain-cot",
-                }
-            ],
-            current_message="继续",
-        ),
-        session_metadata={
-            "role_id": "mira",
-            INTERRUPTED_TURN_METADATA_KEY: {"turn_id": "turn-1"},
-        },
-    )
-
-    frame = result.messages[-2]
-    assert frame["role"] == "user"
-    assert "上一轮助手回复因用户主动中断而未完成" in frame["content"]
-    assert result.messages[-3]["reasoning_content"] == "retain-cot"
-    assert "interrupted" not in result.messages[-3].get("content", "")
 
 
 def test_context_builder_reproduces_temporal_conflict_baseline(


### PR DESCRIPTION
Refs #110

## 变更摘要
- 流式聊天回复期间，发送按钮原位切换为停止按钮；按 session_key + turn_id 精确取消当前回合。
- 后端校验会话与回合身份，停止 AgentLoop、桌面 wrapper task 和关联语音回合的 TTS coordinator，并立即释放会话活跃槽位。
- 为聊天增量、工具事件和结束/错误事件附带 turn_id；渲染端过滤迟到事件，避免旧回合污染新回合。
- 取消时保留已显示的思考、文本增量和工具状态，正常结束助手消息且不追加错误消息。

## 验证
- D:\Coding\Shiori\.venv\Scripts\pytest.exe tests\backend\desktop_bridge：169 passed
- D:\Coding\Shiori\.venv\Scripts\ruff.exe check ...：通过
- pnpm run desktop:typecheck：通过
- pnpm run desktop:test -- apps/desktop/renderer/src/app/desktopSelectors.test.ts apps/desktop/renderer/src/chat/ChatComposer.test.tsx apps/desktop/renderer/src/chat/ChatSurface.test.tsx：522 passed，1 skipped
- git diff --check：通过

## 已知阻塞项
- Windows 环境不支持文件 symlink，已有测试因此跳过 1 项；不是本次代码失败。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cancellation of streaming chat replies from the desktop app. The send button switches to a stop button while streaming; cancelling strictly by session key and turn ID interrupts the agent loop, the desktop wrapper task, and the associated TTS coordinator. The async cancel path awaits the cancelled turn's cleanup before freeing the session slot, and chat events (delta, tool, done, error) now carry the turn ID so the renderer drops late events from an already-cancelled turn.

Cancelling keeps the already-streamed content and adds no error message. The partial reply is persisted to the session with an `interrupted_reply` marker, survives session reloads, stays visible in renderer history, and the next turn receives a context frame stating the interrupted reply was a raw snapshot that must not be continued.

**Breaking changes**
- `chat.send` now requires a non-empty `turn_id` (falls back to `client_message_id` or request ID).
- `chat.cancel` now takes `session_key` and `turn_id` instead of `role_id`.

<sup>Written for commit dc921cee9a8b2b78a20c82611f5291d193c935a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/113?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

