### PR TITLE
fix(desktop): reject empty push payloads (#135)

### DIFF
--- a/apps/backend/agent/tools/message_push.py
+++ b/apps/backend/agent/tools/message_push.py
@@ -128,6 +128,7 @@ class MessagePushTool(Tool):
         )
 
     async def execute(self, **kwargs: Any) -> str:
+        """Sends nonblank payload fields and reports validation or transport errors."""
         if self._transport_lock is None:
             return await self._execute_send(**kwargs)
         async with self._transport_lock:
@@ -151,9 +152,9 @@ class MessagePushTool(Tool):
         if channel in self._retired_channels and not self._has_retired_transport(channel):
             return f"渠道 {channel!r} 已停用"
         requested_chat_id = str(kwargs["chat_id"])
-        message: str | None = kwargs.get("message")
-        file: str | None = kwargs.get("file")
-        image: str | None = kwargs.get("image")
+        message = _nonblank_payload(kwargs.get("message"))
+        file = _nonblank_payload(kwargs.get("file"))
+        image = _nonblank_payload(kwargs.get("image"))
         role_id = str(kwargs.get("role_id") or "").strip()
         session_key = str(kwargs.get("session_key") or "").strip()
 
@@ -240,6 +241,11 @@ class MessagePushTool(Tool):
             )
 
         return "；".join(results) if results else f"渠道 {channel!r} 没有可用的 sender"
+
+
+def _nonblank_payload(value: str | None) -> str | None:
+    # Preserve meaningful text formatting and paths; only empty fields are absent.
+    return value if value and value.strip() else None
 
 
 def _is_truthy(value: object) -> bool:

--- a/apps/backend/desktop_bridge/app_service.py
+++ b/apps/backend/desktop_bridge/app_service.py
@@ -51,11 +51,14 @@ class DesktopAppService:
         message: str = "",
         media: list[str] | None = None,
     ) -> Session:
+        """Persists a nonempty push before synchronizing desktop runtime state."""
+        normalized_message = str(message or "")
+        normalized_media = [item for item in (media or []) if str(item).strip()]
+        if not normalized_message.strip() and not normalized_media:
+            raise ValueError("desktop push 必须包含非空文本或媒体")
         session_key = self.normalize_desktop_session_key(chat_id)
         role_id = self.role_id_from_desktop_session_key(session_key)
         session = self.session_manager.get_or_create(session_key)
-        normalized_message = str(message or "")
-        normalized_media = [item for item in (media or []) if str(item).strip()]
         if self._is_existing_desktop_push(
             session,
             message=normalized_message,

--- a/tests/backend/agent/tools/test_message_push.py
+++ b/tests/backend/agent/tools/test_message_push.py
@@ -9,6 +9,57 @@ from core.common.runtime_scope import bind_runtime
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("payload", [
+    {},
+    {"message": " \t\n"},
+    {"file": "   "},
+    {"image": "   "},
+    {"message": " ", "file": "\t", "image": "\n"},
+])
+async def test_blank_payload_is_rejected_before_resolving_or_sending(payload):
+    tool = MessagePushTool()
+    send = AsyncMock()
+
+    def resolve(_chat_id):
+        raise AssertionError("empty payload must not resolve its target")
+
+    tool.register_channel(
+        "desktop", text=send, file=send, image=send, target_resolver=resolve,
+    )
+
+    result = await tool.execute(channel="desktop", chat_id="mira", **payload)
+
+    assert result == "错误：message、file、image 至少提供一个"
+    send.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("field,value", [
+    ("message", "  hello\n"),
+    ("file", "report with spaces.pdf"),
+    ("image", "https://example.test/image.png"),
+])
+async def test_only_nonblank_fields_are_sent_without_changing_content(field, value):
+    tool = MessagePushTool()
+    senders = {name: AsyncMock() for name in ("message", "file", "image")}
+    tool.register_channel(
+        "desktop", text=senders["message"], file=senders["file"], image=senders["image"],
+    )
+    payload = dict.fromkeys(senders, " \t\n")
+    payload[field] = value
+
+    result = await tool.execute(channel="desktop", chat_id="mira", **payload)
+
+    assert "已发送" in result
+    for name, sender in senders.items():
+        if name == field:
+            sender.assert_awaited_once()
+            assert sender.await_args.args[:2] == ("mira", value)
+        else:
+            sender.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_retired_transport_only_sends_for_previously_accepted_generation():
     tool = MessagePushTool()
     send = AsyncMock()

--- a/tests/backend/desktop_bridge/test_app_service.py
+++ b/tests/backend/desktop_bridge/test_app_service.py
@@ -1,0 +1,70 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from conversation.service import ConversationService
+from desktop_bridge.app_service import DesktopAppService
+from session.manager import SessionManager
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message,media", [
+    ("", None),
+    (" \t\n", []),
+    ("", ["   "]),
+    (" ", ["", "\t", "\n"]),
+])
+async def test_empty_push_has_no_session_or_runtime_side_effects(tmp_path, message, media):
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("role:mira")
+    session.add_message("assistant", "existing history")
+    await manager.save_async(session)
+    before = list(session.messages)
+    updated_at = session.updated_at
+    presence = Mock()
+    relationship = Mock()
+    conversation = Mock()
+    service = DesktopAppService(
+        role_service=SimpleNamespace(),
+        session_manager=manager,
+        conversation_service=conversation,
+        presence=presence,
+        relationship_runtime=relationship,
+    )
+
+    for chat_id in ("role:mira", "role:new"):
+        with pytest.raises(ValueError, match="非空"):
+            await service.apply_desktop_push(chat_id, message=message, media=media)
+
+    assert session.messages == before
+    assert session.updated_at == updated_at
+    assert "role:new" not in manager._cache
+    assert presence.mock_calls == []
+    assert relationship.mock_calls == []
+    assert conversation.mock_calls == []
+    reloaded = SessionManager(tmp_path)
+    assert reloaded.get_or_create("role:mira").messages == before
+    assert not reloaded._store.session_exists("role:new")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("message,media,expected_media", [
+    ("  hello\n", [" "], None),
+    ("", [" ", "image.png", "\t"], ["image.png"]),
+    ("caption", ["document.pdf"], ["document.pdf"]),
+])
+async def test_push_with_content_survives_reload(tmp_path, message, media, expected_media):
+    manager = SessionManager(tmp_path)
+    service = DesktopAppService(
+        role_service=SimpleNamespace(),
+        session_manager=manager,
+        conversation_service=ConversationService(manager),
+    )
+
+    await service.apply_desktop_push("role:mira", message=message, media=media)
+
+    reloaded = SessionManager(tmp_path).get_or_create("role:mira")
+    assert len(reloaded.messages) == 1
+    assert reloaded.messages[0]["content"] == message
+    assert reloaded.messages[0].get("media") == expected_media

