### PR TITLE
feat(desktop): 自动分页加载聊天历史

### DIFF
--- a/apps/desktop/renderer/src/chat/ChatComposer.test.tsx
+++ b/apps/desktop/renderer/src/chat/ChatComposer.test.tsx
@@ -55,4 +55,11 @@ describe("ChatComposer", () => {
     assert.match(markup, /contain:layout/);
     assert.doesNotMatch(markup, /field-sizing/);
   });
+
+  it("does not intercept pointer events outside the visible composer", () => {
+    const markup = renderChatComposer();
+
+    assert.match(markup, /composer-wrap pointer-events-none/);
+    assert.match(markup, /pointer-events-auto mx-auto w-full max-w-\[700px\]/);
+  });
 });

--- a/apps/desktop/renderer/src/chat/ChatComposer.tsx
+++ b/apps/desktop/renderer/src/chat/ChatComposer.tsx
@@ -136,8 +136,8 @@ export const ChatComposer = React.memo(function ChatComposer({
   }
 
   return (
-    <div className="composer-wrap absolute inset-x-0 bottom-10 z-[2] flex min-w-0 justify-center overflow-visible">
-      <div className="mx-auto w-full max-w-[700px] px-5 md:px-6">
+    <div className="composer-wrap pointer-events-none absolute inset-x-0 bottom-10 z-[2] flex min-w-0 justify-center overflow-visible">
+      <div className="pointer-events-auto mx-auto w-full max-w-[700px] px-5 md:px-6">
         <div className="composer grid w-full flex-none gap-1.5 rounded-[18px] border border-[#E4E4E4] bg-[#FFFEFF] px-3 pb-2 pt-2.5">
           {replyTarget ? (
             <div className="flex min-w-0 items-start gap-2 rounded-md border border-[#E5E7EB] bg-[#F8FAFC] px-2.5 py-2 text-left">

--- a/apps/desktop/renderer/src/chat/ChatMessageList.test.tsx
+++ b/apps/desktop/renderer/src/chat/ChatMessageList.test.tsx
@@ -18,7 +18,6 @@ describe("ChatMessageList", () => {
         highlightedMessageKey=""
         visibleMessageWindow={getVisibleChatMessages([message], 10)}
         onBeginAttachmentDrag={() => undefined}
-        onExpandOlderMessages={() => undefined}
         onJumpToMessage={() => undefined}
         onOpenContextMenu={() => undefined}
         onOpenImagePreview={() => undefined}
@@ -72,7 +71,6 @@ describe("ChatMessageList", () => {
         highlightedMessageKey=""
         visibleMessageWindow={getVisibleChatMessages([message], 10)}
         onBeginAttachmentDrag={() => undefined}
-        onExpandOlderMessages={() => undefined}
         onJumpToMessage={() => undefined}
         onOpenContextMenu={() => undefined}
         onOpenImagePreview={() => undefined}
@@ -105,7 +103,6 @@ describe("ChatMessageList", () => {
         highlightedMessageKey=""
         visibleMessageWindow={{ startIndex: 0, hiddenMessageCount: 0, messages }}
         onBeginAttachmentDrag={() => undefined}
-        onExpandOlderMessages={() => undefined}
         onJumpToMessage={() => undefined}
         onOpenContextMenu={() => undefined}
         onOpenImagePreview={() => undefined}
@@ -135,7 +132,6 @@ describe("ChatMessageList", () => {
           })),
         }}
         onBeginAttachmentDrag={() => undefined}
-        onExpandOlderMessages={() => undefined}
         onJumpToMessage={() => undefined}
         onOpenContextMenu={() => undefined}
         onOpenImagePreview={() => undefined}
@@ -159,7 +155,6 @@ describe("ChatMessageList", () => {
           content: "消息内容",
         }], 10)}
         onBeginAttachmentDrag={() => undefined}
-        onExpandOlderMessages={() => undefined}
         onJumpToMessage={() => undefined}
         onOpenContextMenu={() => undefined}
         onOpenImagePreview={() => undefined}

--- a/apps/desktop/renderer/src/chat/ChatMessageList.tsx
+++ b/apps/desktop/renderer/src/chat/ChatMessageList.tsx
@@ -3,7 +3,7 @@ import { ChatMessageRow } from "./ChatMessageRow";
 import { useChatMessageVirtualization } from "./useChatMessageVirtualization";
 import { getChatMessageDomKey, getChatMessageReactKey } from "./chatMessageIdentity";
 import type { getVisibleChatMessages } from "./chatMessageWindow";
-import { cx, focusResetClass } from "../shared/styles";
+import { cx } from "../shared/styles";
 import type { RoleRecord, SessionMessage } from "../shared/types";
 
 type ChatMessageListProps = {
@@ -15,11 +15,8 @@ type ChatMessageListProps = {
   onMessageNavigationTargetMounted?: (messageKey: string, target: HTMLElement) => void;
   isAutoScrollingRef?: React.RefObject<boolean>;
   visibleMessageWindow: ReturnType<typeof getVisibleChatMessages>;
-  canLoadOlderMessages?: boolean;
-  loadingOlderMessages?: boolean;
   onBeginAttachmentDrag: (path: string) => void;
   onContentSizeChange?: () => void;
-  onExpandOlderMessages: () => void;
   onJumpToMessage: (messageKey: string) => void;
   onOpenContextMenu: (
     event: React.MouseEvent<HTMLElement>,
@@ -43,11 +40,8 @@ export const ChatMessageList = React.memo(function ChatMessageList({
   onMessageNavigationTargetMounted,
   isAutoScrollingRef,
   visibleMessageWindow,
-  canLoadOlderMessages = visibleMessageWindow.hiddenMessageCount > 0,
-  loadingOlderMessages = false,
   onBeginAttachmentDrag,
   onContentSizeChange,
-  onExpandOlderMessages,
   onJumpToMessage,
   onOpenContextMenu,
   onOpenImagePreview,
@@ -74,21 +68,6 @@ export const ChatMessageList = React.memo(function ChatMessageList({
       style={{ overflowAnchor: "none" }}
     >
       <div className={cx("grid content-start gap-3", chatContentTrackClass)}>
-        {canLoadOlderMessages ? (
-          <div className="flex justify-center">
-            <button
-              className={cx(
-                "rounded-md border border-[#D8DEE8] bg-white/85 px-3 py-1.5 text-[12px] text-[#5B6472] transition hover:border-[#C6CEDA] hover:bg-white",
-                focusResetClass,
-              )}
-              type="button"
-              disabled={loadingOlderMessages}
-              onClick={onExpandOlderMessages}
-            >
-              {loadingOlderMessages ? "正在加载更早消息" : `更早消息 ${visibleMessageWindow.hiddenMessageCount} 条`}
-            </button>
-          </div>
-        ) : null}
         {virtualMessageWindow.topSpacerHeight > 0 ? (
           <div aria-hidden="true" className="pointer-events-none" style={{ height: virtualMessageWindow.topSpacerHeight }} />
         ) : null}

--- a/apps/desktop/renderer/src/chat/ChatSurface.test.tsx
+++ b/apps/desktop/renderer/src/chat/ChatSurface.test.tsx
@@ -225,7 +225,7 @@ describe("ChatSurface", () => {
     assert.match(markup, /ml-auto items-end/);
   });
 
-  it("renders only the recent chat window first and shows an affordance for older messages", () => {
+  it("renders only the recent chat window first without a manual older-message control", () => {
     const session = createSession();
     session.messages = Array.from({ length: 220 }, (_value, index) => ({
       id: `message-${index + 1}`,
@@ -235,7 +235,7 @@ describe("ChatSurface", () => {
 
     const markup = renderChatSurface(createRole(), "mira", { activeSession: session });
 
-    assert.match(markup, />更早消息 60 条</);
+    assert.doesNotMatch(markup, />更早消息/);
     assert.doesNotMatch(markup, /data-message-key="message-1"/);
     assert.match(markup, /data-message-key="message-220"/);
   });

--- a/apps/desktop/renderer/src/chat/ChatSurface.tsx
+++ b/apps/desktop/renderer/src/chat/ChatSurface.tsx
@@ -13,6 +13,7 @@ import {
   shouldAutoScrollOnContentSizeChange,
   shouldAutoScrollOnNewMessage,
 } from "./chatAutoScroll";
+import { shouldLoadOlderChatMessagesAfterSessionRestore } from "./chatMessagePaginationState";
 import { summarizeChatReplyContent } from "./chatComposerState";
 import { useRoleTasks } from "./useRoleTasks";
 import { useChatMessagePagination } from "./useChatMessagePagination";
@@ -148,6 +149,8 @@ export function ChatSurface({
   const currentLastMessageContent = sessionMessages.at(-1)?.content ?? "";
   const {
     visibleMessageWindow,
+    canLoadOlderMessages,
+    loading: loadingOlderMessages,
     maybeLoadOlderMessages,
   } = useChatMessagePagination({
     activeSession,
@@ -191,6 +194,14 @@ export function ChatSurface({
     const restoredSessionScroll = restoreSessionScroll(sessionKey);
     if (restoredSessionScroll) {
       stickToBottomRef.current = restoredSessionScroll.wasAtBottom;
+      if (shouldLoadOlderChatMessagesAfterSessionRestore({
+        scrollTop: container.scrollTop,
+        restoredWasAtBottom: restoredSessionScroll.wasAtBottom,
+        canLoadOlderMessages,
+        loading: loadingOlderMessages,
+      })) {
+        maybeLoadOlderMessages(container.scrollTop, false);
+      }
       return;
     }
     stickToBottomRef.current = true;

--- a/apps/desktop/renderer/src/chat/ChatSurface.tsx
+++ b/apps/desktop/renderer/src/chat/ChatSurface.tsx
@@ -148,9 +148,7 @@ export function ChatSurface({
   const currentLastMessageContent = sessionMessages.at(-1)?.content ?? "";
   const {
     visibleMessageWindow,
-    loading: loadingOlderMessages,
-    canLoadOlderMessages,
-    onLoadOlderMessages: handleLoadOlderMessages,
+    maybeLoadOlderMessages,
   } = useChatMessagePagination({
     activeSession,
     conversationListRef,
@@ -262,7 +260,13 @@ export function ChatSurface({
     const container = conversationListRef.current;
     if (!container) return;
 
-    const handleScroll = () => updateScrollState({ allowUnstick: true });
+    const handleScroll = () => {
+      updateScrollState({ allowUnstick: true });
+      const container = conversationListRef.current;
+      if (container) {
+        maybeLoadOlderMessages(container.scrollTop, isAutoScrollingRef.current);
+      }
+    };
     const handleResize = () => updateScrollState();
 
     container.addEventListener("scroll", handleScroll, { passive: true });
@@ -276,7 +280,7 @@ export function ChatSurface({
       window.removeEventListener("resize", handleResize);
       resizeObserver.disconnect();
     };
-  }, [activeSession?.messages.length, currentLastMessageContent, highlightedMessageKey, isAutoScrollingRef, sending]);
+  }, [activeSession?.messages.length, currentLastMessageContent, highlightedMessageKey, isAutoScrollingRef, maybeLoadOlderMessages, sending]);
 
   useEffect(() => {
     if (!chatLatestImageSidebarCollapsed) {
@@ -504,9 +508,6 @@ export function ChatSurface({
           visibleMessageWindow={visibleMessageWindow}
           onBeginAttachmentDrag={onBeginAttachmentDrag}
           onContentSizeChange={handleChatContentSizeChange}
-          canLoadOlderMessages={canLoadOlderMessages}
-          loadingOlderMessages={loadingOlderMessages}
-          onExpandOlderMessages={handleLoadOlderMessages}
           onJumpToMessage={onJumpToMessage}
           onOpenContextMenu={openMessageContextMenu}
           onOpenImagePreview={handleOpenChatImagePreview}

--- a/apps/desktop/renderer/src/chat/chatMessagePaginationState.test.ts
+++ b/apps/desktop/renderer/src/chat/chatMessagePaginationState.test.ts
@@ -6,6 +6,8 @@ import {
   getPaginatedChatMessageWindow,
   getPrependAnchorScrollTop,
   shouldLoadOlderChatMessages,
+  shouldLoadOlderChatMessagesAfterSessionRestore,
+  triggerOlderChatMessagesLoad,
 } from "./chatMessagePaginationState";
 import type { SessionPayload } from "../shared/types";
 
@@ -80,5 +82,87 @@ describe("shouldLoadOlderChatMessages", () => {
     assert.equal(shouldLoadOlderChatMessages({ ...base, scrollTop: 96, loading: true }), false);
     assert.equal(shouldLoadOlderChatMessages({ ...base, scrollTop: 96, canLoadOlderMessages: false }), false);
     assert.equal(shouldLoadOlderChatMessages({ ...base, scrollTop: 96, isAutoScrolling: true }), false);
+  });
+});
+
+describe("triggerOlderChatMessagesLoad", () => {
+  const base = {
+    canLoadOlderMessages: true,
+    loading: false,
+    isAutoScrolling: false,
+  };
+
+  it("routes a near-top user scroll to the older-page loader", () => {
+    let loadCount = 0;
+    const triggered = triggerOlderChatMessagesLoad({
+      ...base,
+      scrollTop: 0,
+      loadOlderPage: () => { loadCount += 1; },
+    });
+
+    assert.equal(triggered, true);
+    assert.equal(loadCount, 1);
+  });
+
+  it("keeps the loading gate from invoking a duplicate request", () => {
+    let loadCount = 0;
+    const loadOlderPage = () => { loadCount += 1; };
+    const first = triggerOlderChatMessagesLoad({ ...base, scrollTop: 24, loadOlderPage });
+    const duplicate = triggerOlderChatMessagesLoad({ ...base, scrollTop: 24, loading: true, loadOlderPage });
+
+    assert.equal(first, true);
+    assert.equal(duplicate, false);
+    assert.equal(loadCount, 1);
+  });
+
+  it("does not route programmatic scrolling or positions outside the threshold", () => {
+    let loadCount = 0;
+    const loadOlderPage = () => { loadCount += 1; };
+    assert.equal(triggerOlderChatMessagesLoad({ ...base, scrollTop: 0, isAutoScrolling: true, loadOlderPage }), false);
+    assert.equal(triggerOlderChatMessagesLoad({ ...base, scrollTop: 97, loadOlderPage }), false);
+    assert.equal(loadCount, 0);
+  });
+});
+
+describe("shouldLoadOlderChatMessagesAfterSessionRestore", () => {
+  const base = {
+    canLoadOlderMessages: true,
+    loading: false,
+  };
+
+  it("checks for older history when a non-bottom session restores near the top", () => {
+    assert.equal(shouldLoadOlderChatMessagesAfterSessionRestore({
+      ...base,
+      scrollTop: 0,
+      restoredWasAtBottom: false,
+    }), true);
+  });
+
+  it("does not treat the initial bottom restore as a pagination request", () => {
+    assert.equal(shouldLoadOlderChatMessagesAfterSessionRestore({
+      ...base,
+      scrollTop: 0,
+      restoredWasAtBottom: true,
+    }), false);
+  });
+
+  it("keeps the same loading and threshold gates as user scrolling", () => {
+    assert.equal(shouldLoadOlderChatMessagesAfterSessionRestore({
+      ...base,
+      scrollTop: 97,
+      restoredWasAtBottom: false,
+    }), false);
+    assert.equal(shouldLoadOlderChatMessagesAfterSessionRestore({
+      ...base,
+      loading: true,
+      scrollTop: 0,
+      restoredWasAtBottom: false,
+    }), false);
+    assert.equal(shouldLoadOlderChatMessagesAfterSessionRestore({
+      ...base,
+      canLoadOlderMessages: false,
+      scrollTop: 0,
+      restoredWasAtBottom: false,
+    }), false);
   });
 });

--- a/apps/desktop/renderer/src/chat/chatMessagePaginationState.test.ts
+++ b/apps/desktop/renderer/src/chat/chatMessagePaginationState.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from "node:test";
 import {
   getPaginatedChatMessageWindow,
   getPrependAnchorScrollTop,
+  shouldLoadOlderChatMessages,
 } from "./chatMessagePaginationState";
 import type { SessionPayload } from "../shared/types";
 
@@ -66,5 +67,18 @@ describe("getPaginatedChatMessageWindow", () => {
 describe("getPrependAnchorScrollTop", () => {
   it("compensates exactly for the height added above the visible anchor", () => {
     assert.equal(getPrependAnchorScrollTop(800, 280, 1260), 740);
+  });
+});
+
+describe("shouldLoadOlderChatMessages", () => {
+  it("triggers only for a user scroll within the top threshold", () => {
+    const base = { canLoadOlderMessages: true, loading: false, isAutoScrolling: false };
+
+    assert.equal(shouldLoadOlderChatMessages({ ...base, scrollTop: 96 }), true);
+    assert.equal(shouldLoadOlderChatMessages({ ...base, scrollTop: 0 }), true);
+    assert.equal(shouldLoadOlderChatMessages({ ...base, scrollTop: 97 }), false);
+    assert.equal(shouldLoadOlderChatMessages({ ...base, scrollTop: 96, loading: true }), false);
+    assert.equal(shouldLoadOlderChatMessages({ ...base, scrollTop: 96, canLoadOlderMessages: false }), false);
+    assert.equal(shouldLoadOlderChatMessages({ ...base, scrollTop: 96, isAutoScrolling: true }), false);
   });
 });

--- a/apps/desktop/renderer/src/chat/chatMessagePaginationState.test.ts
+++ b/apps/desktop/renderer/src/chat/chatMessagePaginationState.test.ts
@@ -89,6 +89,7 @@ describe("triggerOlderChatMessagesLoad", () => {
   const base = {
     canLoadOlderMessages: true,
     loading: false,
+    loadingGateActive: false,
     isAutoScrolling: false,
   };
 
@@ -108,7 +109,7 @@ describe("triggerOlderChatMessagesLoad", () => {
     let loadCount = 0;
     const loadOlderPage = () => { loadCount += 1; };
     const first = triggerOlderChatMessagesLoad({ ...base, scrollTop: 24, loadOlderPage });
-    const duplicate = triggerOlderChatMessagesLoad({ ...base, scrollTop: 24, loading: true, loadOlderPage });
+    const duplicate = triggerOlderChatMessagesLoad({ ...base, scrollTop: 24, loadingGateActive: true, loadOlderPage });
 
     assert.equal(first, true);
     assert.equal(duplicate, false);

--- a/apps/desktop/renderer/src/chat/chatMessagePaginationState.ts
+++ b/apps/desktop/renderer/src/chat/chatMessagePaginationState.ts
@@ -1,6 +1,26 @@
 import { getVisibleChatMessages } from "./chatMessageWindow";
 import type { SessionPayload } from "../shared/types";
 
+export const chatMessagePaginationTopThreshold = 96;
+
+/** Returns whether a user scroll near the top should request an older page. */
+export function shouldLoadOlderChatMessages({
+  scrollTop,
+  canLoadOlderMessages,
+  loading,
+  isAutoScrolling,
+}: {
+  scrollTop: number;
+  canLoadOlderMessages: boolean;
+  loading: boolean;
+  isAutoScrolling: boolean;
+}): boolean {
+  return scrollTop <= chatMessagePaginationTopThreshold
+    && canLoadOlderMessages
+    && !loading
+    && !isAutoScrolling;
+}
+
 /** Chooses either the server-backed loaded history or the legacy local render window. */
 export function getPaginatedChatMessageWindow(
   session: SessionPayload | null,

--- a/apps/desktop/renderer/src/chat/chatMessagePaginationState.ts
+++ b/apps/desktop/renderer/src/chat/chatMessagePaginationState.ts
@@ -26,16 +26,18 @@ export function triggerOlderChatMessagesLoad({
   scrollTop,
   canLoadOlderMessages,
   loading,
+  loadingGateActive = false,
   isAutoScrolling,
   loadOlderPage,
 }: {
   scrollTop: number;
   canLoadOlderMessages: boolean;
   loading: boolean;
+  loadingGateActive?: boolean;
   isAutoScrolling: boolean;
   loadOlderPage: () => void;
 }): boolean {
-  if (!shouldLoadOlderChatMessages({
+  if (loadingGateActive || !shouldLoadOlderChatMessages({
     scrollTop,
     canLoadOlderMessages,
     loading,

--- a/apps/desktop/renderer/src/chat/chatMessagePaginationState.ts
+++ b/apps/desktop/renderer/src/chat/chatMessagePaginationState.ts
@@ -21,6 +21,50 @@ export function shouldLoadOlderChatMessages({
     && !isAutoScrolling;
 }
 
+/** Invokes the older-page loader when a scroll event crosses the paging gates. */
+export function triggerOlderChatMessagesLoad({
+  scrollTop,
+  canLoadOlderMessages,
+  loading,
+  isAutoScrolling,
+  loadOlderPage,
+}: {
+  scrollTop: number;
+  canLoadOlderMessages: boolean;
+  loading: boolean;
+  isAutoScrolling: boolean;
+  loadOlderPage: () => void;
+}): boolean {
+  if (!shouldLoadOlderChatMessages({
+    scrollTop,
+    canLoadOlderMessages,
+    loading,
+    isAutoScrolling,
+  })) return false;
+  loadOlderPage();
+  return true;
+}
+
+/** Returns whether restoring a previously browsed session should check for older history. */
+export function shouldLoadOlderChatMessagesAfterSessionRestore({
+  scrollTop,
+  restoredWasAtBottom,
+  canLoadOlderMessages,
+  loading,
+}: {
+  scrollTop: number;
+  restoredWasAtBottom: boolean;
+  canLoadOlderMessages: boolean;
+  loading: boolean;
+}): boolean {
+  return !restoredWasAtBottom && shouldLoadOlderChatMessages({
+    scrollTop,
+    canLoadOlderMessages,
+    loading,
+    isAutoScrolling: false,
+  });
+}
+
 /** Chooses either the server-backed loaded history or the legacy local render window. */
 export function getPaginatedChatMessageWindow(
   session: SessionPayload | null,

--- a/apps/desktop/renderer/src/chat/chatMessageVirtualization.test.ts
+++ b/apps/desktop/renderer/src/chat/chatMessageVirtualization.test.ts
@@ -17,6 +17,51 @@ function messages(count: number): SessionMessage[] {
 }
 
 describe("getVirtualChatMessageWindow", () => {
+  it("keeps the mounted message window bounded at 1k, 5k, and 10k history sizes", () => {
+    for (const count of [1_000, 5_000, 10_000]) {
+      const source = messages(count);
+      const messageKeys = source.map((message) => message.id ?? "");
+      const totalHeight = getVirtualChatMessageWindow({
+        messages: source,
+        messageKeys,
+        measuredHeights: new Map(),
+        scrollTop: Number.POSITIVE_INFINITY,
+        viewportHeight: 720,
+        pinnedMessageIndex: -1,
+      }).totalHeight;
+
+      for (const [position, scrollTop] of [
+        ["top", 0],
+        ["middle", totalHeight / 2],
+        ["bottom", Number.POSITIVE_INFINITY],
+      ] as const) {
+        const window = getVirtualChatMessageWindow({
+          messages: source,
+          messageKeys,
+          measuredHeights: new Map(),
+          scrollTop,
+          viewportHeight: 720,
+          pinnedMessageIndex: -1,
+        });
+
+        assert.ok(
+          window.messages.length < 80,
+          `${count} messages at the ${position} must mount fewer than 80 rows`,
+        );
+        assert.equal(window.messages[0]?.id, `message-${window.startIndex}`);
+        assert.equal(window.messages.at(-1)?.id, `message-${window.endIndex - 1}`);
+        if (position === "top") {
+          assert.equal(window.topSpacerHeight, 0);
+        } else if (position === "middle") {
+          assert.ok(window.topSpacerHeight > 0);
+          assert.ok(window.bottomSpacerHeight > 0);
+        } else {
+          assert.equal(window.bottomSpacerHeight, 0);
+        }
+      }
+    }
+  });
+
   it("keeps a 10k-message React window bounded around the viewport", () => {
     const source = messages(10_000);
     const window = getVirtualChatMessageWindow({

--- a/apps/desktop/renderer/src/chat/useChatMessagePagination.ts
+++ b/apps/desktop/renderer/src/chat/useChatMessagePagination.ts
@@ -8,7 +8,7 @@ import {
 import {
   getPaginatedChatMessageWindow,
   getPrependAnchorScrollTop,
-  shouldLoadOlderChatMessages,
+  triggerOlderChatMessagesLoad,
 } from "./chatMessagePaginationState";
 import type { SessionPayload } from "../shared/types";
 
@@ -73,13 +73,13 @@ export function useChatMessagePagination({
   }, [canLoadOlderMessages, conversationListRef, hasServerPagination, loadOlderMessages, loading, sessionKey]);
 
   const maybeLoadOlderMessages = useCallback((scrollTop: number, isAutoScrolling: boolean) => {
-    if (!shouldLoadOlderChatMessages({
+    triggerOlderChatMessagesLoad({
       scrollTop,
       canLoadOlderMessages,
       loading,
       isAutoScrolling,
-    })) return;
-    loadOlderPage();
+      loadOlderPage,
+    });
   }, [canLoadOlderMessages, loadOlderPage, loading]);
 
   useLayoutEffect(() => {

--- a/apps/desktop/renderer/src/chat/useChatMessagePagination.ts
+++ b/apps/desktop/renderer/src/chat/useChatMessagePagination.ts
@@ -81,7 +81,7 @@ export function useChatMessagePagination({
       isAutoScrolling,
       loadOlderPage,
     });
-  }, [canLoadOlderMessages, loadOlderPage, loading]);
+  }, [canLoadOlderMessages, loadOlderPage, loading, sessionKey]);
 
   useLayoutEffect(() => {
     if (!hasServerPagination && loadingGateRef.current === sessionKey) {

--- a/apps/desktop/renderer/src/chat/useChatMessagePagination.ts
+++ b/apps/desktop/renderer/src/chat/useChatMessagePagination.ts
@@ -52,7 +52,7 @@ export function useChatMessagePagination({
     ? Boolean(activeSession?.pagination?.has_more)
     : visibleMessageWindow.hiddenMessageCount > 0;
 
-  const handleExpandOlderMessages = useCallback(() => {
+  const loadOlderPage = useCallback(() => {
     const container = conversationListRef.current;
     if (!container || !sessionKey || loading || !canLoadOlderMessages || loadingGateRef.current === sessionKey) return;
     loadingGateRef.current = sessionKey;
@@ -79,8 +79,8 @@ export function useChatMessagePagination({
       loading,
       isAutoScrolling,
     })) return;
-    handleExpandOlderMessages();
-  }, [canLoadOlderMessages, handleExpandOlderMessages, loading]);
+    loadOlderPage();
+  }, [canLoadOlderMessages, loadOlderPage, loading]);
 
   useLayoutEffect(() => {
     if (!hasServerPagination && loadingGateRef.current === sessionKey) {
@@ -116,7 +116,6 @@ export function useChatMessagePagination({
     visibleMessageWindow,
     loading,
     canLoadOlderMessages,
-    onLoadOlderMessages: handleExpandOlderMessages,
     maybeLoadOlderMessages,
   };
 }

--- a/apps/desktop/renderer/src/chat/useChatMessagePagination.ts
+++ b/apps/desktop/renderer/src/chat/useChatMessagePagination.ts
@@ -8,6 +8,7 @@ import {
 import {
   getPaginatedChatMessageWindow,
   getPrependAnchorScrollTop,
+  shouldLoadOlderChatMessages,
 } from "./chatMessagePaginationState";
 import type { SessionPayload } from "../shared/types";
 
@@ -34,21 +35,27 @@ export function useChatMessagePagination({
   const messages = activeSession?.messages ?? emptySessionMessages;
   const hasServerPagination = Boolean(activeSession?.pagination);
   const loading = loadingSessionKey === sessionKey;
+  const loadingGateRef = useRef("");
 
   useLayoutEffect(() => {
     setVisibleMessageCount(initialVisibleChatMessageCount);
     anchorRef.current = null;
     setLoadingSessionKey("");
+    loadingGateRef.current = "";
   }, [sessionKey]);
 
   const visibleMessageWindow = useMemo(
     () => getPaginatedChatMessageWindow(activeSession, visibleMessageCount),
     [activeSession, visibleMessageCount],
   );
+  const canLoadOlderMessages = hasServerPagination
+    ? Boolean(activeSession?.pagination?.has_more)
+    : visibleMessageWindow.hiddenMessageCount > 0;
 
   const handleExpandOlderMessages = useCallback(() => {
     const container = conversationListRef.current;
-    if (!container || !sessionKey || loading) return;
+    if (!container || !sessionKey || loading || !canLoadOlderMessages || loadingGateRef.current === sessionKey) return;
+    loadingGateRef.current = sessionKey;
     anchorRef.current = {
       sessionKey,
       scrollHeight: container.scrollHeight,
@@ -58,11 +65,28 @@ export function useChatMessagePagination({
       setLoadingSessionKey(sessionKey);
       void loadOlderMessages(sessionKey).finally(() => {
         setLoadingSessionKey((current) => current === sessionKey ? "" : current);
+        if (loadingGateRef.current === sessionKey) loadingGateRef.current = "";
       });
       return;
     }
     setVisibleMessageCount((current) => current + visibleChatMessageCountStep);
-  }, [conversationListRef, hasServerPagination, loadOlderMessages, loading, sessionKey]);
+  }, [canLoadOlderMessages, conversationListRef, hasServerPagination, loadOlderMessages, loading, sessionKey]);
+
+  const maybeLoadOlderMessages = useCallback((scrollTop: number, isAutoScrolling: boolean) => {
+    if (!shouldLoadOlderChatMessages({
+      scrollTop,
+      canLoadOlderMessages,
+      loading,
+      isAutoScrolling,
+    })) return;
+    handleExpandOlderMessages();
+  }, [canLoadOlderMessages, handleExpandOlderMessages, loading]);
+
+  useLayoutEffect(() => {
+    if (!hasServerPagination && loadingGateRef.current === sessionKey) {
+      loadingGateRef.current = "";
+    }
+  }, [hasServerPagination, sessionKey, visibleMessageCount]);
 
   useLayoutEffect(() => {
     const anchor = anchorRef.current;
@@ -91,9 +115,8 @@ export function useChatMessagePagination({
   return {
     visibleMessageWindow,
     loading,
-    canLoadOlderMessages: hasServerPagination
-      ? Boolean(activeSession?.pagination?.has_more)
-      : visibleMessageWindow.hiddenMessageCount > 0,
+    canLoadOlderMessages,
     onLoadOlderMessages: handleExpandOlderMessages,
+    maybeLoadOlderMessages,
   };
 }

--- a/apps/desktop/renderer/src/chat/useChatMessagePagination.ts
+++ b/apps/desktop/renderer/src/chat/useChatMessagePagination.ts
@@ -77,6 +77,7 @@ export function useChatMessagePagination({
       scrollTop,
       canLoadOlderMessages,
       loading,
+      loadingGateActive: loadingGateRef.current === sessionKey,
       isAutoScrolling,
       loadOlderPage,
     });


### PR DESCRIPTION
## 变更摘要

- 在聊天列表滚动到顶部 96px 内时自动加载更早消息。
- 复用现有分页请求、prepend 滚动锚点与会话隔离逻辑，并增加同步请求门闩。
- 删除手动更早消息按钮及对应列表 props。
- 补齐 1k/5k/10k 虚拟窗口结构性性能基线。

## 关联 Issue

Closes #118

## 验证结果

- pnpm --filter shiori-desktop run typecheck
- pnpm --filter shiori-desktop run lint
- 相关 Renderer 单测：90/90 通过

## 已知阻塞项

- 暂无。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the manual "load older messages" button with automatic pagination when scrolling near the top of the chat history, so older messages load without extra clicks.

- Triggers a load when the user scrolls within 96px of the top, while skipping loads during auto-scroll or an in-flight request.
- Checks for older history when a restored session lands near the top but wasn't at the bottom.
- Removes the manual older-message button and its associated props from `ChatMessageList`.
- Adds a per-session request gate so duplicate pagination requests are not sent.
- Adds structural performance baselines for 1k, 5k, and 10k message virtual windows.
- Makes the composer wrapper ignore pointer events outside its inner box so the scrollbar beside it stays clickable.

Closes #118.

<sup>Written for commit 2973921d6103894283ec58b99ed708ff0f1e3c11. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/120?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

