### PR TITLE
fix(desktop): reconcile and finish failed chat turns

### DIFF
--- a/apps/backend/desktop_bridge/chat_service.py
+++ b/apps/backend/desktop_bridge/chat_service.py
@@ -588,9 +588,12 @@ class DesktopChatService:
                 failure_message=reply,
             )
             collected.append(bridge_event)
-            await self._emit_payload(emit_event, bridge_event.to_dict())
+            if bridge_event.method == "chat.done":
+                await self._emit_payload(emit_event, bridge_event.to_dict())
             for event in session_events:
                 await self._emit_payload(emit_event, event)
+            if bridge_event.method == "chat.error":
+                await self._emit_payload(emit_event, bridge_event.to_dict())
             return session, collected
         except asyncio.CancelledError:
             if tts is not None:
@@ -605,6 +608,11 @@ class DesktopChatService:
                     tts,
                     announce=_announce_voice_reply,
                 )
+            await self._emit_failed_session_update(
+                request_id=request_id,
+                session_key=session_key,
+                emit_event=emit_event,
+            )
             bridge_event = build_chat_terminal_event(
                 request_id=request_id,
                 turn_id=turn_id,
@@ -621,6 +629,28 @@ class DesktopChatService:
                 self._event_bus.off(ToolCallStarted, _on_tool_started)
                 self._event_bus.off(ToolCallCompleted, _on_tool_completed)
             self._event_bus.off(TurnCommitted, _on_done)
+
+    async def _emit_failed_session_update(
+        self,
+        *,
+        request_id: str,
+        session_key: str,
+        emit_event: EventEmitter,
+    ) -> None:
+        """Reconciles failed turns without replacing their original exception."""
+
+        try:
+            session_events: list[dict[str, Any]] = []
+            await self._emit_session_updated(
+                request_id=request_id,
+                session=self._session_manager.get_or_create(session_key),
+                emit_event=session_events.append,
+            )
+            for event in session_events:
+                await self._emit_payload(emit_event, event)
+        except Exception:
+            # Snapshot preparation is secondary to delivering the terminal error.
+            logger.exception("failed to publish failed-turn session: %s", session_key)
 
     def start_chat_turn(
         self,
@@ -643,7 +673,9 @@ class DesktopChatService:
         async def emit_turn_event(payload):
             # Completion enables the next send in the renderer. Publish it only
             # after the role turn and persistence have released their ownership.
-            if terminal_events or payload.get("method") in {"chat.done", "chat.error"}:
+            if terminal_events or payload.get("method") in {
+                "chat.done", "chat.error", "session.updated"
+            }:
                 terminal_events.append(payload)
             else:
                 await self._emit_payload(emit_event, payload)

--- a/apps/desktop/renderer/src/app/useDesktopBridgeLifecycle.test.tsx
+++ b/apps/desktop/renderer/src/app/useDesktopBridgeLifecycle.test.tsx
@@ -1,0 +1,117 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { act } from "react";
+import type { BridgeEvent } from "../../../src/bridge/shared";
+import type { SessionPayload } from "../shared/types";
+import { mountTestComponent } from "../shared/testing/domTestHarness";
+import { useDesktopBridgeLifecycle } from "./useDesktopBridgeLifecycle";
+
+async function mountLifecycle({ cancelling = false } = {}) {
+  let listener!: (event: BridgeEvent) => void;
+  const activeSessionRef: React.MutableRefObject<SessionPayload | null> = { current: {
+    key: "role:mira", created_at: "", updated_at: "", last_consolidated: 0,
+    metadata: {}, messages: [{ id: "user-1", role: "user", content: "hello" }],
+  } };
+  const completions: string[] = [];
+  const statesAtError: SessionPayload[] = [];
+  const errors: string[] = [];
+  const ignore = () => {};
+  const args: Parameters<typeof useDesktopBridgeLifecycle>[0] = {
+    activeRoleId: "mira", activeIllustration: "",
+    setActiveRoleId: ignore, setActiveIllustration: ignore, setHealth: ignore,
+    setError: (value) => { if (typeof value === "string" && value) errors.push(value); },
+    setNotice: ignore, setWindowMaximized: ignore, setWindowVisible: ignore,
+    setUnreadCounts: ignore,
+    activeRoleIdRef: { current: "mira" }, activeSessionRef,
+    mainViewRef: { current: { kind: "chat" } }, rolesRef: { current: [] },
+    chooseIllustration: () => "", cacheRoleSession: ignore,
+    clearAllSendingSessions: ignore, clearSessionSending: ignore,
+    completeChatTurn: (_key, turn) => { completions.push(turn); },
+    isCurrentChatTurn: (key, turn) => key === "role:mira" && turn === "turn-1" && !completions.includes(turn),
+    isChatTurnCancelling: () => cancelling,
+    commitActiveSession: (session) => { activeSessionRef.current = session; },
+    updateCommittedActiveSession: (update) => { activeSessionRef.current = update(activeSessionRef.current); },
+    appendSessionErrorMessage: (_key, message) => {
+      const current = activeSessionRef.current;
+      assert.ok(current);
+      statesAtError.push(current);
+      activeSessionRef.current = { ...current, messages: [...current.messages, { role: "error", content: message }] };
+    },
+    loadRolesFromBridge: async () => [], openRole: async () => true,
+    buildNavigationEntry: () => ({ view: { kind: "chat" }, activeRoleId: "mira", settingsSection: "models" }),
+    pushNavigationEntry: ignore,
+  };
+  function Harness() {
+    useDesktopBridgeLifecycle(args);
+    return null;
+  }
+  const view = await mountTestComponent(null);
+  Object.defineProperty(window, "miraDesktop", { configurable: true, value: {
+    onEvent: (callback: typeof listener) => { listener = callback; return ignore; },
+    windowState: async () => ({ isMaximized: false, isVisible: true }),
+    bridgeStatus: async () => ({ running: true }),
+    invoke: async () => ({ error: null }),
+  } });
+  await view.render(<Harness />);
+  return {
+    ...view, activeSessionRef, completions, statesAtError, errors,
+    async emit(method: string, payload: BridgeEvent["payload"] = {}) {
+      await act(async () => listener({ id: "request-1", type: "event", method, payload: {
+        session_key: "role:mira", turn_id: "turn-1", ...payload,
+      } }));
+    },
+  };
+}
+
+describe("useDesktopBridgeLifecycle", () => {
+  it("reconciles a failed stream before appending its error and releasing the turn", async () => {
+    const view = await mountLifecycle();
+    try {
+      await view.emit("chat.delta", { content_delta: "partial", thinking_delta: "thinking" });
+      await view.emit("chat.tool.started", { iteration: 1, call_id: "call-1", tool_name: "web_search", arguments: {} });
+      const current = view.activeSessionRef.current!;
+      const { messages, ...summary } = current;
+      await view.emit("session.updated", {
+        session: { ...summary, metadata: { reconciled: true } }, message: messages[0],
+      });
+      await view.emit("chat.error", { message: "provider failed" });
+
+      const beforeError = view.statesAtError[0]!;
+      assert.equal(beforeError.metadata.reconciled, true);
+      assert.equal(beforeError.messages[1]?.streaming, false);
+      assert.equal(beforeError.messages[1]?.content, "partial");
+      assert.equal(beforeError.messages[1]?.reasoning_content, "thinking");
+      assert.equal(beforeError.messages[1]?.tool_chain?.[0]?.calls[0]?.status, "error");
+      assert.equal(view.activeSessionRef.current?.messages.at(-1)?.role, "error");
+      assert.deepEqual(view.errors, ["provider failed"]);
+      assert.deepEqual(view.completions, ["turn-1"]);
+      await view.emit("chat.delta", { content_delta: "late" });
+      assert.equal(view.activeSessionRef.current?.messages.length, 3);
+    } finally { await view.cleanup(); }
+  });
+
+  it("ends a stream when the backend cannot supply a snapshot", async () => {
+    const view = await mountLifecycle();
+    try {
+      await view.emit("chat.delta", { content_delta: "partial" });
+      await view.emit("chat.error", { message: "provider failed" });
+      assert.equal(view.statesAtError[0]?.messages[1]?.streaming, false);
+      assert.deepEqual(view.completions, ["turn-1"]);
+    } finally { await view.cleanup(); }
+  });
+
+  it("ignores foreign errors and leaves cancelling traces to cancellation reconciliation", async () => {
+    const view = await mountLifecycle({ cancelling: true });
+    try {
+      await view.emit("chat.delta", { content_delta: "partial" });
+      const streaming = view.activeSessionRef.current;
+      await view.emit("chat.error", { session_key: "role:other", message: "foreign" });
+      await view.emit("chat.error", { turn_id: "turn-old", message: "stale" });
+      assert.deepEqual(view.completions, []);
+      await view.emit("chat.error", { message: "cancelled" });
+      assert.equal(view.activeSessionRef.current, streaming);
+      assert.deepEqual(view.errors, []);
+      assert.deepEqual(view.completions, ["turn-1"]);
+    } finally { await view.cleanup(); }
+  });
+});

--- a/apps/desktop/renderer/src/app/useDesktopBridgeLifecycle.ts
+++ b/apps/desktop/renderer/src/app/useDesktopBridgeLifecycle.ts
@@ -3,6 +3,7 @@ import {
   applyChatStreamDelta,
   applyChatToolCompleted,
   applyChatToolStarted,
+  failChatStream,
   finishChatStream,
 } from "../chat/chatStreamingState";
 import { useLatestRef } from "../shared/useLatestRef";
@@ -297,6 +298,10 @@ export function useDesktopBridgeLifecycle({
           const cancelling = callbacks.isChatTurnCancelling(eventSessionKey, eventTurnId);
           const currentSession = activeSessionRef.current;
           if (!cancelling && currentSession && eventSessionKey === currentSession.key) {
+            callbacks.updateCommittedActiveSession((current) => {
+              if (!current || current.key !== eventSessionKey) return current;
+              return failChatStream(current);
+            });
             const message = String(event.payload.message ?? "对话失败");
             setError(message);
             callbacks.appendSessionErrorMessage(currentSession.key, message);

--- a/apps/desktop/renderer/src/chat/chatStreamingState.test.ts
+++ b/apps/desktop/renderer/src/chat/chatStreamingState.test.ts
@@ -7,6 +7,7 @@ import {
   applyChatStreamDelta,
   applyChatToolCompleted,
   applyChatToolStarted,
+  failChatStream,
   finalizeChatCancellation,
   finishChatStream,
   interruptChatStream,
@@ -24,6 +25,34 @@ function session(): SessionPayload {
 }
 
 describe("chat streaming state", () => {
+  it("finishes failed text and tool traces before a later persisted reply", () => {
+    const streaming = applyChatToolStarted(applyChatStreamDelta(session(), "partial", "thinking"), {
+      iteration: 1, callId: "running", toolName: "web_search", arguments: { query: "test" },
+    });
+    const completed = applyChatToolCompleted(streaming, {
+      iteration: 1, callId: "completed", toolName: "read_file", arguments: {},
+      finalArguments: {}, status: "success", resultPreview: "result",
+    });
+    const laterReply = { id: "proactive-1", role: "assistant", content: "proactive" };
+    const withLaterReply = { ...completed, messages: [...completed.messages, laterReply] };
+    const failed = failChatStream(withLaterReply);
+    const trace = failed.messages[1]!;
+
+    assert.equal(trace.streaming, false);
+    assert.equal(trace.content, "partial");
+    assert.equal(trace.reasoning_content, "thinking");
+    assert.equal(trace.render_id, completed.messages[1]?.render_id);
+    assert.equal(trace.metadata?.streamed_reply, true);
+    assert.deepEqual(trace.tool_chain?.[0]?.calls.map((call) => call.status), ["error", "success"]);
+    assert.equal(trace.tool_chain?.[0]?.calls[1], completed.messages[1]?.tool_chain?.[0]?.calls[1]);
+    assert.equal(failed.messages[2], laterReply);
+    assert.equal(completed.messages[1]?.streaming, true);
+    assert.equal(completed.messages[1]?.tool_chain?.[0]?.calls[0]?.status, "running");
+    assert.equal(failChatStream(failed), failed);
+    const empty = session();
+    assert.equal(failChatStream(empty), empty);
+  });
+
   it("merges Thinking and content deltas into one transient assistant message", () => {
     const original = session();
     const thinking = applyChatStreamDelta(original, "", "先判断语气");

--- a/apps/desktop/renderer/src/chat/chatStreamingState.ts
+++ b/apps/desktop/renderer/src/chat/chatStreamingState.ts
@@ -37,11 +37,37 @@ export function finishChatStream(
   const last = session.messages[lastIndex];
   if (!last || last.role !== "assistant" || !last.streaming) return session;
   const messages = [...session.messages];
-  messages[lastIndex] = {
-    ...last,
+  messages[lastIndex] = finishAssistantMessage(last, metrics);
+  return { ...session, messages };
+}
+
+/** Ends failed-turn traces, including rows followed by a persisted proactive reply. */
+export function failChatStream(session: SessionPayload): SessionPayload {
+  let changed = false;
+  const messages = session.messages.map((message) => {
+    if (message.role !== "assistant" || !message.streaming) return message;
+    changed = true;
+    return {
+      ...finishAssistantMessage(message),
+      ...(message.tool_chain ? {
+        tool_chain: message.tool_chain.map((group) => ({
+          ...group,
+          calls: group.calls.map((call) => call.status === "running"
+            ? { ...call, status: "error" }
+            : call),
+        })),
+      } : {}),
+    };
+  });
+  return changed ? { ...session, messages } : session;
+}
+
+function finishAssistantMessage(message: SessionMessage, metrics: ChatTurnMetrics = {}) {
+  return {
+    ...message,
     streaming: false,
     metadata: {
-      ...last.metadata,
+      ...message.metadata,
       streamed_reply: true,
       ...(metrics.total_tokens !== undefined || metrics.thinking_duration_ms !== undefined
         ? {
@@ -53,7 +79,6 @@ export function finishChatStream(
         : {}),
     },
   };
-  return { ...session, messages };
 }
 
 /** Marks a cancelled transient assistant reply complete while retaining its local trace for the next turn. */

--- a/tests/backend/desktop_bridge/test_chat_service.py
+++ b/tests/backend/desktop_bridge/test_chat_service.py
@@ -1031,10 +1031,63 @@ async def test_chat_terminal_waits_for_turn_and_session_work(failure_stage):
     )
     await service.drain()
 
-    assert [event["method"] for event in emitted] == (
-        ["chat.error"] if failure_stage else ["chat.done", "session.updated"]
-    )
-    assert emitted[0]["payload"]["turn_id"] == "turn-1"
+    expected = {
+        None: ["chat.done", "session.updated"],
+        "after_commit": ["session.updated", "chat.error"],
+        "session_update": ["chat.error"],
+    }
+    assert [event["method"] for event in emitted] == expected[failure_stage]
+    terminal = next(event for event in emitted if event["method"].startswith("chat."))
+    assert terminal["payload"]["turn_id"] == "turn-1"
     if failure_stage:
-        assert emitted[0]["payload"]["message"] == f"{failure_stage} failed"
+        assert terminal["payload"]["message"] == f"{failure_stage} failed"
+    assert event_bus._handlers == {}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("failure_stage", ["session_lookup", "session_update"])
+async def test_failure_snapshot_cannot_replace_original_error(failure_stage, caplog):
+    original_error = RuntimeError("provider failed")
+    snapshot_error = RuntimeError("snapshot unavailable")
+    emitted = []
+    event_bus = EventBus()
+    lookup = Mock(return_value=Session(key="role:mira"))
+    update = AsyncMock()
+    if failure_stage == "session_lookup":
+        lookup.side_effect = snapshot_error
+    else:
+        update.side_effect = snapshot_error
+
+    async def emit_payload(emit_event, payload):
+        emit_event(payload)
+
+    service = DesktopChatService(
+        agent_loop=SimpleNamespace(process_direct=AsyncMock(side_effect=original_error)),
+        event_bus=event_bus,
+        session_manager=SimpleNamespace(get_or_create=lookup),
+        role_id_from_session_key=lambda _key: "mira",
+        sync_desktop_session_thread=Mock(),
+        emit_payload=emit_payload,
+        emit_session_updated=update,
+    )
+    with pytest.raises(RuntimeError) as raised:
+        await service.run_chat_turn(
+            request_id="request-1",
+            turn_id="turn-1",
+            session_key="role:mira",
+            content="hello",
+            media=[],
+            metadata={},
+            omit_user_turn=True,
+            emit_event=emitted.append,
+        )
+
+    assert raised.value is original_error
+    assert [event["method"] for event in emitted] == ["chat.error"]
+    assert emitted[0]["payload"] == {
+        "session_key": "role:mira",
+        "turn_id": "turn-1",
+        "message": "provider failed",
+    }
+    assert "snapshot unavailable" in caplog.text
     assert event_bus._handlers == {}

--- a/tests/backend/desktop_bridge/test_chat_service_integration.py
+++ b/tests/backend/desktop_bridge/test_chat_service_integration.py
@@ -113,6 +113,9 @@ async def test_pipeline_early_exit_emits_one_error_and_releases_desktop_turn(
     assert all(event["payload"]["message"] == expected for event in terminals)
     assert busy_on_terminal == [False, False]
     assert len([event for event in emitted if event["method"] == "session.updated"]) == 2
+    assert [event["method"] for event in emitted] == [
+        "session.updated", "chat.error", "session.updated", "chat.error",
+    ]
     assert not service.is_busy("role:mira")
     assert session_manager.get_or_create("role:mira").messages == []
     assert SessionManager(tmp_path).get_or_create("role:mira").messages == []
@@ -120,10 +123,13 @@ async def test_pipeline_early_exit_emits_one_error_and_releases_desktop_turn(
 
 
 @pytest.mark.asyncio
-async def test_desktop_chat_service_emits_chat_error_event(tmp_path):
+async def test_desktop_chat_service_reconciles_persisted_user_before_chat_error(tmp_path):
     session_manager = SessionManager(tmp_path)
     event_bus = EventBus()
     emitted: list[dict] = []
+    session = session_manager.get_or_create("role:mira")
+    session.add_message("user", "hi")
+    await session_manager.append_messages(session, session.messages[:])
 
     class _Loop:
         async def process_direct(self, *args, **kwargs):
@@ -139,7 +145,12 @@ async def test_desktop_chat_service_emits_chat_error_event(tmp_path):
         session,
         emit_event,
     ) -> None:
-        raise AssertionError("error path should not emit session.updated")
+        await _emit_payload(emit_event, {
+            "id": request_id,
+            "type": "event",
+            "method": "session.updated",
+            "payload": {"session_key": session.key, "messages": session.messages[:]},
+        })
 
     service = DesktopChatService(
         agent_loop=_Loop(),  # type: ignore[arg-type]
@@ -162,7 +173,12 @@ async def test_desktop_chat_service_emits_chat_error_event(tmp_path):
             emit_event=emitted.append,
         )
 
-    assert emitted == [
+    assert emitted[0]["method"] == "session.updated"
+    persisted = SessionManager(tmp_path).get_or_create("role:mira")
+    assert emitted[0]["payload"]["messages"] == persisted.messages
+    assert persisted.messages[0]["role"] == "user"
+    assert persisted.messages[0]["content"] == "hi"
+    assert emitted[1:] == [
         {
             "id": "1",
             "type": "event",


### PR DESCRIPTION
Fixes #137

## Change

When a desktop chat turn fails, publish the authoritative `session.updated` event before `chat.error`, using the existing session summary and changed-message protocol. Buffer both events until turn ownership is released. Successful turns retain `chat.done` followed by `session.updated`.

If session lookup or update preparation fails, log that secondary failure, still deliver the original error event, and re-raise the original exception. Cancellation retains its existing reconciliation flow.

The renderer ends failed streaming assistant traces before appending the error bubble, including traces followed by a persisted proactive reply. Running tool calls stop showing execution status; completed results and message identities are retained.

## Validation

- Targeted backend chat service and integration tests: 27 passed.
- Targeted bridge lifecycle and chat streaming state tests: 13 passed.
- Renderer TypeScript check: passed.
- ESLint on changed renderer files and Ruff on changed Python files: passed.
- Renderer production build: passed, with the existing Vite chunk-size warning above 500 kB.

Regressions cover failure event ordering and released ownership, original exception preservation when session lookup or serialization fails, persisted user reconciliation, text and tool cleanup, stale event rejection, and cancellation ownership.

## Blockers

None. This PR remains Draft for review; no full-suite regression was run.
