### PR TITLE
fix(desktop): 按角色匹配 client_message_id 防止回复顶掉用户消息

### DIFF
--- a/apps/desktop/renderer/src/app/sessionMessagePagination.test.ts
+++ b/apps/desktop/renderer/src/app/sessionMessagePagination.test.ts
@@ -1,0 +1,97 @@
+/// <reference types="node" />
+
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { mergeSessionSummaryAndMessage } from "./sessionMessagePagination.js";
+import type { SessionMessage, SessionPayload, SessionSummary } from "../shared/types.js";
+
+function createSummary(): SessionSummary {
+  return {
+    key: "role:mira",
+    created_at: "2026-09-07T11:00:00+08:00",
+    updated_at: "2026-09-07T11:00:00+08:00",
+    last_consolidated: 0,
+    metadata: { role_id: "mira" },
+  };
+}
+
+function createSession(messages: SessionMessage[]): SessionPayload {
+  return {
+    ...createSummary(),
+    messages,
+  };
+}
+
+describe("mergeSessionSummaryAndMessage", () => {
+  it("keeps the user turn when the assistant reply carries the same client message id", () => {
+    const currentSession = createSession([
+      {
+        id: "role:mira:5",
+        seq: 5,
+        role: "user",
+        content: "刚发出去的消息",
+        metadata: { client_message_id: "client-message-1" },
+      },
+      {
+        role: "assistant",
+        content: "流式回复",
+        streaming: true,
+      },
+    ]);
+    const committedReply: SessionMessage = {
+      id: "role:mira:6",
+      seq: 6,
+      role: "assistant",
+      content: "流式回复全文",
+      metadata: { client_message_id: "client-message-1", turn_id: "turn-1" },
+    };
+
+    const merged = mergeSessionSummaryAndMessage(currentSession, createSummary(), committedReply);
+
+    assert.deepEqual(
+      merged.messages.map((message) => [message.role, message.id ?? ""]),
+      [
+        ["user", "role:mira:5"],
+        ["assistant", "role:mira:6"],
+      ],
+    );
+    assert.equal(merged.messages[0]?.content, "刚发出去的消息");
+  });
+
+  it("replaces the optimistic user turn with its persisted copy by client message id", () => {
+    const currentSession = createSession([
+      {
+        id: "role:mira:4",
+        seq: 4,
+        role: "assistant",
+        content: "上一条回复",
+      },
+      {
+        role: "user",
+        content: "刚发出去的消息",
+        metadata: { client_message_id: "client-message-1" },
+      },
+    ]);
+    const persistedUserMessage: SessionMessage = {
+      id: "role:mira:5",
+      seq: 5,
+      role: "user",
+      content: "刚发出去的消息",
+      metadata: { client_message_id: "client-message-1" },
+    };
+
+    const merged = mergeSessionSummaryAndMessage(
+      currentSession,
+      createSummary(),
+      persistedUserMessage,
+    );
+
+    assert.deepEqual(
+      merged.messages.map((message) => [message.role, message.id ?? ""]),
+      [
+        ["assistant", "role:mira:4"],
+        ["user", "role:mira:5"],
+      ],
+    );
+  });
+});

--- a/apps/desktop/renderer/src/app/sessionMessagePagination.ts
+++ b/apps/desktop/renderer/src/app/sessionMessagePagination.ts
@@ -92,9 +92,16 @@ function findMatchingMessageIndex(
     const seqMatch = messages.findIndex((message) => message.seq === incoming.seq);
     if (seqMatch >= 0) return seqMatch;
   }
