### PR TITLE
fix(agent): preserve session history during context retries

### DIFF
--- a/apps/backend/agent/core/passive_turn/reasoner.py
+++ b/apps/backend/agent/core/passive_turn/reasoner.py
@@ -323,6 +323,7 @@ class DefaultReasoner(
                     "disabled_sections": sorted(plan["disabled_sections"]),
                 }
             )
+            # 重试只裁剪请求上下文，保留完整会话历史和记忆整合位置。
             history_for_attempt = self._slice_history(
                 source_history,
                 plan["history_window"],
@@ -374,22 +375,15 @@ class DefaultReasoner(
                 tools_used = list(result.metadata.get("tools_used") or [])
                 tools_unlocked = list(result.metadata.get("tools_unlocked") or [])
                 tool_chain = list(result.metadata.get("tool_chain") or [])
+                retry_trace["selected_plan"] = plan["name"]
+                retry_trace["trimmed_sections"] = sorted(plan["disabled_sections"])
                 if attempt > 0:
-                    window = plan["history_window"]
-                    retry_trace["selected_plan"] = plan["name"]
-                    retry_trace["trimmed_sections"] = sorted(plan["disabled_sections"])
                     logger.warning(
-                        "重试成功 plan=%s window=%d disabled=%s，修剪 session 历史",
+                        "重试成功 plan=%s window=%d disabled=%s",
                         plan["name"],
-                        window,
+                        plan["history_window"],
                         sorted(plan["disabled_sections"]),
                     )
-                    if window == 0:
-                        session.messages.clear()
-                    else:
-                        session.messages = session.messages[-window:]
-                    session.last_consolidated = 0
-                    await self._session_manager.save_async(cast(Any, session))
 
                 if self._tool_search_enabled and (tools_used or tools_unlocked):
                     self._discovery.update(
@@ -397,9 +391,6 @@ class DefaultReasoner(
                         [*tools_unlocked, *tools_used],
                         self._tools.get_always_on_names(),
                     )
-                if attempt == 0:
-                    retry_trace["selected_plan"] = plan["name"]
-                    retry_trace["trimmed_sections"] = sorted(plan["disabled_sections"])
                 if isinstance(llm_user_content, (str, list)):
                     retry_trace["llm_user_content"] = llm_user_content
                 if isinstance(llm_context_frame, str) and llm_context_frame.strip():
@@ -451,7 +442,7 @@ class DefaultReasoner(
                         sorted(next_plan["disabled_sections"]),
                     )
                 else:
-                    logger.warning("上下文超长：所有窗口均失败，清空历史后仍超长")
+                    logger.warning("上下文超长：所有窗口均失败，请求不带历史仍超长")
                     return TurnRunResult(
                         reply="上下文过长无法处理，请尝试新建对话。",
                         context_retry=retry_trace,

--- a/tests/backend/agent/core/passive_turn/test_reasoner.py
+++ b/tests/backend/agent/core/passive_turn/test_reasoner.py
@@ -77,9 +77,10 @@ async def test_run_turn_retry_preserves_persisted_history(
             *expected_history,
             {"role": "user", "content": msg.content},
         ]
-    assert [
-        attempt["history_window"] for attempt in result.context_retry["attempts"]
-    ] == expected_windows
+    attempts = result.context_retry["attempts"]
+    assert isinstance(attempts, list)
+    assert [attempt["history_window"] for attempt in attempts] == expected_windows
+    assert isinstance(result.reply, str)
     if success_attempt is None:
         expected_reply = (
             "安全审查" if error_type is ContentSafetyError else "上下文过长"

--- a/tests/backend/agent/core/passive_turn/test_reasoner.py
+++ b/tests/backend/agent/core/passive_turn/test_reasoner.py
@@ -1,0 +1,111 @@
+from copy import deepcopy
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from agent.core.passive_turn.reasoner import DefaultReasoner
+from agent.core.runtime_support import ToolDiscoveryState
+from agent.core.types import ReasonerResult
+from agent.lifecycle.types import PromptRenderResult
+from agent.looping.ports import LLMConfig, LLMServices
+from agent.provider import ContentSafetyError, ContextLengthError
+from agent.tools.registry import ToolRegistry
+from session.manager import SessionManager
+
+
+@pytest.mark.parametrize("error_type", [ContentSafetyError, ContextLengthError])
+@pytest.mark.parametrize("last_consolidated", [0, 6])
+@pytest.mark.parametrize(
+    "success_attempt", [1, 5, 6, None], ids=["catalog", "half", "empty", "exhausted"]
+)
+async def test_run_turn_retry_preserves_persisted_history(
+    tmp_path, error_type, last_consolidated, success_attempt
+):
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("cli:retry")
+    total_messages = last_consolidated + 6
+    for index in range(total_messages):
+        role = "user" if index % 2 == 0 else "assistant"
+        if index == total_messages - 1:
+            role = "user"
+        session.add_message(role, f"message-{index}", metadata={"index": index})
+    session.last_consolidated = last_consolidated
+    session.consolidation_requested = True
+    await manager.save_async(session)
+    original_messages = deepcopy(session.messages)
+    source_history = session.get_history(start_index=last_consolidated)
+    msg = SimpleNamespace(
+        channel="cli",
+        chat_id="retry",
+        content=original_messages[-1]["content"],
+        media=[],
+        timestamp=datetime.now(timezone.utc),
+    )
+    reasoner = DefaultReasoner(
+        llm=LLMServices(provider=AsyncMock(), light_provider=AsyncMock()),
+        llm_config=LLMConfig(),
+        tools=ToolRegistry(),
+        discovery=ToolDiscoveryState(),
+        tool_search_enabled=False,
+        memory_window=40,
+        context=AsyncMock(),
+        session_manager=manager,
+    )
+    reasoner.render_prompt = AsyncMock(
+        side_effect=lambda request: PromptRenderResult(
+            messages=[
+                *request.history,
+                {"role": "user", "content": request.content},
+            ]
+        )
+    )
+    failure_count = 7 if success_attempt is None else success_attempt
+    responses = [error_type("retry required") for _ in range(failure_count)]
+    if success_attempt is not None:
+        responses.append(ReasonerResult(reply="recovered"))
+    reasoner.run = AsyncMock(side_effect=responses)
+
+    result = await reasoner.run_turn(msg=msg, session=session)
+
+    # Each request can shrink its context while the current user input remains.
+    expected_windows = [6, 6, 6, 6, 6, 3, 0][: len(responses)]
+    for call, window in zip(reasoner.run.await_args_list, expected_windows, strict=True):
+        expected_history = source_history[-window:] if window else []
+        assert call.args[0] == [
+            *expected_history,
+            {"role": "user", "content": msg.content},
+        ]
+    assert [
+        attempt["history_window"] for attempt in result.context_retry["attempts"]
+    ] == expected_windows
+    if success_attempt is None:
+        expected_reply = (
+            "安全审查" if error_type is ContentSafetyError else "上下文过长"
+        )
+        assert expected_reply in result.reply
+        assert result.context_retry["selected_plan"] is None
+    else:
+        assert result.reply == "recovered"
+        assert result.context_retry["selected_plan"] == (
+            "trim_skills_catalog"
+            if success_attempt == 1
+            else "trim_retrieved_memory_history"
+        )
+
+    # Reload independently before and after the caller persists the turn result.
+    reloaded = SessionManager(tmp_path).get_or_create(session.key)
+    assert reloaded.messages == original_messages
+    assert reloaded.last_consolidated == last_consolidated
+    assert session.messages == original_messages
+    assert session.last_consolidated == last_consolidated
+    assert session.consolidation_requested is True
+
+    session.add_message("assistant", result.reply)
+    await manager.save_async(session)
+    reloaded = SessionManager(tmp_path).get_or_create(session.key)
+    assert reloaded.messages[:-1] == original_messages
+    assert reloaded.messages[-1]["content"] == result.reply
+    assert reloaded.messages[-1]["seq"] == total_messages
+    assert reloaded.last_consolidated == last_consolidated


### PR DESCRIPTION
Closes #132

## 变更摘要

- 修复 ContentSafetyError / ContextLengthError 重试成功后永久删除会话历史的问题。窗口裁剪仅作用于当次模型请求，不再修改 session.messages、重置 last_consolidated 或触发历史全量持久化。
- 保留重试轨迹和工具发现更新，调整日志以准确描述请求窗口。
- 新增 16 个参数化回归，覆盖两类异常、仅裁技能目录、半窗口、空历史以及重试耗尽，分别验证有无已整合历史。真实 SQLite 重载验证原消息内容、ID、seq、metadata 和整合位置，并再次验证调用方追加回复后的持久化结果。

## 实际验证

- 修复前新增回归：10 failed, 6 passed，数据库重载确认 6→3/0 和 12→6/3/0。
- 使用仓库 .venv 解释器，在本分支 worktree 运行 pytest：tests/backend/agent/core/passive_turn/test_reasoner.py、tests/backend/agent/core/test_safety_retry.py、tests/backend/agent/core/test_p2_reasoner.py，37 passed。
- 对修改的 reasoner.py 和新增 test_reasoner.py 执行 Ruff：通过。
- git diff --check：通过。
- CI 测试类型检查曾报两处错误，已通过断言收窄 attempts 和 reply 类型；修正后该测试文件 Pyright 为 0 errors，16 项参数化回归全部通过，Ruff 通过。
- 修正提交 2567741c 的 GitHub CI 全部通过：后端生产与测试 Pyright、pytest，以及桌面 lint、类型检查、测试和生产构建（run 34181305668）。

## 已知阻塞项

无。此修复防止后续删除，不恢复此前已经丢失的数据库记录；本地仅运行相关测试，GitHub CI 完成仓库既定检查和桌面构建。
