### PR TITLE
fix(desktop): close aborted chat turns with terminal errors

### DIFF
--- a/apps/backend/desktop_bridge/chat_completion.py
+++ b/apps/backend/desktop_bridge/chat_completion.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+from bus.events_lifecycle import TurnCommitted
+from desktop_bridge.models import BridgeEvent
+
+
+def build_chat_terminal_event(
+    *,
+    request_id: str,
+    turn_id: str,
+    session_key: str,
+    role_id: str,
+    committed: TurnCommitted | None = None,
+    failure_message: str = "",
+) -> BridgeEvent:
+    """Completes an uncommitted turn as an error without inventing a persisted reply."""
+
+    payload = {"session_key": session_key, "turn_id": turn_id}
+    if committed is None:
+        return BridgeEvent(
+            id=request_id,
+            type="event",
+            method="chat.error",
+            payload={
+                **payload,
+                "message": failure_message or "回合未完成，请重试。",
+            },
+        )
+    return BridgeEvent(
+        id=request_id,
+        type="event",
+        method="chat.done",
+        payload={
+            **payload,
+            "role_id": role_id,
+            "reply": committed.assistant_response,
+            "thinking": committed.thinking,
+            "tools_used": list(committed.tools_used),
+            "total_tokens": committed.total_tokens,
+            "thinking_duration_ms": committed.thinking_duration_ms,
+        },
+    )

--- a/apps/backend/desktop_bridge/chat_service.py
+++ b/apps/backend/desktop_bridge/chat_service.py
@@ -16,6 +16,7 @@ from bus.events_lifecycle import (
     TurnCommitted,
 )
 from desktop_bridge.models import BridgeEvent
+from desktop_bridge.chat_completion import build_chat_terminal_event
 from desktop_bridge.voice.role_tts_settings import resolve_role_tts_settings
 from desktop_bridge.tool_call_preview import truncate_desktop_tool_result
 from desktop_bridge.voice.tts_coordinator import TtsTurnCoordinator
@@ -425,6 +426,7 @@ class DesktopChatService:
     ) -> tuple[Session, list[BridgeEvent]]:
         turn_id = turn_id or request_id
         collected: list[BridgeEvent] = []
