### PR TITLE
fix(scheduler): prevent duplicate desktop task deliveries

### DIFF
--- a/apps/backend/agent/scheduler.py
+++ b/apps/backend/agent/scheduler.py
@@ -616,6 +616,7 @@ class SchedulerService:
                     chat_id=job.chat_id,
                     message=job.message,
                     role_id=job.role_id,
+                    push_delivery_key=self._job_role_metadata(job)["delivery_key"],
                 ),
             )
             logger.info(f"[scheduler] instant 推送完成 {label!r}: {result}")
@@ -651,6 +652,8 @@ class SchedulerService:
                         chat_id=job.chat_id,
                         message=content,
                         role_id=job.role_id,
+                        push_delivery_key=self._job_role_metadata(job)["delivery_key"],
+                        push_message_already_persisted=True,
                     ),
                 )
                 logger.info(f"[scheduler] soft 推送完成 {label!r}: {result}")
@@ -673,7 +676,9 @@ class SchedulerService:
             "role_id": job.role_id,
             "role_config_version": job.role_config_version,
             "thread_id": job.thread_id or f"thread:{job.role_id}:scheduler:{job.id}",
-            "delivery_key": job.delivery_key or job.id,
+            # The creating turn may own several jobs. Identify this job occurrence,
+            # keeping nominal fire time stable across retries and process restarts.
+            "delivery_key": f"scheduler:{job.id}:{job.fire_at.isoformat()}",
             "transport_channel": job.channel,
             "transport_chat_id": job.chat_id,
             "role_source": "scheduler",

--- a/apps/backend/agent/tools/message_push.py
+++ b/apps/backend/agent/tools/message_push.py
@@ -101,6 +101,9 @@ class MessagePushTool(Tool):
         file: Callable[[str, str, str | None], Awaitable[None]] | None = None,
         image: Callable[[str, str], Awaitable[None]] | None = None,
         target_resolver: Callable[[str], str] | None = None,
+        text_with_metadata: (
+            Callable[[str, str, dict[str, object]], Awaitable[None]] | None
+        ) = None,
     ) -> None:
         """注册渠道的各类 sender。
         - text(chat_id, message)
@@ -108,6 +111,7 @@ class MessagePushTool(Tool):
         - file(chat_id, file_path, name=None)
         - image(chat_id, image_path_or_url)
         - target_resolver(chat_id) -> canonical chat_id
+        - text_with_metadata(chat_id, message, metadata) preserves delivery ownership
         """
         self._senders[channel] = {}
         self._retired_channels.discard(channel)
@@ -115,6 +119,8 @@ class MessagePushTool(Tool):
             self._senders[channel]["text"] = text
         if stream_text:
             self._senders[channel]["stream_text"] = stream_text
+        if text_with_metadata:
+            self._senders[channel]["text_with_metadata"] = text_with_metadata
         if file:
             self._senders[channel]["file"] = file
         if image:
@@ -184,9 +190,25 @@ class MessagePushTool(Tool):
         results: list[str] = []
         image_sent = False
         try:
-            if message and ("text" in senders or "stream_text" in senders):
-                sender_name = "stream_text" if "stream_text" in senders else "text"
-                await senders[sender_name](chat_id, message)
+            if message and any(
+                name in senders for name in ("text_with_metadata", "stream_text", "text")
+            ):
+                if "text_with_metadata" in senders:
+                    await senders["text_with_metadata"](
+                        chat_id,
+                        message,
+                        {
+                            "delivery_key": str(
+                                kwargs.get("push_delivery_key") or ""
+                            ).strip(),
+                            "already_persisted": _is_truthy(
+                                kwargs.get("push_message_already_persisted")
+                            ),
+                        },
+                    )
+                else:
+                    sender_name = "stream_text" if "stream_text" in senders else "text"
+                    await senders[sender_name](chat_id, message)
                 preview = message[:60] + "..." if len(message) > 60 else message
                 logger.info(f"[message_push] {channel}:{chat_id} ← text: {preview!r}")
                 results.append("文本已发送")

