### PR TITLE
fix(desktop): 稳定聊天消息虚拟滚动

### DIFF
--- a/apps/desktop/renderer/src/chat/ChatMessageList.test.tsx
+++ b/apps/desktop/renderer/src/chat/ChatMessageList.test.tsx
@@ -125,7 +125,7 @@ describe("ChatMessageList", () => {
         visibleMessageWindow={{
           startIndex: 0,
           hiddenMessageCount: 0,
-          messages: Array.from({ length: 200 }, (_value, index): SessionMessage => ({
+          messages: Array.from({ length: 1_000 }, (_value, index): SessionMessage => ({
             id: `message-${index}`,
             role: "assistant",
             content: `message-${index}`,

--- a/apps/desktop/renderer/src/chat/chatMessageVirtualization.test.ts
+++ b/apps/desktop/renderer/src/chat/chatMessageVirtualization.test.ts
@@ -5,6 +5,7 @@ import { describe, it } from "node:test";
 import {
   getVirtualChatMessageWindow,
   chatMessageVirtualRowGap,
+  chatMessageVirtualizationThreshold,
 } from "./chatMessageVirtualization";
 import type { SessionMessage } from "../shared/types";
 
@@ -17,6 +18,22 @@ function messages(count: number): SessionMessage[] {
 }
 
 describe("getVirtualChatMessageWindow", () => {
+  it("keeps a bounded bridge history page fully mounted before virtualization is needed", () => {
+    const source = messages(chatMessageVirtualizationThreshold);
+    const window = getVirtualChatMessageWindow({
+      messages: source,
+      messageKeys: source.map((message) => message.id ?? ""),
+      measuredHeights: new Map(),
+      scrollTop: Number.POSITIVE_INFINITY,
+      viewportHeight: 720,
+      pinnedMessageIndex: -1,
+    });
+
+    assert.equal(window.messages.length, chatMessageVirtualizationThreshold);
+    assert.equal(window.topSpacerHeight, 0);
+    assert.equal(window.bottomSpacerHeight, 0);
+  });
+
   it("keeps the mounted message window bounded at 1k, 5k, and 10k history sizes", () => {
     for (const count of [1_000, 5_000, 10_000]) {
       const source = messages(count);
@@ -98,7 +115,7 @@ describe("getVirtualChatMessageWindow", () => {
   });
 
   it("keeps the last row mounted when the scroll position reaches total height", () => {
-    const source = messages(12);
+    const source = messages(chatMessageVirtualizationThreshold + 12);
     const window = getVirtualChatMessageWindow({
       messages: source,
       messageKeys: source.map((message) => message.id ?? ""),
@@ -108,7 +125,7 @@ describe("getVirtualChatMessageWindow", () => {
       pinnedMessageIndex: -1,
     });
 
-    assert.equal(window.messages.at(-1)?.id, "message-11");
+    assert.equal(window.messages.at(-1)?.id, `message-${source.length - 1}`);
     assert.equal(window.endIndex, source.length);
   });
 });

--- a/apps/desktop/renderer/src/chat/chatMessageVirtualization.ts
+++ b/apps/desktop/renderer/src/chat/chatMessageVirtualization.ts
@@ -3,6 +3,10 @@ import type { SessionMessage } from "../shared/types";
 export const chatMessageVirtualOverscanPixels = 720;
 export const chatMessageVirtualFallbackViewportHeight = 720;
 export const chatMessageVirtualRowGap = 12;
+// The bridge initially loads bounded history pages. Rendering those pages in
+// full avoids placing a real message behind a height estimate while the user
+// starts scrolling; virtualization remains reserved for genuinely long lists.
+export const chatMessageVirtualizationThreshold = 240;
 
 export type ChatMessageVirtualWindow = {
   startIndex: number;
@@ -96,13 +100,35 @@ export function getVirtualChatMessageWindow({
     };
   }
 
+  if (messages.length <= chatMessageVirtualizationThreshold) {
+    const totalHeight = messages.reduce(
+      (total, message, index) => total + heightForMessage(
+        message,
+        messageKeys[index]!,
+        measuredHeights,
+      ),
+      0,
+    );
+    return {
+      startIndex: 0,
+      endIndex: messages.length,
+      firstVisibleIndex: 0,
+      messages: [...messages],
+      topSpacerHeight: 0,
+      bottomSpacerHeight: 0,
+      totalHeight: Math.max(0, totalHeight - chatMessageVirtualRowGap),
+    };
+  }
+
   const offsets = [0];
   for (let index = 0; index < messages.length; index += 1) {
     offsets.push(
       offsets[index]! + heightForMessage(messages[index]!, messageKeys[index]!, measuredHeights),
     );
   }
-  const totalHeight = offsets.at(-1) ?? 0;
+  // Grid gaps exist only between rows. The cumulative offsets model one gap
+  // after every row, so remove the final non-existent gap from the scroll map.
+  const totalHeight = Math.max(0, (offsets.at(-1) ?? 0) - chatMessageVirtualRowGap);
   const safeScrollTop = Math.max(0, Math.min(scrollTop, totalHeight));
   const safeViewportHeight = Math.max(1, viewportHeight || chatMessageVirtualFallbackViewportHeight);
   const firstVisibleIndex = firstIndexAfterOffset(offsets, safeScrollTop);
@@ -123,8 +149,10 @@ export function getVirtualChatMessageWindow({
     endIndex,
     firstVisibleIndex,
     messages: messages.slice(startIndex, endIndex),
-    topSpacerHeight: offsets[startIndex] ?? 0,
-    bottomSpacerHeight: totalHeight - (offsets[endIndex] ?? totalHeight),
+    // The grid supplies the boundary gap beside each spacer. Keeping that gap
+    // out of spacer heights prevents the virtual positions drifting per slice.
+    topSpacerHeight: Math.max(0, (offsets[startIndex] ?? 0) - chatMessageVirtualRowGap),
+    bottomSpacerHeight: Math.max(0, totalHeight - (offsets[endIndex] ?? totalHeight)),
     totalHeight,
   };
 }


### PR DESCRIPTION
## Summary

- 已加载消息不超过 240 条时完整渲染，避免高度估算把真实消息置于占位区域。
- 超长会话仍维持有界虚拟 DOM。
- 修正虚拟列表上下占位区的间距计算，避免滚动位置累计偏移。

Closes #127

## Verification

- node node_modules/tsx/dist/cli.mjs --tsconfig apps/desktop/renderer/tsconfig.json --test apps/desktop/renderer/src/chat/chatMessageVirtualization.test.ts apps/desktop/renderer/src/chat/ChatMessageList.test.tsx apps/desktop/renderer/src/chat/chatMessagePaginationState.test.ts apps/desktop/renderer/src/app/useDesktopSessionState.test.ts
- pnpm --filter shiori-desktop run typecheck

## Known blockers

- None.