### PR TITLE
fix(desktop): return the persisted user message for chat.send

### DIFF
--- a/apps/backend/desktop_bridge/app_service.py
+++ b/apps/backend/desktop_bridge/app_service.py
@@ -121,7 +121,8 @@ class DesktopAppService:
         content: str,
         media: list[str],
         metadata: dict[str, object] | None,
-    ) -> Session:
+    ) -> dict[str, Any]:
+        """Persists a user message and returns it after all runtime effects finish."""
         original_length = len(session.messages)
         original_updated_at = session.updated_at
         session.add_message(
@@ -134,14 +135,16 @@ class DesktopAppService:
                 chat_id=session.key,
             ),
         )
+        # Other writers can append while persistence or runtime effects await.
+        persisted_message = session.messages[original_length]
         try:
-            await self.session_manager.append_messages(session, session.messages[-1:])
+            await self.session_manager.append_messages(session, [persisted_message])
         except Exception:
             del session.messages[original_length:]
             session.updated_at = original_updated_at
             raise
         self.sync_desktop_session_thread(session, role_id=role_id)
-        return await self._apply_post_persist_runtime_effects(
+        _ = await self._apply_post_persist_runtime_effects(
             session,
             record_presence=(
                 self.presence.record_user_message if self.presence is not None else None
@@ -152,6 +155,7 @@ class DesktopAppService:
                 else None
             ),
         )
+        return persisted_message
 
     def build_desktop_user_message_metadata(
         self,

--- a/apps/backend/desktop_bridge/chat_requests.py
+++ b/apps/backend/desktop_bridge/chat_requests.py
@@ -108,7 +108,7 @@ class DesktopChatRequestHandler:
             role_id=aggregate.role.id,
             chat_id=session.key,
         )
-        await self._app_service.persist_desktop_user_message(
+        persisted_message = await self._app_service.persist_desktop_user_message(
             session=session,
             role_id=aggregate.role.id,
             content=content,
@@ -127,7 +127,7 @@ class DesktopChatRequestHandler:
         )
         return {
             "session": self._session_presenter.serialize_summary(session),
-            "message": self._session_presenter.serialize_message(session.messages[-1]),
+            "message": self._session_presenter.serialize_message(persisted_message),
             "turn_id": turn_id,
             "events": [],
         }

--- a/tests/backend/desktop_bridge/test_app_service.py
+++ b/tests/backend/desktop_bridge/test_app_service.py
@@ -1,3 +1,4 @@
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -68,3 +69,71 @@ async def test_push_with_content_survives_reload(tmp_path, message, media, expec
     assert len(reloaded.messages) == 1
     assert reloaded.messages[0]["content"] == message
     assert reloaded.messages[0].get("media") == expected_media
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("pause_at", ["append_messages", "save_async"])
+async def test_persist_user_message_keeps_identity_across_concurrent_append(
+    tmp_path, monkeypatch, pause_at,
+):
+    manager = SessionManager(tmp_path)
+    session = manager.get_or_create("role:mira")
+    presence = Mock()
+    relationship = Mock()
+    relationship.enrich_session_metadata.return_value = {"relationship": "updated"}
+    service = DesktopAppService(
+        role_service=SimpleNamespace(),
+        session_manager=manager,
+        conversation_service=ConversationService(manager),
+        presence=presence,
+        relationship_runtime=relationship,
+    )
+    entered = asyncio.Event()
+    resume = asyncio.Event()
+    original_operation = getattr(manager, pause_at)
+    append_messages = manager.append_messages
+
+    async def paused_operation(*args):
+        # Inject a scheduling boundary; this tests the async return contract,
+        # without assuming the default persistence implementation yields here.
+        entered.set()
+        await resume.wait()
+        await original_operation(*args)
+
+    monkeypatch.setattr(manager, pause_at, paused_operation)
+    task = asyncio.create_task(service.persist_desktop_user_message(
+        session=session,
+        role_id="mira",
+        content="my message",
+        media=["photo.png"],
+        metadata={"client_message_id": "client-user", "turn_id": "turn-user"},
+    ))
+    try:
+        await asyncio.wait_for(entered.wait(), timeout=2)
+        user_message = session.messages[0]
+        assert not task.done()
+        session.add_message("assistant", "proactive reply", proactive=True)
+        assistant_message = session.messages[-1]
+        await append_messages(session, [assistant_message])
+        resume.set()
+        persisted = await asyncio.wait_for(task, timeout=2)
+    finally:
+        if not task.done():
+            task.cancel()
+        await asyncio.gather(task, return_exceptions=True)
+
+    assert persisted is user_message
+    assert persisted["id"] != assistant_message["id"]
+    assert isinstance(persisted["seq"], int)
+    assert persisted["role"] == "user"
+    assert persisted["content"] == "my message"
+    assert persisted["media"] == ["photo.png"]
+    assert persisted["metadata"]["client_message_id"] == "client-user"
+    assert persisted["metadata"]["turn_id"] == "turn-user"
+    presence.record_user_message.assert_called_once_with(session.key)
+    relationship.handle_user_message.assert_called_once_with(session.key)
+    reloaded = SessionManager(tmp_path).get_or_create(session.key)
+    assert reloaded.metadata["relationship"] == "updated"
+    assert {message["id"] for message in reloaded.messages} == {
+        persisted["id"], assistant_message["id"],
+    }

--- a/tests/backend/desktop_bridge/test_chat_requests.py
+++ b/tests/backend/desktop_bridge/test_chat_requests.py
@@ -1,0 +1,80 @@
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from desktop_bridge.chat_requests import DesktopChatRequestHandler
+from desktop_bridge.session_presenter import DesktopSessionPresenter
+from session.manager import Session
+
+
+@pytest.mark.asyncio
+async def test_send_serializes_returned_user_message_when_session_tail_has_changed():
+    session = Session(key="role:mira")
+    session.add_message(
+        "user",
+        "my message",
+        id="user-id",
+        seq=1,
+        media=["photo.png"],
+        metadata={"client_message_id": "client-user", "turn_id": "turn-user"},
+    )
+    persisted = session.messages[0]
+    session.add_message("assistant", "proactive reply", id="assistant-id", seq=2)
+    app_service = Mock()
+    app_service.build_desktop_user_message_metadata.side_effect = (
+        lambda metadata, **kwargs: metadata
+    )
+    app_service.persist_desktop_user_message = AsyncMock(return_value=persisted)
+    role_service = Mock()
+    role_service.open_role_async = AsyncMock(
+        return_value=SimpleNamespace(
+            role=SimpleNamespace(id="mira"),
+            session=session,
+        )
+    )
+    chat_service = Mock()
+    chat_service.is_busy.return_value = False
+    start_chat_turn = Mock()
+    handler = DesktopChatRequestHandler(
+        role_service=role_service,
+        app_service=app_service,
+        chat_service=chat_service,
+        start_chat_turn=start_chat_turn,
+        session_presenter=DesktopSessionPresenter(Mock()),
+        sanitize_voice_metrics=Mock(),
+    )
+    emit_event = AsyncMock()
+
+    response = await handler.handle(
+        "chat.send",
+        {
+            "role_id": "mira",
+            "content": "my message",
+            "media": ["photo.png"],
+            "client_message_id": "client-user",
+            "turn_id": "turn-user",
+        },
+        request_id="request-user",
+        emit_event=emit_event,
+    )
+
+    assert response["message"]["id"] == "user-id"
+    assert response["message"]["seq"] == 1
+    assert response["message"]["role"] == "user"
+    assert response["message"]["content"] == "my message"
+    assert response["message"]["media"] == ["photo.png"]
+    assert response["message"]["metadata"]["client_message_id"] == "client-user"
+    assert response["turn_id"] == "turn-user"
+    assert response["session"]["key"] == session.key
+    app_service.persist_desktop_user_message.assert_awaited_once()
+    start_chat_turn.assert_called_once_with(
+        request_id="request-user",
+        turn_id="turn-user",
+        session_key=session.key,
+        content="my message",
+        media=["photo.png"],
+        metadata=app_service.persist_desktop_user_message.call_args.kwargs["metadata"],
+        omit_user_turn=True,
+        emit_event=emit_event,
+    )


### PR DESCRIPTION
Fixes #136

When another writer appends during user-message persistence or its runtime effects, `chat.send` can serialize the new session tail instead of the initiating user's message. Capture the appended user message before awaiting, return that same object after persistence and runtime effects complete, and serialize it in the response. This preserves its persisted ID, sequence and client-message identity.

Validation:
- 62 targeted bridge tests passed across `test_app_service.py`, `test_chat_requests.py`, `test_app_service_integration.py`, `test_integration.py` and `test_service.py`.
- Three new regression cases failed before the fix, including the response containing `assistant-id` instead of `user-id`. The service cases inject scheduling boundaries at `append_messages` and relationship `save_async`; they verify the async contract and do not claim to reproduce default scheduler timing.
- After the final unused-result annotation and test formatting, the 10 directly affected unit tests passed again.
- Ruff passed for all four changed files. Pyright passed for the two source files with 0 errors and 18 warnings. `git diff --check` passed.
- Python commands used the repository `.venv` interpreter. No desktop build was run for this backend-only change.

Known blockers: none for this response-identity fix. The existing index-based rollback can remove another writer's messages if persistence fails during a concurrent append; that separate failure-path risk is outside this PR.