--- a/apps/backend/desktop_bridge/app_service.py
+++ b/apps/backend/desktop_bridge/app_service.py
@@ -50,22 +50,32 @@ class DesktopAppService:
         *,
         message: str = "",
         media: list[str] | None = None,
+        delivery_key: str = "",
+        already_persisted: bool = False,
     ) -> Session:
+        """Persists new pushes; committed turn deliveries only refresh their session."""
         session_key = self.normalize_desktop_session_key(chat_id)
         role_id = self.role_id_from_desktop_session_key(session_key)
         session = self.session_manager.get_or_create(session_key)
         normalized_message = str(message or "")
         normalized_media = [item for item in (media or []) if str(item).strip()]
+        if already_persisted:
+            # A turn commit owns this message. A missing commit is an error, not
+            # permission for the transport to become a second persistence owner.
+            if not delivery_key or not self._has_delivery(session, delivery_key):
+                raise ValueError("Desktop push references an uncommitted delivery")
+            return await self._finish_desktop_push(session, role_id=role_id)
         if self._is_existing_desktop_push(
             session,
             message=normalized_message,
             media=normalized_media,
+            delivery_key=delivery_key,
         ):
             return session
         original_length = len(session.messages)
         original_updated_at = session.updated_at
         message_metadata = self.build_desktop_user_message_metadata(
-            None,
+            {"delivery_key": delivery_key} if delivery_key else None,
             role_id=role_id,
             chat_id=session.key,
         )
@@ -83,6 +93,9 @@ class DesktopAppService:
             del session.messages[original_length:]
             session.updated_at = original_updated_at
             raise