--- a/tests/backend/desktop_bridge/test_service.py
+++ b/tests/backend/desktop_bridge/test_service.py
@@ -23,6 +23,39 @@ from session.manager import SessionManager
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize("field", ["image", "file"])
+@pytest.mark.parametrize("message", ["", "valid text"])
+async def test_push_tool_blank_media_cannot_create_empty_desktop_messages(
+    tmp_path, field, message,
+):
+    role_store = RoleStore(tmp_path)
+    role_store.create_role(role_id="mira", name="Mira", system_prompt="You are Mira.")
+    manager = SessionManager(tmp_path)
+    push_tool = MessagePushTool()
+    service = DesktopBridgeService(
+        workspace=tmp_path,
+        role_store=role_store,
+        session_manager=manager,
+        agent_loop=SimpleNamespace(),
+        event_bus=EventBus(),
+        push_tool=push_tool,
+    )
+    try:
+        result = await push_tool.execute(
+            channel="desktop", chat_id="mira", message=message, **{field: "   "},
+        )
+
+        persisted = SessionManager(tmp_path).get_or_create("role:mira").messages
+        assert [item["content"] for item in persisted] == ([message] if message else [])
+        if message:
+            assert result == "文本已发送"
+        else:
+            assert result == "错误：message、file、image 至少提供一个"
+    finally:
+        await service.aclose()
+
+
+@pytest.mark.asyncio
 async def test_injected_role_service_publishes_role_deleted(tmp_path) -> None:
     role_store = RoleStore(tmp_path)
     session_manager = SessionManager(tmp_path)


### PR DESCRIPTION
Closes #135

MessagePushTool previously treated whitespace-only image/file fields as sendable. The desktop bridge then removed the blank media but persisted an empty assistant message and the tool reported success. The tool now treats blank fields as absent, preserves valid content unchanged, and the desktop application boundary rejects an empty normalized payload before accessing sessions or triggering runtime effects.

Regression coverage includes the real tool -> desktop bridge -> SQLite path, mixed valid text with blank media, direct boundary rejection, and valid text/media persistence after reload. This confirms a reachable source of empty messages; it does not attribute all three historical empty bubbles to that source.

Validation:
- Before the fix, the new focused cases produced 15 failures and 4 passes, including empty SQLite messages and false send-success results.
- After the fix: 73 passed across message_push, role target validation, desktop app service, desktop service, and bridge integration tests.
- Ruff on all changed Python files and git diff --check passed.

Known blockers: none. Existing stored empty messages are not modified. This backend-only Draft PR has not run a desktop packaging build or a full repository regression.