+  // 已提交的助手回复会原样继承请求 metadata（含用户的 client_message_id），
+  // 因此按 client_message_id 匹配必须限定同角色，否则助手回复会顶掉用户消息；
+  // 未命中时继续走下方的流式助手兜底分支。
   const incomingClientMessageId = clientMessageId(incoming);
   if (incomingClientMessageId) {
-    return messages.findIndex((message) => clientMessageId(message) === incomingClientMessageId);
+    const clientMatch = messages.findIndex((message) => (
+      message.role === incoming.role
+        && clientMessageId(message) === incomingClientMessageId
+    ));
+    if (clientMatch >= 0) return clientMatch;
   }
   const maxLoadedSeq = messages.reduce(
     (maximum, message) => typeof message.seq === "number" ? Math.max(maximum, message.seq) : maximum,

--- a/apps/desktop/renderer/src/chat/chatSessionMerge.test.ts
+++ b/apps/desktop/renderer/src/chat/chatSessionMerge.test.ts
@@ -341,6 +341,53 @@ describe("mergeIncomingSessionDuringSend", () => {
     assert.equal(merged, acknowledgedSession);
   });
 
+  it("does not acknowledge a pending user turn from the assistant reply that inherits its client message id", () => {
+    const pendingUserMessage: SessionMessage = {
+      role: "user",
+      content: "被回复顶掉的消息",
+      metadata: { client_message_id: "desktop-message-shared" },
+    };
+    const replyOnlySession = createSession([
+      {
+        id: "role:mira:2",
+        role: "assistant",
+        content: "回合结束的回复",
+        metadata: { client_message_id: "desktop-message-shared", turn_id: "turn-1" },
+      },
+    ]);
+
+    assert.equal(
+      isPendingUserMessageAcknowledged(pendingUserMessage, replyOnlySession),
+      false,
+    );
+  });
+
+  it("re-inserts the pending user turn when a snapshot only carries its assistant reply", () => {
+    const pendingUserMessage: SessionMessage = {
+      role: "user",
+      content: "被回复顶掉的消息",
+      metadata: { client_message_id: "desktop-message-shared" },
+    };
+    const currentSession = createSession([pendingUserMessage]);
+    const replyOnlySession = createSession([
+      {
+        id: "role:mira:2",
+        role: "assistant",
+        content: "回合结束的回复",
+        metadata: { client_message_id: "desktop-message-shared", turn_id: "turn-1" },
+      },
+    ]);
+
+    const merged = mergeIncomingSessionDuringSend(
+      currentSession,
+      replyOnlySession,
+      false,
+      pendingUserMessage,
+    );
+
+    assert.deepEqual(merged?.messages, [pendingUserMessage, ...replyOnlySession.messages]);
+  });
+
   it("does not acknowledge an identified pending turn from matching historical content", () => {
     const pendingUserMessage: SessionMessage = {
       role: "user",

--- a/apps/desktop/renderer/src/chat/chatSessionMerge.ts
+++ b/apps/desktop/renderer/src/chat/chatSessionMerge.ts
@@ -102,7 +102,8 @@ function findMissingOptimisticUserMessage(
   const clientMessageId = normalizeClientMessageId(optimisticUserMessage);
   const alreadyPersisted = incomingSession.messages.some((message) => {
     if (clientMessageId) {
-      return normalizeClientMessageId(message) === clientMessageId;
+      return message.role === optimisticUserMessage.role
+        && normalizeClientMessageId(message) === clientMessageId;
     }
     return areEquivalentMessagesIgnoringMissingIds(optimisticUserMessage, message);
   });
@@ -116,7 +117,8 @@ function findIncomingMessageIndex(
   const clientMessageId = normalizeClientMessageId(message);
   if (clientMessageId) {
     return incomingSession.messages.findIndex((incomingMessage) => (
-      normalizeClientMessageId(incomingMessage) === clientMessageId
+      incomingMessage.role === message.role
+        && normalizeClientMessageId(incomingMessage) === clientMessageId
     ));
   }
   return incomingSession.messages.findIndex((incomingMessage) => (
@@ -151,7 +153,8 @@ function findCurrentPendingUserIndex(
   const clientMessageId = normalizeClientMessageId(pendingUserMessage);
   if (clientMessageId) {
     return currentSession.messages.findIndex((message) => (
-      normalizeClientMessageId(message) === clientMessageId
+      message.role === pendingUserMessage.role
+        && normalizeClientMessageId(message) === clientMessageId
     ));
   }
   return currentSession.messages.findIndex((message) => (
@@ -204,9 +207,10 @@ export function isPendingUserMessageAcknowledged(
 ): boolean {
   const clientMessageId = normalizeClientMessageId(pendingUserMessage);
   return incomingSession.messages.some((message) => {
-    const incomingClientMessageId = normalizeClientMessageId(message);
     if (clientMessageId) {
-      return clientMessageId === incomingClientMessageId;
+      // 助手回复携带同一 client_message_id 时不算确认，必须是同角色的持久化副本。
+      return message.role === pendingUserMessage.role
+        && normalizeClientMessageId(message) === clientMessageId;
     }
     return Boolean(normalizeMessageId(message))
       && areEquivalentMessagesIgnoringMissingIds(pendingUserMessage, message);
@@ -275,9 +279,10 @@ export function mergeIncomingSessionDuringSend(
   const pendingClientMessageId = pendingUserMessage
     ? normalizeClientMessageId(pendingUserMessage)
     : "";
-  const pendingUserIndex = pendingClientMessageId
+  const pendingUserIndex = pendingUserMessage && pendingClientMessageId
     ? currentSession.messages.findIndex((message) => (
-        normalizeClientMessageId(message) === pendingClientMessageId
+        message.role === pendingUserMessage.role
+          && normalizeClientMessageId(message) === pendingClientMessageId
       ))
     : -1;
 


### PR DESCRIPTION
Closes #130

## 变更
- findMatchingMessageIndex 的 client_message_id 匹配加同角色约束，未命中时落穿到流式助手兜底分支，避免助手回复顶掉当轮用户消息或追加成重复气泡。
- chatSessionMerge.ts 全部 5 处 cmid 判断（isPendingUserMessageAcknowledged、findIncomingMessageIndex、findCurrentPendingUserIndex、findMissingOptimisticUserMessage、pendingUserIndex 查找）同步加角色校验。
- 新增镜像测试 sessionMessagePagination.test.ts（回归：携带用户 cmid 的助手回复不得顶掉用户消息，应替换流式占位行），chatSessionMerge.test.ts 补 2 个伪确认用例。

## 验证
- 相关套件（chatSessionMerge / sessionMessagePagination / useDesktopSessionState / chatMessageIdentity）39 个测试全部通过。
- renderer tsc --noEmit 通过；改动文件 ESLint 通过；git diff --check 干净。
- 修复前用真实模块复放脚本在正常时序 100% 复现用户消息被顶掉（根因证据：sessions.db 中助手回复原样继承用户 client_message_id），修复后回归用例覆盖同一时序。

## 已知阻塞项
- 无。

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a chat merge bug where a committed assistant reply inheriting the user's `client_message_id` replaced the user's message instead of the streaming placeholder.

**Bug Fixes**
- Adds role checks to all five match paths in `chatSessionMerge.ts` and the one in `sessionMessagePagination.ts`.
- Assistant replies that fail the role match now fall through to the streaming assistant branch and replace the placeholder.
- Adds regression tests for `sessionMessagePagination` and two pseudo-acknowledgement cases in `chatSessionMerge`.

<sup>Written for commit 3d5149a0e461c6503366f8aabb2cf7db382b6a5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/131?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