+        return await self._finish_desktop_push(session, role_id=role_id)
+
+    async def _finish_desktop_push(self, session: Session, *, role_id: str) -> Session:
         self.sync_desktop_session_thread(session, role_id=role_id)
         return await self._apply_post_persist_runtime_effects(
             session,
@@ -201,12 +214,23 @@ class DesktopAppService:
         return session
 
     @staticmethod
+    def _has_delivery(session: Session, delivery_key: str) -> bool:
+        return any(
+            item.get("role") == "assistant"
+            and (item.get("metadata") or {}).get("delivery_key") == delivery_key
+            for item in session.messages
+        )
+
+    @staticmethod
     def _is_existing_desktop_push(
         session: Session,
         *,
         message: str,
         media: list[str],
+        delivery_key: str = "",
     ) -> bool:
+        if delivery_key:
+            return DesktopAppService._has_delivery(session, delivery_key)
         if not session.messages:
             return False
         last_message = session.messages[-1]

--- a/apps/backend/desktop_bridge/service.py
+++ b/apps/backend/desktop_bridge/service.py
@@ -373,11 +373,14 @@ class DesktopBridgeService:
             *,
             message: str = "",
             media: list[str] | None = None,
+            metadata: dict[str, object] | None = None,
         ) -> None:
             session = await self.app_service.apply_desktop_push(
                 chat_id,
                 message=message,
                 media=media,
+                delivery_key=str((metadata or {}).get("delivery_key") or ""),
+                already_persisted=(metadata or {}).get("already_persisted") is True,
             )
             await self._broadcast_session_updated(
                 request_id="proactive", session=session
@@ -385,8 +388,8 @@ class DesktopBridgeService:
 
         push_tool.register_channel(
             "desktop",
-            text=lambda chat_id, message: _emit_session_for_chat(
-                chat_id, message=message
+            text_with_metadata=lambda chat_id, message, metadata: _emit_session_for_chat(
+                chat_id, message=message, metadata=metadata
             ),
             file=lambda chat_id, file_path, _name=None: _emit_session_for_chat(
                 chat_id, media=[file_path]

--- a/tests/backend/agent/test_scheduler.py
+++ b/tests/backend/agent/test_scheduler.py
@@ -1,11 +1,26 @@
 from __future__ import annotations
 
+import asyncio
 import json
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
-from agent.scheduler import JobStore
+from agent.looping.core import AgentLoop
+from agent.looping.ports import AgentLoopConfig, AgentLoopDeps, MemoryServices
+from agent.provider import LLMResponse
+from agent.scheduler import JobStore, SchedulerService
+from agent.tools.message_push import MessagePushTool
+from agent.tools.registry import ToolRegistry
+from bus.event_bus import EventBus
+from bus.queue import MessageBus
+from core.roles import RoleRepository, RoleRuntimeRegistry, RoleStore
+from core.roles.model_runtime import RoleModelRuntime, RoleModelSnapshot
+from desktop_bridge import DesktopBridgeService
+from session.manager import SessionManager
+from tests.backend.conftest import make_job
 
 
 def test_job_store_raises_for_invalid_json(tmp_path: Path):
@@ -22,3 +37,126 @@ def test_job_store_raises_for_invalid_job_payload(tmp_path: Path):
 
     with pytest.raises((KeyError, TypeError, ValueError)):
         JobStore(path).load()
+
+
+@pytest.mark.parametrize("trigger", ["at", "every"])
+def test_delivery_identity_is_per_job_and_survives_job_store_reload(tmp_path, trigger):
+    scheduler = SchedulerService(
+        store_path=tmp_path / "jobs.json", push_tool=MagicMock()
+    )
+    now = datetime(2026, 9, 8, tzinfo=timezone.utc)
+    jobs = [make_job(trigger=trigger, fire_at=now) for _ in range(2)]
+    for job in jobs:
+        job.delivery_key = "shared-creating-turn"
+    keys = [scheduler._job_role_metadata(job)["delivery_key"] for job in jobs]
+    assert len(set(keys)) == 2
+    assert "shared-creating-turn" not in keys
+    scheduler.store.save({job.id: job for job in jobs})
+    assert [
+        scheduler._job_role_metadata(job)["delivery_key"]
+        for job in scheduler.store.load()
+    ] == keys
+
+
+@pytest.mark.parametrize("tier", ["soft", "instant"])
+async def test_recurring_desktop_delivery_persists_once_per_occurrence(tmp_path, tier):
+    role_store = RoleStore(tmp_path)
+    role_store.create_role(role_id="mira", name="Mira", system_prompt="test")
+    sessions = SessionManager(tmp_path)
+    event_bus = EventBus()
+    provider = MagicMock()
+    provider.chat = AsyncMock(
+        return_value=LLMResponse(content="scheduled reply", tool_calls=[])
+    )
+    memory = MagicMock()
+    memory.read_self.return_value = ""
+    memory.read_recent_context.return_value = ""
+    memory.get_memory_context.return_value = ""
+    memory.has_long_term_memory.return_value = False
+    model_runtime = RoleModelRuntime(role_store=role_store, registrations=[])
+    model_runtime.resolve = MagicMock(
+        return_value=RoleModelSnapshot(
+            registration_id="test",
+            provider=provider,
+            model="test",
+            effort="none",
+            role_id="mira",
+        )
+    )
+    loop = AgentLoop(
+        AgentLoopDeps(
+            bus=MessageBus(),
+            provider=provider,
+            tools=ToolRegistry(),
+            session_manager=sessions,
+            workspace=tmp_path,
+            event_bus=event_bus,
+            memory_services=MemoryServices(engine=memory),
+            role_runtime_registry=RoleRuntimeRegistry(
+                RoleRepository(role_store), model_resolver=model_runtime
+            ),
+        ),
+        AgentLoopConfig(),
+    )
+    push = MessagePushTool()
+    bridge = DesktopBridgeService(
+        workspace=tmp_path,
+        role_store=role_store,
+        session_manager=sessions,
+        agent_loop=loop,
+        event_bus=event_bus,
+        push_tool=push,
+    )
+    emitted = []
+    bridge.add_event_listener(emitted.append)
+    now = datetime(2026, 9, 8, tzinfo=timezone.utc)
+    scheduler = SchedulerService(
+        store_path=tmp_path / "jobs.json",
+        push_tool=push,
+        agent_loop=loop,
+        _now_fn=lambda: now,
+    )
+    job = make_job(
+        tier=tier,
+        trigger="every",
+        interval_seconds=60,
+        fire_at=now,
+        channel="desktop",
+        chat_id="role:mira",
+        message="scheduled reply",
+        prompt="Send the scheduled reply",
+    )
+    scheduler._jobs[job.id] = job
+    delivery_keys = []
+    for occurrence in range(2):
+        delivery_key = scheduler._job_role_metadata(job)["delivery_key"]
+        delivery_keys.append(delivery_key)
+        await scheduler._tick()
+        await asyncio.gather(*scheduler._active_tasks.values())
+        persisted = SessionManager(tmp_path).get_or_create("role:mira").messages
+        assert len(persisted) == occurrence + 1
+        assert [item["content"] for item in persisted] == ["scheduled reply"] * (
+            occurrence + 1
+        )
+        assert persisted[-1]["metadata"]["delivery_key"] == delivery_key
+        assert emitted[-1]["method"] == "session.updated"
+        now = job.fire_at + timedelta(seconds=1)
+
+    assert delivery_keys[0] != delivery_keys[1]
+    assert [item["seq"] for item in persisted] == [0, 1]
+    # Replay the first delivery after a later occurrence: it is no longer last.
+    for _ in range(2):
+        result = await push.execute(
+            channel="desktop",
+            chat_id="role:mira",
+            message="scheduled reply",
+            push_delivery_key=delivery_keys[0],
+            push_message_already_persisted=tier == "soft",
+        )
+        assert "已发送" in result
+    assert len(SessionManager(tmp_path).get_or_create("role:mira").messages) == 2
+    if tier == "soft":
+        assert provider.chat.await_count == 2
+    else:
+        provider.chat.assert_not_awaited()
+    await bridge.aclose()

--- a/tests/backend/agent/test_scheduler_service.py
+++ b/tests/backend/agent/test_scheduler_service.py
@@ -55,7 +55,8 @@ async def test_instant_push_receives_correct_args(
     await drain_tasks()
 
     mock_push.execute.assert_called_once_with(
-        channel="telegram", chat_id="999", message="喝水了", role_id="mira"
+        channel="telegram", chat_id="999", message="喝水了", role_id="mira",
+        push_delivery_key=svc._job_role_metadata(job)["delivery_key"],
     )
 
 
@@ -115,6 +116,8 @@ async def test_soft_sends_ai_response_via_push(
         chat_id=job.chat_id,
         message="北京今天晴，15°C",
         role_id="mira",
+        push_delivery_key=svc._job_role_metadata(job)["delivery_key"],
+        push_message_already_persisted=True,
     )
 
 
@@ -564,7 +567,7 @@ def test_legacy_role_job_metadata_gets_stable_context_defaults(
     metadata = svc._job_role_metadata(job)
 
     assert metadata["thread_id"] == f"thread:mira:scheduler:{job.id}"
-    assert metadata["delivery_key"] == job.id
+    assert metadata["delivery_key"] == f"scheduler:{job.id}:{job.fire_at.isoformat()}"
     assert metadata["role_work_kind"] == "scheduled_job"
 
 

--- a/tests/backend/agent/tools/test_message_push.py
+++ b/tests/backend/agent/tools/test_message_push.py
@@ -23,3 +23,39 @@ async def test_retired_transport_only_sends_for_previously_accepted_generation()
         result = await tool.execute(channel="telegram", chat_id="one", message="new")
     send.assert_awaited_once_with("one", "accepted")
     assert "已停用" in result
+
+
+@pytest.mark.parametrize("sender_name", ["text", "stream_text"])
+async def test_delivery_metadata_keeps_legacy_senders_compatible(sender_name):
+    tool = MessagePushTool()
+    sender = AsyncMock()
+    tool.register_channel("telegram", **{sender_name: sender})
+
+    result = await tool.execute(
+        channel="telegram", chat_id="one", message="scheduled",
+        push_delivery_key="occurrence", push_message_already_persisted=True,
+    )
+
+    sender.assert_awaited_once_with("one", "scheduled")
+    assert "已发送" in result
+
+
+async def test_metadata_sender_uses_push_identity_not_shared_turn_identity():
+    tool = MessagePushTool()
+    sender = AsyncMock()
+    tool.register_channel("desktop", text_with_metadata=sender)
+
+    await tool.execute(
+        channel="desktop", chat_id="one", message="first", delivery_key="turn",
+    )
+    sender.assert_awaited_once_with("one", "first", {
+        "delivery_key": "", "already_persisted": False,
+    })
+    sender.reset_mock()
+    await tool.execute(
+        channel="desktop", chat_id="one", message="second", delivery_key="turn",
+        push_delivery_key="occurrence", push_message_already_persisted=True,
+    )
+    sender.assert_awaited_once_with("one", "second", {
+        "delivery_key": "occurrence", "already_persisted": True,
+    })

--- a/tests/backend/desktop_bridge/test_service.py
+++ b/tests/backend/desktop_bridge/test_service.py
@@ -22,6 +22,29 @@ from desktop_bridge.voice.voice_service import (
 from session.manager import SessionManager
 
 
+@pytest.mark.parametrize("delivery_key", ["", "missing"])
+async def test_registered_committed_push_requires_its_original_message(tmp_path, delivery_key):
+    role_store = RoleStore(tmp_path)
+    role_store.create_role(role_id="mira", name="Mira", system_prompt="test")
+    sessions = SessionManager(tmp_path)
+    push = MessagePushTool()
+    service = DesktopBridgeService(
+        workspace=tmp_path, role_store=role_store, session_manager=sessions,
+        agent_loop=SimpleNamespace(), event_bus=EventBus(), push_tool=push,
+    )
+    emitted = []
+    service.add_event_listener(emitted.append)
+    result = await push.execute(
+        channel="desktop", chat_id="role:mira", message="uncommitted",
+        push_delivery_key=delivery_key, push_message_already_persisted=True,
+    )
+    assert "发送失败" in result
+    assert "uncommitted delivery" in result
+    assert SessionManager(tmp_path).get_or_create("role:mira").messages == []
+    assert emitted == []
+    await service.aclose()
+
+
 @pytest.mark.asyncio
 async def test_injected_role_service_publishes_role_deleted(tmp_path) -> None:
     role_store = RoleStore(tmp_path)


### PR DESCRIPTION
Closes #134

The shared desktop entrypoint validates empty payloads before inspecting committed delivery ownership. The prerequisite empty-payload fix in #142 is merged; this PR now targets main.

Scheduled role replies were persisted by the agent turn and appended again by the desktop push transport, producing identical content at different sequence numbers. The scheduler now passes an explicit committed-delivery marker and occurrence identity through an optional metadata-aware text sender. Desktop delivery validates the original committed message and refreshes the session without appending it again; instant pushes retain desktop persistence ownership.

Delivery identities include the job ID and nominal fire time. Retries remain stable across job-store reloads, separate executions of recurring jobs stay distinct, and jobs created by the same parent turn cannot collide. Ordinary tools do not reuse their shared turn identity as a push identity, and existing text/stream senders keep their original signatures.

Validation:
- 113 passed after combining #134 and #135: `tests/backend/agent/test_scheduler.py`, `test_scheduler_service.py`, `tools/test_message_push.py`, `tools/test_message_push_role_target.py`, `tests/backend/desktop_bridge/test_integration.py`, `test_service.py`, and `test_app_service.py`, using the repository `.venv` interpreter with this worktree's backend on `PYTHONPATH`.
- The scheduler regression runs the real Scheduler, AgentLoop, desktop bridge, and SQLite with a stubbed model response. Both soft and instant jobs run two occurrences, reload SQLite, and replay the older delivery twice without adding rows.
- Ruff checks passed for all nine Python files changed by the combined fixes; `git diff --check` passed.
- No frontend build was needed for this backend-only change. No full-suite regression was run.

CI: backend checks and tests, desktop lint, typecheck, tests, and production build passed for the submitted head.

Known blockers: none. Existing duplicate history is not deleted or migrated.
