### PR TITLE
fix(desktop): 修复取消回复后下一条用户消息错位闪烁消失

### DIFF
--- a/apps/backend/desktop_bridge/chat_requests.py
+++ b/apps/backend/desktop_bridge/chat_requests.py
@@ -50,12 +50,18 @@ class DesktopChatRequestHandler:
                 str(payload.get("session_key") or "").strip(),
                 str(payload.get("turn_id") or "").strip(),
             )
-            return {
+            response: dict[str, Any] = {
                 "status": result.status,
                 "message": result.message,
                 "session_key": result.session_key,
                 "turn_id": result.turn_id,
             }
+            if result.session is not None and result.interrupted_message is not None:
+                response["session"] = self._session_presenter.serialize_summary(result.session)
+                response["message_payload"] = self._session_presenter.serialize_message(
+                    result.interrupted_message
+                )
+            return response
         return None
 
     async def _send(

--- a/apps/backend/desktop_bridge/chat_service.py
+++ b/apps/backend/desktop_bridge/chat_service.py
@@ -59,6 +59,8 @@ class ChatTurnCancelResult:
     session_key: str
     turn_id: str
     message: str
+    session: Session | None = None
+    interrupted_message: dict[str, Any] | None = None
 
 
 @dataclass(frozen=True)
@@ -186,7 +188,7 @@ class DesktopChatService:
         if active_turn is not None:
             await self._await_turn_cleanup(normalized_session_key, active_turn)
         if result.status == "interrupted" and isinstance(interrupt_state, TurnInterruptState):
-            await self._persist_interrupted_turn(
+            interrupted_message = await self._persist_interrupted_turn(
                 session_key=normalized_session_key,
                 turn_id=normalized_turn_id,
                 state=interrupt_state,
@@ -194,6 +196,14 @@ class DesktopChatService:
             discard = getattr(self._agent_loop, "discard_interrupt_state", None)
             if callable(discard):
                 discard(normalized_session_key, interrupt_state)
+            if interrupted_message is not None:
+                # The renderer must swap its transient trace for the persisted
+                # message, or the next turn sorts around an id-less bubble.
+                result = replace(
+                    result,
+                    session=self._session_manager.get_or_create(normalized_session_key),
+                    interrupted_message=interrupted_message,
+                )
         return result
 
     async def _persist_and_discard_interrupted_turn(
@@ -309,12 +319,12 @@ class DesktopChatService:
         session_key: str,
         turn_id: str,
         state: TurnInterruptState,
-    ) -> None:
+    ) -> dict[str, Any] | None:
         """Persists one cancelled desktop reply before its session can be reused."""
 
         session = self._session_manager.get_or_create(session_key)
         if self._has_completed_turn(session, turn_id):
-            return
+            return None
         has_trace = bool(
             state.partial_reply
             or state.partial_thinking
@@ -350,6 +360,7 @@ class DesktopChatService:
         role_id = self._role_id_from_session_key(session_key)
         if role_id:
             self._sync_desktop_session_thread(session, role_id=role_id)
+        return assistant_message
 
     @staticmethod
     def _has_completed_turn(session: Session, turn_id: str) -> bool:

--- a/apps/desktop/renderer/src/app/chatTurnFlow.test.ts
+++ b/apps/desktop/renderer/src/app/chatTurnFlow.test.ts
@@ -1,0 +1,191 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+import type { SessionMessage, SessionPayload } from "../shared/types";
+import { buildOptimisticUserChatMessage } from "../chat/chatComposerState";
+import { ensureChatMessageRenderId, reconcileSessionMessageRenderIds } from "../chat/chatMessageIdentity";
+import { mergeIncomingSessionDuringSend, shouldClearPendingUserMessage } from "../chat/chatSessionMerge";
+import { applyChatStreamDelta, finalizeChatCancellation, finishChatStream } from "../chat/chatStreamingState";
+import { mergeOpenedSessionSnapshot, mergeSessionSummaryAndMessage } from "./sessionMessagePagination";
+
+const KEY = "role:mira";
+
+function summary() {
+  return {
+    key: KEY,
+    created_at: "2026-09-07T10:00:00+08:00",
+    updated_at: "2026-09-07T10:00:00+08:00",
+    last_consolidated: 0,
+    metadata: {},
+  };
+}
+
+function persisted(role: "user" | "assistant", seq: number, content: string, cmid?: string): SessionMessage {
+  return {
+    id: `${KEY}:${seq}`,
+    seq,
+    role,
+    content,
+    timestamp: "2026-09-07T10:00:00+08:00",
+    media: [],
+    metadata: cmid ? { client_message_id: cmid } : {},
+  };
+}
+
+/** Replays the renderer's session pipeline exactly as useDesktopSessionState composes it. */
+class ChatFlowHarness {
+  active: SessionPayload | null;
+  pending: Record<string, SessionMessage> = {};
+  sending: Record<string, string> = {};
+
+  constructor(initial: SessionPayload) {
+    this.active = initial;
+  }
+
+  commitActiveSession(next: SessionPayload | null): void {
+    const incoming = next ? mergeOpenedSessionSnapshot(this.active, next) : null;
+    const pendingMessage = incoming ? this.pending[incoming.key] ?? null : null;
+    const sending = Boolean(incoming?.key && this.sending[incoming.key]);
+    const merged = mergeIncomingSessionDuringSend(this.active, incoming, sending, pendingMessage);
+    if (pendingMessage && incoming && shouldClearPendingUserMessage(pendingMessage, incoming, sending)) {
+      delete this.pending[incoming.key];
+    }
+    this.active = reconcileSessionMessageRenderIds(this.active, merged);
+  }
+
+  update(updater: (current: SessionPayload | null) => SessionPayload | null): void {
+    this.active = updater(this.active);
+  }
+
+  send(content: string, cmid: string): void {
+    const optimistic = buildOptimisticUserChatMessage(content, [], null, cmid);
+    this.pending[KEY] = optimistic;
+    this.sending[KEY] = "mira";
+    this.update((current) => current ? { ...current, messages: [...current.messages, optimistic] } : current);
+  }
+
+  response(userSeq: number, content: string, cmid: string): void {
+    this.commitActiveSession(
+      mergeSessionSummaryAndMessage(this.active, summary(), persisted("user", userSeq, content, cmid)),
+    );
+  }
+
+  delta(content: string): void {
+    this.update((current) => current ? applyChatStreamDelta(current, content, "") : current);
+  }
+
+  done(): void {
+    this.update((current) => current ? finishChatStream(current) : current);
+    delete this.sending[KEY];
+  }
+
+  cancelWithoutAcknowledgement(): void {
+    this.update((current) => current ? finalizeChatCancellation(current, "interrupted") : current);
+    delete this.sending[KEY];
+  }
+
+  cancelAcknowledged(assistantSeq: number, content: string): void {
+    this.cancelWithoutAcknowledgement();
+    this.commitActiveSession(
+      mergeSessionSummaryAndMessage(this.active, summary(), persisted("assistant", assistantSeq, content)),
+    );
+  }
+
+  sessionUpdated(assistantSeq: number, content: string): void {
+    this.commitActiveSession(
+      mergeSessionSummaryAndMessage(this.active, summary(), persisted("assistant", assistantSeq, content)),
+    );
+  }
+
+  roles(): string[] {
+    return (this.active?.messages ?? []).map((message) => `${message.role}:${String(message.content)}`);
+  }
+}
+
+function initialSession(): SessionPayload {
+  return {
+    ...summary(),
+    messages: [
+      ensureChatMessageRenderId(persisted("user", 1, "第一条")),
+      ensureChatMessageRenderId(persisted("assistant", 2, "第一条回复")),
+    ],
+    pagination: {
+      limit: 50,
+      has_more: false,
+      oldest_seq: 1,
+      newest_seq: 2,
+      total_count: 2,
+      before_seq: null,
+      next_before_seq: null,
+    },
+  };
+}
+
+test("two streamed rounds keep user message order", () => {
+  const harness = new ChatFlowHarness(initialSession());
+
+  harness.send("第二条", "cm-2");
+  harness.response(3, "第二条", "cm-2");
+  harness.delta("第二");
+  harness.delta("条回复");
+  harness.done();
+  harness.sessionUpdated(4, "第二条回复");
+
+  harness.send("第三条", "cm-3");
+  harness.response(5, "第三条", "cm-3");
+  harness.delta("第三条回复");
+  harness.done();
+  harness.sessionUpdated(6, "第三条回复");
+
+  assert.deepEqual(harness.roles(), [
+    "user:第一条",
+    "assistant:第一条回复",
+    "user:第二条",
+    "assistant:第二条回复",
+    "user:第三条",
+    "assistant:第三条回复",
+  ]);
+});
+
+test("a round after an acknowledged cancellation keeps user message order", () => {
+  const harness = new ChatFlowHarness(initialSession());
+
+  harness.send("第二条", "cm-2");
+  harness.response(3, "第二条", "cm-2");
+  harness.delta("第二条回复的一半");
+  harness.cancelAcknowledged(4, "第二条回复的一半");
+
+  harness.send("第三条", "cm-3");
+  harness.response(5, "第三条", "cm-3");
+  harness.delta("第三条回复");
+  harness.done();
+  harness.sessionUpdated(6, "第三条回复");
+
+  assert.deepEqual(harness.roles(), [
+    "user:第一条",
+    "assistant:第一条回复",
+    "user:第二条",
+    "assistant:第二条回复的一半",
+    "user:第三条",
+    "assistant:第三条回复",
+  ]);
+});
+
+test("an unacknowledged interrupted trace is never duplicated by later merges", () => {
+  const harness = new ChatFlowHarness(initialSession());
+
+  harness.send("第二条", "cm-2");
+  harness.response(3, "第二条", "cm-2");
+  harness.delta("第二条回复的一半");
+  harness.cancelWithoutAcknowledgement();
+
+  harness.send("第三条", "cm-3");
+  harness.response(5, "第三条", "cm-3");
+  harness.delta("第三条回复");
+  harness.done();
+  harness.sessionUpdated(6, "第三条回复");
+
+  const contents = harness.roles();
+  assert.deepEqual([...new Set(contents)].sort(), [...contents].sort());
+  assert.ok(contents.includes("user:第三条"));
+  assert.ok(contents.includes("assistant:第二条回复的一半"));
+});

--- a/apps/desktop/renderer/src/app/useDesktopSessionState.ts
+++ b/apps/desktop/renderer/src/app/useDesktopSessionState.ts
@@ -650,6 +650,19 @@ export function useDesktopSessionState({
           ? finalizeChatCancellation(current, status as "interrupted" | "idle")
           : current);
         completeChatTurn(sessionKey, turnId);
+        // Swap the transient interrupted trace for its persisted form so the
+        // next turn's seq ordering does not sort around an id-less bubble.
+        const update = parseSessionMessageUpdatePayload({
+          session: res.payload.session,
+          message: res.payload.message_payload,
+        });
+        if (update?.message && update.session.key === sessionKey) {
+          commitActiveSession(mergeSessionSummaryAndMessage(
+            activeSessionRef.current,
+            update.session,
+            update.message,
+          ));
+        }
       }
       return true;
     } catch (error) {

--- a/apps/desktop/renderer/src/chat/chatSessionMerge.ts
+++ b/apps/desktop/renderer/src/chat/chatSessionMerge.ts
@@ -179,6 +179,13 @@ function preserveInterruptedAssistantTrace(
       return;
     }
     if (findIncomingMessageIndex(message, incomingSession) >= 0) return;
+    // Incrementally merged sessions retain the id-less interrupted trace itself;
+    // re-inserting it would duplicate the bubble and displace the new user turn.
+    if (incomingSession.messages.some((incomingMessage) => (
+      areEquivalentMessagesIgnoringMissingIds(message, incomingMessage)
+    ))) {
+      return;
+    }
     const anchorIndex = findNextIncomingMessageIndex(currentSession.messages, index, incomingSession);
     const targetIndex = anchorIndex >= 0 ? anchorIndex : incomingUserIndex;
     const anchoredMessages = interruptedMessagesByIncomingIndex.get(targetIndex) ?? [];


### PR DESCRIPTION
## 问题

主窗口聊天中，**上一轮回复被取消（打断）后**，下一条用户消息发送时会先渲染、随即跳到上一轮回复的上方、然后闪烁消失；重启应用后消息恢复（数据一直是完好落库的，纯渲染端合并问题）。

## 根因

取消流式回复后，被打断的助手气泡在渲染端以「无 id / 无 seq 的临时消息」保留。下一轮发送时两个缺陷叠加：

1. `preserveInterruptedAssistantTrace` 判断「incoming 会话里是否已包含这条打断消息」时，匹配器要求 incoming 一侧必须带 message id。而增量合并产物里保留的恰是这条无 id 的临时消息本身 → 误判缺失 → 每次合并都在新用户消息前**再插入一份副本**。列表里同一对象出现两次（render_id 相同 → React key 冲突），表现为用户气泡被顶到上一轮回复上方并闪烁消失。
2. 后端在 `chat.cancel` 时其实已把打断回复持久化（带 id/seq），但从不告知渲染端 → 临时消息永远拿不到持久化身份，`seq` 排序（有 seq 在前、无 seq 沉底）持续围绕它错位。

用渲染端真实合并管线（`mergeOpenedSessionSnapshot → mergeIncomingSessionDuringSend → reconcileSessionMessageRenderIds`）逐事件重放两轮对话即可稳定复现：取消一轮后，下一轮 response 合并时打断消息在新用户消息前后各出现一份，之后每次 `session.updated` 继续增殖。

## 修复

- **前端**：membership 检查补充「无 id 等价匹配」——incoming 里已保留等价临时副本时不再重插（`chatSessionMerge.ts`）。
- **后端 + 前端**：`chat.cancel` 响应携带持久化后的打断消息（`session` 摘要 + `message_payload`，`message` 键已被状态文案占用故另取名）；渲染端在取消成功后合并它，把临时气泡换成带 id/seq 的持久化版本，后续轮次的 seq 排序自然正确。响应不带该字段时（无残留内容可持久化）行为退化为原状 + 去重保护。

## 验证

- 新增 `chatTurnFlow.test.ts`：以真实合并函数重放「正常两轮」「取消后确认」「取消未确认」三个场景；修复前「取消后」场景稳定复现重复与错位，修复后全过。
- 桌面全部单测 637 通过（含新增 3 个）、`pnpm typecheck` 通过、eslint 0 错误（仅 1 个既有无关 warning）。
- 后端 `ruff` 通过、`pyright --level error` 0 错误、`pytest tests/backend/desktop_bridge` 207 通过。

## 兼容性

`chat.cancel` 响应新增字段为纯附加，旧渲染端忽略之；新渲染端对不带字段的响应走原路径。与 PR #139（重构）无文件交集，两者可独立合并。


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the desktop chat rendering bug where, after canceling a streamed reply, the next user message is displaced above the previous reply and flickers away.

**Bug Fixes**
- The interrupted-trace membership check now accepts an equivalent id-less copy already present in the merged session, so the trace is no longer re-inserted as a duplicate.
- `chat.cancel` now returns the persisted interrupted message, and the renderer merges it in to swap the transient trace for its hydrated form so seq ordering stays correct.
- The new `session` and `message_payload` fields in the `chat.cancel` response are additive; older renderers ignore them.

<sup>Written for commit 2b2e6ca56bed929a38d40ab97cded4cbe6da0f21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/YinFengWindy/Shiori-Agent/pull/140?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