+        committed: TurnCommitted | None = None
         tts = self._create_tts_coordinator(
             request_id=request_id,
             session_key=session_key,
@@ -478,25 +480,12 @@ class DesktopChatService:
                 tts.push(event.content_delta)
 
         async def _on_done(event: TurnCommitted) -> None:
+            nonlocal committed
             if event.session_key != session_key:
                 return
-            bridge_event = BridgeEvent(
-                id=request_id,
-                type="event",
-                method="chat.done",
-                payload={
-                    "session_key": event.session_key,
-                    "turn_id": turn_id,
-                    "role_id": self._role_id_from_session_key(event.session_key),
-                    "reply": event.assistant_response,
-                    "thinking": event.thinking,
-                    "tools_used": list(event.tools_used),
-                    "total_tokens": event.total_tokens,
-                    "thinking_duration_ms": event.thinking_duration_ms,
-                },
-            )
-            collected.append(bridge_event)
-            await self._emit_payload(emit_event, bridge_event.to_dict())
+            # Later lifecycle modules and session synchronization can still fail.
+            # Resolve the terminal event only after all awaited turn work succeeds.
+            committed = event
             if (
                 tts is not None
                 and not tts_received_streamed_content
@@ -563,7 +552,7 @@ class DesktopChatService:
             self._event_bus.on(ToolCallCompleted, _on_tool_completed)
         self._event_bus.on(TurnCommitted, _on_done)
         try:
-            _ = await self._agent_loop.process_direct(
+            reply = await self._agent_loop.process_direct(
                 content,
                 session_key=session_key,
                 channel="desktop",
@@ -582,11 +571,26 @@ class DesktopChatService:
             role_id = self._role_id_from_session_key(session_key)
             if role_id:
                 self._sync_desktop_session_thread(session, role_id=role_id)
+            # Prepare the durable session update before reporting success, while
+            # retaining chat.done -> session.updated ordering for the renderer.
+            session_events: list[dict[str, Any]] = []
             await self._emit_session_updated(
                 request_id=request_id,
                 session=session,
-                emit_event=emit_event,
+                emit_event=session_events.append,
             )
+            bridge_event = build_chat_terminal_event(
+                request_id=request_id,
+                turn_id=turn_id,
+                session_key=session_key,
+                role_id=role_id,
+                committed=committed,
+                failure_message=reply,
+            )
+            collected.append(bridge_event)
+            await self._emit_payload(emit_event, bridge_event.to_dict())
+            for event in session_events:
+                await self._emit_payload(emit_event, event)
             return session, collected
         except asyncio.CancelledError:
             if tts is not None:
@@ -601,15 +605,12 @@ class DesktopChatService:
                     tts,
                     announce=_announce_voice_reply,
                 )
-            bridge_event = BridgeEvent(
-                id=request_id,
-                type="event",
-                method="chat.error",
-                payload={
-                    "session_key": session_key,
-                    "turn_id": turn_id,
-                    "message": str(exc),
-                },
+            bridge_event = build_chat_terminal_event(
+                request_id=request_id,
+                turn_id=turn_id,
+                session_key=session_key,
+                role_id="",
+                failure_message=str(exc),
             )
             collected.append(bridge_event)
             await self._emit_payload(emit_event, bridge_event.to_dict())

--- a/tests/backend/desktop_bridge/test_chat_completion.py
+++ b/tests/backend/desktop_bridge/test_chat_completion.py
@@ -1,0 +1,42 @@
+from bus.events_lifecycle import TurnCommitted
+from desktop_bridge.chat_completion import build_chat_terminal_event
+
+
+def test_uncommitted_empty_reply_has_a_visible_error():
+    event = build_chat_terminal_event(
+        request_id="request-1",
+        turn_id="turn-1",
+        session_key="role:mira",
+        role_id="mira",
+    )
+
+    assert event.method == "chat.error"
+    assert event.payload == {
+        "session_key": "role:mira",
+        "turn_id": "turn-1",
+        "message": "回合未完成，请重试。",
+    }
+
+
+def test_committed_empty_reply_is_still_a_successful_turn():
+    event = build_chat_terminal_event(
+        request_id="request-1",
+        turn_id="turn-1",
+        session_key="role:mira",
+        role_id="mira",
+        committed=TurnCommitted(
+            session_key="role:mira",
+            channel="desktop",
+            chat_id="role:mira",
+            input_message="hello",
+            persisted_user_message=None,
+            assistant_response="",
+            tools_used=["message_push"],
+            total_tokens=120,
+        ),
+    )
+
+    assert event.method == "chat.done"
+    assert event.payload["reply"] == ""
+    assert event.payload["tools_used"] == ["message_push"]
+    assert event.payload["total_tokens"] == 120

--- a/tests/backend/desktop_bridge/test_chat_service.py
+++ b/tests/backend/desktop_bridge/test_chat_service.py
@@ -967,6 +967,74 @@ async def test_cancelled_chat_task_terminates_voice_lifecycle() -> None:
     with pytest.raises(asyncio.CancelledError):
         await task
 
+    assert not any(event["method"] in {"chat.done", "chat.error"} for event in emitted)
     assert [
         event["method"] for event in emitted if event["method"].startswith("voice.")
     ] == ["voice.reply.started", "voice.tts.finished"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_stage", [None, "after_commit", "session_update"])
+async def test_chat_terminal_waits_for_turn_and_session_work(failure_stage):
+    event_bus = EventBus()
+    emitted = []
+    service = None
+
+    async def process_direct(*_args, **_kwargs):
+        await event_bus.fanout(TurnCommitted(
+            session_key="role:mira",
+            channel="desktop",
+            chat_id="role:mira",
+            input_message="hello",
+            persisted_user_message=None,
+            assistant_response="answer",
+            tools_used=[],
+        ))
+        assert emitted == []
+        if failure_stage == "after_commit":
+            raise RuntimeError("after_commit failed")
+        return "answer"
+
+    async def emit_session_updated(*, request_id, session, emit_event):
+        assert emitted == []
+        if failure_stage == "session_update":
+            raise RuntimeError("session_update failed")
+        emit_event({"method": "session.updated", "payload": {"session_key": session.key}})
+
+    def collect(payload):
+        assert not service.is_busy("role:mira")
+        emitted.append(payload)
+
+    async def emit_payload(emit_event, payload):
+        result = emit_event(payload)
+        if result is not None:
+            await result
+
+    service = DesktopChatService(
+        agent_loop=SimpleNamespace(process_direct=process_direct),
+        event_bus=event_bus,
+        session_manager=SimpleNamespace(get_or_create=Mock(return_value=Session(key="role:mira"))),
+        role_id_from_session_key=lambda _key: "mira",
+        sync_desktop_session_thread=Mock(),
+        emit_payload=emit_payload,
+        emit_session_updated=emit_session_updated,
+    )
+    service.start_chat_turn(
+        request_id="request-1",
+        turn_id="turn-1",
+        session_key="role:mira",
+        content="hello",
+        media=[],
+        metadata={},
+        omit_user_turn=True,
+        emit_event=collect,
+    )
+    await service.drain()
+
+    assert [event["method"] for event in emitted] == (
+        ["chat.error"] if failure_stage else ["chat.done", "session.updated"]
+    )
+    assert emitted[0]["payload"]["turn_id"] == "turn-1"
+    if failure_stage:
+        assert emitted[0]["payload"]["message"] == f"{failure_stage} failed"
+    assert event_bus._handlers == {}

--- a/tests/backend/desktop_bridge/test_chat_service_integration.py
+++ b/tests/backend/desktop_bridge/test_chat_service_integration.py
@@ -2,15 +2,121 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import Mock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
+from agent.core.passive_turn.pipeline import AgentCoreDeps, PassiveTurnPipeline
+from agent.core.types import ContextBundle
+from agent.lifecycle.types import BeforeReasoningCtx, BeforeTurnCtx
 from agent.looping.interrupt import TurnInterruptState
+from agent.tools.registry import ToolRegistry
 from bus.event_bus import EventBus
+from bus.events import InboundMessage
 from desktop_bridge.chat_service import DesktopChatService
 from session.manager import SessionManager
 from session.manager.models import INTERRUPTED_TURN_METADATA_KEY
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exit_path", ["before_turn", "before_reasoning", "provider_error"])
+async def test_pipeline_early_exit_emits_one_error_and_releases_desktop_turn(
+    tmp_path, exit_path
+):
+    session_manager = SessionManager(tmp_path)
+    event_bus = EventBus()
+    reasoner = SimpleNamespace(run_turn=AsyncMock(side_effect=RuntimeError("provider down")))
+    pipeline = PassiveTurnPipeline(
+        AgentCoreDeps(
+            session=SimpleNamespace(session_manager=session_manager),
+            context_store=SimpleNamespace(prepare=AsyncMock(return_value=ContextBundle())),
+            context=Mock(),
+            tools=ToolRegistry(),
+            reasoner=reasoner,
+            event_bus=event_bus,
+        )
+    )
+
+    def abort(ctx):
+        ctx.abort = True
+        ctx.abort_reply = "This turn was blocked."
+
+    if exit_path != "provider_error":
+        event_bus.on(
+            BeforeTurnCtx if exit_path == "before_turn" else BeforeReasoningCtx, abort
+        )
+
+    class _Loop:
+        async def process_direct(self, content, *, session_key, channel, chat_id, **_kwargs):
+            outbound = await pipeline.run(
+                InboundMessage(
+                    channel=channel, sender="user", chat_id=chat_id, content=content
+                ),
+                session_key,
+                dispatch_outbound=False,
+            )
+            return outbound.content
+
+    emitted = []
+    busy_on_terminal = []
+
+    def collect(payload):
+        if payload["method"] in {"chat.done", "chat.error"}:
+            busy_on_terminal.append(service.is_busy("role:mira"))
+        emitted.append(payload)
+
+    async def emit_payload(emit_event, payload):
+        result = emit_event(payload)
+        if result is not None:
+            await result
+
+    async def emit_session_updated(*, request_id, session, emit_event):
+        await emit_payload(
+            emit_event,
+            {
+                "id": request_id,
+                "method": "session.updated",
+                "payload": {"session_key": session.key},
+            },
+        )
+
+    service = DesktopChatService(
+        agent_loop=_Loop(),
+        event_bus=event_bus,
+        session_manager=session_manager,
+        role_id_from_session_key=lambda _key: "mira",
+        sync_desktop_session_thread=lambda _session, *, role_id: None,
+        emit_payload=emit_payload,
+        emit_session_updated=emit_session_updated,
+    )
+    for index in range(2):
+        service.start_chat_turn(
+            request_id=f"request-{index}",
+            turn_id=f"turn-{index}",
+            session_key="role:mira",
+            content="hello",
+            media=[],
+            metadata={},
+            omit_user_turn=True,
+            emit_event=collect,
+        )
+        await service.drain()
+
+    terminals = [event for event in emitted if event["method"] in {"chat.done", "chat.error"}]
+    assert [event["method"] for event in terminals] == ["chat.error", "chat.error"]
+    assert [event["payload"]["turn_id"] for event in terminals] == ["turn-0", "turn-1"]
+    expected = (
+        "处理消息时出错，请稍后再试。"
+        if exit_path == "provider_error"
+        else "This turn was blocked."
+    )
+    assert all(event["payload"]["message"] == expected for event in terminals)
+    assert busy_on_terminal == [False, False]
+    assert len([event for event in emitted if event["method"] == "session.updated"]) == 2
+    assert not service.is_busy("role:mira")
+    assert session_manager.get_or_create("role:mira").messages == []
+    assert SessionManager(tmp_path).get_or_create("role:mira").messages == []
+    assert reasoner.run_turn.await_count == (2 if exit_path == "provider_error" else 0)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Closes #133

When BeforeTurn or BeforeReasoning aborts, or the reasoner returns a provider-error reply, the pipeline skips TurnCommitted. DesktopChatService now completes those turns with chat.error carrying the returned message, so the renderer clears its sending state automatically. Previously the backend was idle and the stop button could recover the UI manually; no restart was required.

Terminal-event construction lives in a dedicated helper. Successful completion waits for process_direct and session-update preparation, preventing an early chat.done followed by chat.error if later turn work fails. The existing chat.done -> session.updated order, release-before-terminal behavior, and cancellation response contract are preserved. No assistant message is invented or persisted for an aborted turn.

Validation:
- Regression first reproduced all three pipeline exits with no terminal events (3 failed before the fix).
- Repository .venv: 57 tests passed across test_chat_completion.py, test_chat_service.py, test_chat_service_integration.py, and test_integration.py.
- Final integration-file rerun: 5 passed, including SQLite reload and an immediate subsequent turn for each early-exit path.
- Ruff passed for all five changed Python files; py_compile passed for both production modules; git diff --check passed.
- Coverage includes normal completion, empty committed/uncommitted replies, post-commit and session-update failures, listener cleanup, cancellation, and voice behavior.

Known blockers: none. Backend-only change; no desktop frontend build was needed. PR remains Draft for review.
