### PR TITLE
fix(chat): preserve message identity and navigation windows

### DIFF
--- a/apps/desktop/renderer/src/app/sessionMessagePagination.test.ts
+++ b/apps/desktop/renderer/src/app/sessionMessagePagination.test.ts
@@ -2,7 +2,7 @@
 
 import assert from "node:assert/strict";
 import { describe, it } from "node:test";
-import { mergeSessionSummaryAndMessage } from "./sessionMessagePagination.js";
+import { mergeOpenedSessionSnapshot, mergeSessionMessage, mergeSessionSummaryAndMessage } from "./sessionMessagePagination.js";
 import type { SessionMessage, SessionPayload, SessionSummary } from "../shared/types.js";
 
 function createSummary(): SessionSummary {
@@ -23,6 +23,58 @@ function createSession(messages: SessionMessage[]): SessionPayload {
 }
 
 describe("mergeSessionSummaryAndMessage", () => {
+  it("keeps a failed trace from consuming a later turn's repeated-prefix reply", () => {
+    const current: SessionMessage[] = [
+      { id: "user-1", seq: 1, role: "user", content: "first" },
+      { role: "assistant", content: "hello", render_id: "local:failed", streaming: false, metadata: { streamed_reply: true } },
+      { role: "user", content: "next", render_id: "local:user", metadata: { client_message_id: "next" } },
+      { role: "assistant", content: "hello there", render_id: "local:active", streaming: true },
+    ];
+    const merged = mergeSessionMessage(current, { id: "reply", seq: 3, role: "assistant", content: "hello there friend", metadata: { client_message_id: "next" } });
+    assert.deepEqual(merged.map((message) => message.render_id ?? message.id), ["user-1", "local:failed", "local:user", "local:active"]);
+    assert.equal(merged.at(-1)!.id, "reply");
+    assert.equal(merged[1]!.content, "hello");
+  });
+
+  it("retains a transient row exactly once across a paginated snapshot roundtrip", () => {
+    for (const role of ["error", "user"]) {
+      const row = { role, content: "local", render_id: `local:${role}:1` };
+      const current = createSession([row]);
+      const merged = mergeOpenedSessionSnapshot(current, {
+        ...current,
+        messages: [{ ...row }],
+        pagination: { limit: 80, has_more: false, total_count: 0, oldest_seq: null, newest_seq: null, before_seq: null, next_before_seq: null },
+      });
+      assert.equal(merged.messages.length, 1);
+      assert.equal(merged.messages[0]!.render_id, row.render_id);
+    }
+  });
+
+  it("keeps optimistic user before a reply arriving before acknowledgement, including later page merges", () => {
+    const user = { role: "user", content: "new", render_id: "local:user:1", metadata: { client_message_id: "turn" } };
+    const reply = { id: "reply", seq: 3, role: "assistant", content: "reply", metadata: { client_message_id: "turn" } };
+    let merged = mergeSessionMessage([user], reply);
+    assert.deepEqual(merged.map((message) => message.role), ["user", "assistant"]);
+    merged = mergeSessionMessage(merged, { id: "history", seq: 1, role: "assistant", content: "old" });
+    merged = mergeSessionMessage(merged, reply);
+    assert.deepEqual(merged.map((message) => message.id ?? "local"), ["history", "local", "reply"]);
+    merged = mergeSessionMessage(merged, { ...user, id: "user", seq: 2, render_id: undefined });
+    assert.deepEqual(merged.map((message) => message.id), ["history", "user", "reply"]);
+    assert.equal(merged[1]!.render_id, user.render_id);
+  });
+
+  it("keeps distinct persisted assistant rows in the same client turn", () => {
+    const first = { id: "a1", seq: 1, role: "assistant", content: "same", metadata: { client_message_id: "turn" } };
+    assert.equal(mergeSessionMessage([first], { ...first, id: "a2", seq: 2 }).length, 2);
+  });
+
+  it("upgrades a tool-only interrupted reply by call identity without appending a duplicate", () => {
+    const transient: SessionMessage = { role: "assistant", content: "", render_id: "local:tool", streaming: true, tool_chain: [{ text: "", reasoning_content: "", calls: [{ call_id: "call", name: "lookup", status: "running", arguments: {}, final_arguments: {}, result: "" }] }] };
+    const merged = mergeSessionMessage([transient], { ...transient, id: "interrupted", seq: 1, render_id: undefined, streaming: false, metadata: { interrupted_reply: true } });
+    assert.equal(merged.length, 1);
+    assert.equal(merged[0]!.render_id, transient.render_id);
+  });
+
   it("keeps the user turn when the assistant reply carries the same client message id", () => {
     const currentSession = createSession([
       {

--- a/apps/desktop/renderer/src/app/sessionMessagePagination.ts
+++ b/apps/desktop/renderer/src/app/sessionMessagePagination.ts
@@ -5,6 +5,7 @@ import type {
   SessionPayload,
   SessionSummary,
 } from "../shared/types";
+import { createChatMessageMatcher } from "../chat/chatMessageMatching";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value) && typeof value === "object" && !Array.isArray(value);
@@ -71,58 +72,31 @@ export function getSessionPaginationState(page: SessionMessagePage) {
   };
 }
 
-function messageId(message: SessionMessage): string {
-  return String(message.id ?? "").trim();
-}
-
-function clientMessageId(message: SessionMessage): string {
-  return String(message.metadata?.client_message_id ?? "").trim();
-}
-
-function findMatchingMessageIndex(
-  messages: readonly SessionMessage[],
-  incoming: SessionMessage,
-): number {
-  const incomingId = messageId(incoming);
-  if (incomingId) {
-    const idMatch = messages.findIndex((message) => messageId(message) === incomingId);
-    if (idMatch >= 0) return idMatch;
-  }
-  if (typeof incoming.seq === "number") {
-    const seqMatch = messages.findIndex((message) => message.seq === incoming.seq);
-    if (seqMatch >= 0) return seqMatch;
-  }
-  // 已提交的助手回复会原样继承请求 metadata（含用户的 client_message_id），
-  // 因此按 client_message_id 匹配必须限定同角色，否则助手回复会顶掉用户消息；
-  // 未命中时继续走下方的流式助手兜底分支。
-  const incomingClientMessageId = clientMessageId(incoming);
-  if (incomingClientMessageId) {
-    const clientMatch = messages.findIndex((message) => (
-      message.role === incoming.role
-        && clientMessageId(message) === incomingClientMessageId
-    ));
-    if (clientMatch >= 0) return clientMatch;
-  }
-  const maxLoadedSeq = messages.reduce(
-    (maximum, message) => typeof message.seq === "number" ? Math.max(maximum, message.seq) : maximum,
-    -1,
-  );
-  if (incoming.role === "assistant" && (!incomingId && typeof incoming.seq !== "number"
-    || typeof incoming.seq === "number" && incoming.seq > maxLoadedSeq)) {
-    for (let index = messages.length - 1; index >= 0; index -= 1) {
-      const message = messages[index];
-      if (message?.role === "assistant" && !messageId(message)) return index;
-    }
-  }
-  return -1;
-}
-
 function sortSessionMessages(messages: readonly SessionMessage[]): SessionMessage[] {
   const persisted = messages
     .filter((message) => typeof message.seq === "number")
     .sort((left, right) => left.seq! - right.seq!);
-  const transient = messages.filter((message) => typeof message.seq !== "number");
-  return [...persisted, ...transient];
+  const before = new Map<SessionMessage, SessionMessage[]>();
+  const tail: SessionMessage[] = [];
+  let previousSeq = -1;
+  messages.forEach((message, index) => {
+    if (message.seq != null) {
+      previousSeq = Math.max(previousSeq, message.seq);
+      return;
+    }
+    // Preserve a local row before the following reply, including when that
+    // reply arrives before the user's acknowledgement. Older pages cannot anchor it.
+    const anchor = messages.slice(index + 1).find((candidate) => (
+      candidate.seq != null && candidate.seq > previousSeq
+    ));
+    if (!anchor) tail.push(message);
+    else {
+      const group = before.get(anchor) ?? [];
+      group.push(message);
+      before.set(anchor, group);
+    }
+  });
+  return [...persisted.flatMap((message) => [...(before.get(message) ?? []), message]), ...tail];
 }
 
 /** Upserts a persisted bridge message while preserving the existing render identity. */
@@ -130,7 +104,7 @@ export function mergeSessionMessage(
   messages: readonly SessionMessage[],
   incoming: SessionMessage,
 ): SessionMessage[] {
-  const matchedIndex = findMatchingMessageIndex(messages, incoming);
+  const matchedIndex = createChatMessageMatcher(messages)(incoming);
   if (matchedIndex >= 0) {
     const current = messages[matchedIndex]!;
     const nextMessages = [...messages];
@@ -160,7 +134,7 @@ export function mergeSessionSummaryAndMessage(
     ? current.pagination?.newest_seq ?? null
     : null;
   for (const incomingMessage of incomingMessages) {
-    const matchedMessageIndex = findMatchingMessageIndex(mergedMessages, incomingMessage);
+    const matchedMessageIndex = createChatMessageMatcher(mergedMessages)(incomingMessage);
     const matchedMessage = matchedMessageIndex >= 0 ? mergedMessages[matchedMessageIndex] : null;
     if (typeof incomingMessage.seq === "number"
       && (matchedMessageIndex < 0 || typeof matchedMessage?.seq !== "number")) {

--- a/apps/desktop/renderer/src/app/useDesktopSessionState.test.ts
+++ b/apps/desktop/renderer/src/app/useDesktopSessionState.test.ts
@@ -148,7 +148,7 @@ describe("desktop paginated session protocol", () => {
   it("merges an incremental message without replacing the currently loaded page", () => {
     const current = createSession([
       { id: "role:shiori:6", seq: 6, role: "user", content: "上一条" },
-      { role: "assistant", content: "流式内容", streaming: true, render_id: "stream-1" },
+      { role: "assistant", content: "完整", streaming: true, render_id: "stream-1" },
     ]);
     const update = parseSessionMessageUpdatePayload({
       session: {

--- a/apps/desktop/renderer/src/chat/ChatMessageList.test.tsx
+++ b/apps/desktop/renderer/src/chat/ChatMessageList.test.tsx
@@ -9,6 +9,24 @@ import { ChatMessageList } from "./ChatMessageList";
 import { getVisibleChatMessages } from "./chatMessageWindow";
 
 describe("ChatMessageList", () => {
+  it("mounts an old highlighted row and the newest message together with their original DOM keys", () => {
+    const messages = Array.from({ length: 10_000 }, (_, index) => ({ id: `message-${index}`, role: "user", content: `message-${index}` }));
+    const markup = renderToStaticMarkup(<ChatMessageList
+      activeRole={null}
+      conversationEndRef={React.createRef<HTMLDivElement>()}
+      conversationListRef={React.createRef<HTMLDivElement>()}
+      highlightedMessageKey="message-10"
+      visibleMessageWindow={{ startIndex: 0, hiddenMessageCount: 0, messages }}
+      onBeginAttachmentDrag={() => undefined}
+      onJumpToMessage={() => undefined}
+      onOpenContextMenu={() => undefined}
+      onOpenImagePreview={() => undefined}
+    />);
+    assert.ok(markup.includes('data-message-key="message-10"'));
+    assert.ok(markup.includes('data-message-key="message-9999"'));
+    assert.ok((markup.match(/data-message-key=/g) ?? []).length < 80);
+  });
+
   function renderMessage(message: SessionMessage): string {
     return renderToStaticMarkup(
       <ChatMessageList

--- a/apps/desktop/renderer/src/chat/ChatMessageList.tsx
+++ b/apps/desktop/renderer/src/chat/ChatMessageList.tsx
@@ -68,26 +68,28 @@ export const ChatMessageList = React.memo(function ChatMessageList({
       style={{ overflowAnchor: "none" }}
     >
       <div className={cx("grid content-start gap-3", chatContentTrackClass)}>
-        {virtualMessageWindow.topSpacerHeight > 0 ? (
-          <div aria-hidden="true" className="pointer-events-none" style={{ height: virtualMessageWindow.topSpacerHeight }} />
-        ) : null}
-        {virtualMessageWindow.messages.map((message, visibleIndex) => {
-          const index = visibleMessageWindow.startIndex + virtualMessageWindow.startIndex + visibleIndex;
-          return (
-            <ChatMessageRow
-              key={getChatMessageReactKey(message, index)}
-              activeRole={activeRole}
-              index={index}
-              isHighlighted={getChatMessageDomKey(message, index) === highlightedMessageKey}
-              message={message}
-              onBeginAttachmentDrag={onBeginAttachmentDrag}
-              onJumpToMessage={onJumpToMessage}
-              onMeasureElement={observeMessageElement}
-              onOpenContextMenu={onOpenContextMenu}
-              onOpenImagePreview={onOpenImagePreview}
-            />
-          );
-        })}
+        {virtualMessageWindow.ranges.flatMap((range) => [
+          ...(range.spacerHeightBefore > 0 ? [
+            <div key={`spacer:${range.startIndex}`} aria-hidden="true" className="pointer-events-none" style={{ height: range.spacerHeightBefore }} />,
+          ] : []),
+          ...range.messages.map((message, visibleIndex) => {
+            const index = visibleMessageWindow.startIndex + range.startIndex + visibleIndex;
+            return (
+              <ChatMessageRow
+                key={getChatMessageReactKey(message, index)}
+                activeRole={activeRole}
+                index={index}
+                isHighlighted={getChatMessageDomKey(message, index) === highlightedMessageKey}
+                message={message}
+                onBeginAttachmentDrag={onBeginAttachmentDrag}
+                onJumpToMessage={onJumpToMessage}
+                onMeasureElement={observeMessageElement}
+                onOpenContextMenu={onOpenContextMenu}
+                onOpenImagePreview={onOpenImagePreview}
+              />
+            );
+          }),
+        ])}
         {virtualMessageWindow.bottomSpacerHeight > 0 ? (
           <div aria-hidden="true" className="pointer-events-none" style={{ height: virtualMessageWindow.bottomSpacerHeight }} />
         ) : null}

--- a/apps/desktop/renderer/src/chat/chatMessageIdentity.test.ts
+++ b/apps/desktop/renderer/src/chat/chatMessageIdentity.test.ts
@@ -43,6 +43,48 @@ describe("ensureChatMessageRenderId", () => {
 });
 
 describe("reconcileSessionMessageRenderIds", () => {
+  it("reserves a tool call identity before an unrelated text prefix can claim the stream", () => {
+    const tool_chain = [{ text: "", reasoning_content: "", calls: [{ call_id: "call", name: "lookup", status: "success", arguments: {}, final_arguments: {}, result: "done" }] }];
+    const stream = { role: "assistant", content: "partial", render_id: "local:tool", tool_chain };
+    const reconciled = reconcileSessionMessageRenderIds(createSession([stream]), createSession([
+      { id: "unrelated", role: "assistant", content: "partial unrelated" },
+      { id: "actual", role: "assistant", content: "final", tool_chain },
+    ]))!;
+    assert.equal(reconciled.messages[0]!.render_id, "server:unrelated");
+    assert.equal(reconciled.messages[1]!.render_id, stream.render_id);
+  });
+
+  it("reserves a live overlay key before matching an earlier persisted row", () => {
+    const overlay = { role: "user", content: "hello", render_id: "local:user:overlay" };
+    const incoming = createSession([{ id: "older", role: "user", content: "hello there" }, overlay]);
+    const reconciled = reconcileSessionMessageRenderIds(createSession([overlay]), incoming)!;
+    assert.equal(reconciled.messages[1]!.render_id, overlay.render_id);
+    assert.notEqual(reconciled.messages[0]!.render_id, overlay.render_id);
+  });
+
+  it("allocates unique keys even when incoming keys collide with existing and generated identities", () => {
+    const incoming = createSession([
+      { role: "error", content: "one", render_id: "shared" },
+      { id: "duplicate", role: "user", content: "two", render_id: "shared" },
+      { role: "assistant", content: "three", render_id: "server:duplicate" },
+    ]);
+    const reconciled = reconcileSessionMessageRenderIds(null, incoming)!;
+    assert.equal(new Set(reconciled.messages.map((message) => message.render_id)).size, 3);
+    assert.equal(reconciled.messages[2]!.render_id, "server:duplicate");
+    assert.equal(reconcileSessionMessageRenderIds(reconciled, reconciled), reconciled);
+  });
+
+  it("keeps distinct assistant rows sharing one request client id and repeated content", () => {
+    const current = createSession([{ id: "a1", role: "assistant", content: "same", render_id: "local:assistant:original", metadata: { client_message_id: "turn" } }]);
+    const incoming = createSession([
+      { id: "a2", role: "assistant", content: "same", metadata: { client_message_id: "turn" } },
+      { id: "a1", role: "assistant", content: "edited", metadata: { client_message_id: "turn" } },
+    ]);
+    const reconciled = reconcileSessionMessageRenderIds(current, incoming)!;
+    assert.equal(reconciled.messages[0]!.render_id, "server:a2");
+    assert.equal(reconciled.messages[1]!.render_id, "local:assistant:original");
+  });
+
   it("reuses the optimistic user render id after the authoritative snapshot adds a persisted id", () => {
     const optimisticUserMessage = ensureChatMessageRenderId({
       role: "user",

--- a/apps/desktop/renderer/src/chat/chatMessageIdentity.ts
+++ b/apps/desktop/renderer/src/chat/chatMessageIdentity.ts
@@ -1,5 +1,5 @@
 import type { SessionMessage, SessionPayload } from "../shared/types";
-import { normalizeSessionMediaPaths } from "./chatMedia";
+import { createChatMessageMatcher } from "./chatMessageMatching";
 
 const localChatMessageRenderIdPrefix = "local";
 let nextLocalChatMessageRenderId = 0;
@@ -10,70 +10,6 @@ function normalizeMessageId(message: SessionMessage): string {
 
 function normalizeRenderId(message: SessionMessage): string {
   return String(message.render_id ?? "").trim();
-}
-
-function normalizeClientMessageId(message: SessionMessage): string {
-  return String(message.metadata?.client_message_id ?? "").trim();
-}
-
-function normalizeReplyMetadata(message: SessionMessage) {
-  return {
-    messageId: String(message.metadata?.reply_to_message_id ?? "").trim(),
-    content: String(message.metadata?.reply_to_content ?? "").trim(),
-    sender: String(message.metadata?.reply_to_sender ?? "").trim(),
-  };
-}
-
-function normalizeMedia(message: SessionMessage): string[] {
-  return normalizeSessionMediaPaths(message.media);
-}
-
-function sameMedia(left: SessionMessage, right: SessionMessage): boolean {
-  const leftMedia = normalizeMedia(left);
-  const rightMedia = normalizeMedia(right);
-  if (leftMedia.length !== rightMedia.length) {
-    return false;
-  }
-  return leftMedia.every((item, index) => item === rightMedia[index]);
-}
-
-function sameReplyMetadata(left: SessionMessage, right: SessionMessage): boolean {
-  const leftReply = normalizeReplyMetadata(left);
-  const rightReply = normalizeReplyMetadata(right);
-  return leftReply.messageId === rightReply.messageId
-    && leftReply.content === rightReply.content
-    && leftReply.sender === rightReply.sender;
-}
-
-function canReuseRenderIdForStreamingUpdate(current: SessionMessage, incoming: SessionMessage): boolean {
-  const currentClientMessageId = normalizeClientMessageId(current);
-  const incomingClientMessageId = normalizeClientMessageId(incoming);
-  if (currentClientMessageId && incomingClientMessageId) {
-    return current.role === incoming.role && currentClientMessageId === incomingClientMessageId;
-  }
-  const currentId = normalizeMessageId(current);
-  const incomingId = normalizeMessageId(incoming);
-  if (currentId && incomingId && currentId !== incomingId) {
-    return false;
-  }
-  if (current.role !== incoming.role || !sameMedia(current, incoming) || !sameReplyMetadata(current, incoming)) {
-    return false;
-  }
-  const currentContent = current.content;
-  const incomingContent = incoming.content;
-  const currentThinking = String(current.reasoning_content ?? "");
-  const incomingThinking = String(incoming.reasoning_content ?? "");
-  if (currentContent === incomingContent && currentThinking === incomingThinking) {
-    return true;
-  }
-  return isStreamingTextExtension(currentContent, incomingContent)
-    && isStreamingTextExtension(currentThinking, incomingThinking);
-}
-
-function isStreamingTextExtension(left: string, right: string): boolean {
-  const shorter = left.length <= right.length ? left : right;
-  const longer = left.length > right.length ? left : right;
-  return longer.startsWith(shorter);
 }
 
 function createLocalChatMessageRenderId(role: string): string {
@@ -110,7 +46,24 @@ export function ensureChatMessageRenderId(message: SessionMessage): SessionMessa
   };
 }
 
-/** Reuses local render identities when an authoritative session snapshot replaces optimistic or streaming messages. */
+function matchCurrentMessages(current: readonly SessionMessage[], incoming: readonly SessionMessage[]) {
+  const matches = new Map<number, number>();
+  const claimed = new Set<number>();
+  const findMatch = createChatMessageMatcher(current);
+  // Explicit identities claim their rows before content fallback can consume them.
+  for (const minimumStrength of [4, 3, 2, 1]) {
+    incoming.forEach((message, incomingIndex) => {
+      if (matches.has(incomingIndex)) return;
+      const currentIndex = findMatch(message, claimed, minimumStrength);
+      if (currentIndex < 0) return;
+      matches.set(incomingIndex, currentIndex);
+      claimed.add(currentIndex);
+    });
+  }
+  return matches;
+}
+
+/** Reuses compatible identities and allocates unique keys across the complete incoming snapshot. */
 export function reconcileSessionMessageRenderIds(
   currentSession: SessionPayload | null,
   incomingSession: SessionPayload | null,
@@ -119,38 +72,32 @@ export function reconcileSessionMessageRenderIds(
     return null;
   }
 
-  const currentMessages = currentSession?.messages ?? [];
-  let nextCurrentSearchStart = 0;
+  const currentMessages = currentSession?.key === incomingSession.key ? currentSession.messages : [];
+  const matches = matchCurrentMessages(currentMessages, incomingSession.messages);
+  const reserved = new Map<string, number>();
+  incomingSession.messages.forEach((message, index) => {
+    const key = normalizeRenderId(message);
+    if (key && !reserved.has(key)) reserved.set(key, index);
+  });
+  const used = new Set<string>();
   let changed = false;
 
-  const nextMessages = incomingSession.messages.map((incomingMessage) => {
-    let matchedCurrentMessage: SessionMessage | null = null;
-    for (let currentIndex = nextCurrentSearchStart; currentIndex < currentMessages.length; currentIndex += 1) {
-      const currentMessage = currentMessages[currentIndex];
-      if (!canReuseRenderIdForStreamingUpdate(currentMessage, incomingMessage)) {
-        continue;
-      }
-      matchedCurrentMessage = currentMessage;
-      nextCurrentSearchStart = currentIndex + 1;
-      break;
-    }
-
-    if (matchedCurrentMessage) {
-      const matchedRenderId = normalizeRenderId(matchedCurrentMessage);
-      if (matchedRenderId && matchedRenderId !== normalizeRenderId(incomingMessage)) {
-        changed = true;
-        return {
-          ...incomingMessage,
-          render_id: matchedRenderId,
-        };
+  const nextMessages = incomingSession.messages.map((incomingMessage, index) => {
+    const currentIndex = matches.get(index);
+    const matchedKey = currentIndex == null ? "" : normalizeRenderId(currentMessages[currentIndex]!);
+    let key = matchedKey && (!reserved.has(matchedKey) || reserved.get(matchedKey) === index)
+      ? matchedKey : normalizeRenderId(incomingMessage);
+    if (!key || used.has(key)) {
+      const id = normalizeMessageId(incomingMessage);
+      key = id ? createServerChatMessageRenderId(id) : "";
+      while (!key || used.has(key) || (reserved.has(key) && reserved.get(key) !== index)) {
+        key = createLocalChatMessageRenderId(incomingMessage.role);
       }
     }
-
-    const ensuredMessage = ensureChatMessageRenderId(incomingMessage);
-    if (ensuredMessage !== incomingMessage) {
-      changed = true;
-    }
-    return ensuredMessage;
+    used.add(key);
+    if (key === normalizeRenderId(incomingMessage)) return incomingMessage;
+    changed = true;
+    return { ...incomingMessage, render_id: key };
   });
 
   if (!changed) {

--- a/apps/desktop/renderer/src/chat/chatMessageMatching.test.ts
+++ b/apps/desktop/renderer/src/chat/chatMessageMatching.test.ts
@@ -1,0 +1,48 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { createChatMessageMatcher, getChatMessageMatchStrength } from "./chatMessageMatching";
+import type { SessionMessage } from "../shared/types";
+
+describe("getChatMessageMatchStrength", () => {
+  it("rejects conflicting durable identities even for the same assistant turn or render key", () => {
+    const current: SessionMessage = { id: "a1", seq: 1, render_id: "local:a", role: "assistant", content: "same", metadata: { client_message_id: "turn" } };
+    assert.equal(getChatMessageMatchStrength(current, { ...current, id: "a2", seq: 2 }), 0);
+    assert.equal(getChatMessageMatchStrength(current, { ...current, id: undefined, seq: 2 }), 0);
+  });
+
+  it("does not merge repeated local errors or user turns with distinct render identities", () => {
+    for (const role of ["error", "user"]) {
+      const current = { role, content: "same", render_id: "local:1" };
+      assert.equal(getChatMessageMatchStrength(current, { ...current, render_id: "local:2" }), 0);
+      assert.equal(getChatMessageMatchStrength(current, { ...current }), 3);
+    }
+  });
+
+  it("rejects empty prefixes, unrelated proactive replies, and user text extensions", () => {
+    assert.equal(getChatMessageMatchStrength({ role: "assistant", content: "", streaming: true }, { id: "a", role: "assistant", content: "reply" }), 0);
+    assert.equal(getChatMessageMatchStrength({ role: "assistant", content: "partial", streaming: true }, { id: "a", role: "assistant", content: "unrelated" }), 0);
+    assert.equal(getChatMessageMatchStrength({ role: "assistant", content: "hello", streaming: true }, { id: "a", role: "assistant", content: "hello again", metadata: { proactive: true } }), 0);
+    assert.equal(getChatMessageMatchStrength({ role: "user", content: "hello" }, { id: "u", role: "user", content: "hello again" }), 0);
+  });
+
+  it("preserves Thinking-first and tool-only streaming transitions with positive evidence", () => {
+    assert.equal(getChatMessageMatchStrength({ role: "assistant", content: "", reasoning_content: "think" }, { id: "a", role: "assistant", content: "reply", reasoning_content: "thinking" }), 1);
+    const tool_chain = [{ text: "", reasoning_content: "", calls: [{ call_id: "call-1", name: "lookup", status: "success", arguments: {}, final_arguments: {}, result: "done" }] }];
+    assert.equal(getChatMessageMatchStrength({ role: "assistant", content: "", tool_chain }, { id: "a", role: "assistant", content: "reply", tool_chain }), 2);
+    assert.equal(getChatMessageMatchStrength({ role: "assistant", content: "", tool_chain }, { id: "a", role: "assistant", content: "reply", tool_chain, media: ["image.png"] }), 2);
+    const anonymousTools = tool_chain.map((group) => ({ ...group, calls: group.calls.map((call) => ({ ...call, call_id: "" })) }));
+    assert.equal(getChatMessageMatchStrength({ role: "assistant", content: "", tool_chain: anonymousTools }, { id: "a", role: "assistant", content: "reply", tool_chain: anonymousTools }), 0);
+  });
+});
+
+describe("createChatMessageMatcher", () => {
+  it("bounds content acknowledgement by neighbors while allowing a reply-before-user acknowledgement", () => {
+    const find = createChatMessageMatcher([
+      { id: "old", seq: 5, role: "assistant", content: "old" },
+      { role: "user", content: "same" },
+      { id: "reply", seq: 7, role: "assistant", content: "reply" },
+    ]);
+    assert.equal(find({ id: "history", seq: 2, role: "user", content: "same" }), -1);
+    assert.equal(find({ id: "new-user", seq: 6, role: "user", content: "same" }), 1);
+  });
+});

--- a/apps/desktop/renderer/src/chat/chatMessageMatching.ts
+++ b/apps/desktop/renderer/src/chat/chatMessageMatching.ts
@@ -1,0 +1,121 @@
+import type { SessionMessage } from "../shared/types";
+import { normalizeSessionMediaPaths } from "./chatMedia";
+
+function normalized(value: unknown) {
+  return String(value ?? "").trim();
+}
+
+function samePayloadContext(left: SessionMessage, right: SessionMessage) {
+  const leftMedia = normalizeSessionMediaPaths(left.media);
+  const rightMedia = normalizeSessionMediaPaths(right.media);
+  return leftMedia.length === rightMedia.length
+    && leftMedia.every((path, index) => path === rightMedia[index])
+    && ["reply_to_message_id", "reply_to_content", "reply_to_sender"].every(
+      (key) => normalized(left.metadata?.[key]) === normalized(right.metadata?.[key]),
+    );
+}
+
+/** Ranks identity evidence; conflicting persisted identities always describe distinct rows. */
+export function getChatMessageMatchStrength(current: SessionMessage, incoming: SessionMessage) {
+  if (current.role !== incoming.role) return 0;
+  const currentId = normalized(current.id);
+  const incomingId = normalized(incoming.id);
+  if (currentId && incomingId && currentId !== incomingId) return 0;
+  if (current.seq != null && incoming.seq != null && current.seq !== incoming.seq) return 0;
+  if (currentId && currentId === incomingId) return 4;
+  if (current.seq != null && current.seq === incoming.seq) return 4;
+  const currentClientId = normalized(current.metadata?.client_message_id);
+  const incomingClientId = normalized(incoming.metadata?.client_message_id);
+  if (currentClientId && incomingClientId && currentClientId !== incomingClientId) return 0;
+  if (normalized(current.render_id) && normalized(current.render_id) === normalized(incoming.render_id)) return 3;
+  if (currentClientId && currentClientId === incomingClientId) return 2;
+  if (currentClientId && !incomingClientId) return 0;
+  // Content is evidence only when upgrading a transient row. A new local turn
+  // must never borrow an earlier persisted row's identity, even with equal text.
+  if (currentId || current.seq != null || (!incomingId && incoming.seq == null)) return 0;
+  if (current.metadata?.proactive !== incoming.metadata?.proactive
+    && (current.metadata?.proactive === true || incoming.metadata?.proactive === true)) return 0;
+  const currentCallIds = new Set(toolCallIds(current));
+  if (toolCallIds(incoming).some((id) => currentCallIds.has(id))) return 2;
+  if (!samePayloadContext(current, incoming)) return 0;
+  const content = current.content;
+  const thinking = String(current.reasoning_content ?? "");
+  if (!content.trim() && !thinking.trim()) return 0;
+  if (current.role !== "assistant") {
+    return content === incoming.content && thinking === String(incoming.reasoning_content ?? "") ? 1 : 0;
+  }
+  return incoming.content.startsWith(content)
+    && String(incoming.reasoning_content ?? "").startsWith(thinking) ? 1 : 0;
+}
+
+function toolCallIds(message: SessionMessage) {
+  return message.tool_chain?.flatMap((group) => group.calls.map((call) => normalized(call.call_id)).filter(Boolean)) ?? [];
+}
+
+function identityKeys(message: SessionMessage) {
+  return [
+    ["id", normalized(message.id)],
+    ["seq", message.seq == null ? "" : String(message.seq)],
+    ["render", normalized(message.render_id)],
+    ["client", normalized(message.metadata?.client_message_id)],
+    ...toolCallIds(message).map((id) => ["call", id]),
+  ].filter(([, value]) => value).map(([kind, value]) => JSON.stringify([message.role, kind, value]));
+}
+
+/** Indexes identity evidence once for page/snapshot reconciliation, keeping content fallback bounded to local rows. */
+export function createChatMessageMatcher(messages: readonly SessionMessage[]) {
+  const identities = new Map<string, number[]>();
+  const transientIndices: number[] = [];
+  const previousSequences: (number | undefined)[] = [];
+  const nextSequences: (number | undefined)[] = [];
+  const userTurnIds: string[] = [];
+  const hasLaterUser: boolean[] = [];
+  let userTurnId = "";
+  let previousSeq: number | undefined;
+  messages.forEach((message, index) => {
+    if (message.role === "user") userTurnId = normalized(message.metadata?.client_message_id);
+    userTurnIds[index] = userTurnId;
+    previousSequences[index] = previousSeq;
+    if (message.seq != null) previousSeq = message.seq;
+    if (!normalized(message.id) && message.seq == null) transientIndices.push(index);
+    for (const key of identityKeys(message)) {
+      const indices = identities.get(key) ?? [];
+      indices.push(index);
+      identities.set(key, indices);
+    }
+  });
+  let nextSeq: number | undefined;
+  let laterUser = false;
+  for (let index = messages.length - 1; index >= 0; index -= 1) {
+    nextSequences[index] = nextSeq;
+    hasLaterUser[index] = laterUser;
+    if (messages[index]!.role === "user") laterUser = true;
+    if (messages[index]!.seq != null) nextSeq = messages[index]!.seq;
+  }
+  return (incoming: SessionMessage, excluded?: ReadonlySet<number>, minimumStrength = 1) => {
+    const candidates = new Set(identityKeys(incoming).flatMap((key) => identities.get(key) ?? []));
+    if (minimumStrength === 1) transientIndices.forEach((index) => candidates.add(index));
+    let matchedIndex = -1;
+    let bestStrength = minimumStrength - 1;
+    for (const index of candidates) {
+      if (excluded?.has(index)) continue;
+      const strength = getChatMessageMatchStrength(messages[index]!, incoming);
+      if (strength <= bestStrength) continue;
+      const incomingTurnId = normalized(incoming.metadata?.client_message_id);
+      const sameTurn = Boolean(incomingTurnId && incomingTurnId === userTurnIds[index]);
+      // A failed/interrupted trace before a later user turn cannot consume that
+      // turn's reply simply because the assistant repeats a familiar prefix.
+      if (strength === 1 && incoming.role === "assistant" && !sameTurn
+        && (hasLaterUser[index] || (incomingTurnId && userTurnIds[index]))) continue;
+      const previous = previousSequences[index];
+      const next = nextSequences[index];
+      const withinNeighbors = incoming.seq == null
+        || (previous == null || incoming.seq > previous) && (next == null || incoming.seq < next);
+      if (strength > 1 || withinNeighbors) {
+        bestStrength = strength;
+        matchedIndex = index;
+      }
+    }
+    return matchedIndex;
+  };
+}

--- a/apps/desktop/renderer/src/chat/chatMessageVirtualization.test.ts
+++ b/apps/desktop/renderer/src/chat/chatMessageVirtualization.test.ts
@@ -18,6 +18,25 @@ function messages(count: number): SessionMessage[] {
 }
 
 describe("getVirtualChatMessageWindow", () => {
+  it("mounts the viewport and a distant pin with bounded rows and exact spacer geometry", () => {
+    const source = messages(10_000);
+    const measuredHeights = new Map(source.map((message, index) => [message.id!, 80 + index % 13]));
+    const window = getVirtualChatMessageWindow({
+      messages: source, messageKeys: source.map((message) => message.id!), measuredHeights,
+      scrollTop: Number.POSITIVE_INFINITY, viewportHeight: 720, pinnedMessageIndex: 12,
+    });
+    assert.ok(window.messages.some((message) => message.id === "message-12"));
+    assert.equal(window.messages.at(-1)?.id, "message-9999");
+    assert.ok(window.messages.length < 80);
+    assert.equal(window.ranges.length, 2);
+    const spacers = window.ranges.map((range) => range.spacerHeightBefore).filter((height) => height > 0);
+    if (window.bottomSpacerHeight > 0) spacers.push(window.bottomSpacerHeight);
+    const renderedHeight = window.messages.reduce((total, message) => total + measuredHeights.get(message.id!)!, 0)
+      + spacers.reduce((total, height) => total + height, 0)
+      + (window.messages.length + spacers.length - 1) * chatMessageVirtualRowGap;
+    assert.equal(renderedHeight, window.totalHeight);
+  });
+
   it("keeps a bounded bridge history page fully mounted before virtualization is needed", () => {
     const source = messages(chatMessageVirtualizationThreshold);
     const window = getVirtualChatMessageWindow({

--- a/apps/desktop/renderer/src/chat/chatMessageVirtualization.ts
+++ b/apps/desktop/renderer/src/chat/chatMessageVirtualization.ts
@@ -16,6 +16,7 @@ export type ChatMessageVirtualWindow = {
   topSpacerHeight: number;
   bottomSpacerHeight: number;
   totalHeight: number;
+  ranges: { startIndex: number; messages: SessionMessage[]; spacerHeightBefore: number }[];
 };
 
 type GetVirtualChatMessageWindowArgs = {
@@ -74,7 +75,7 @@ function firstIndexAfterOffset(offsets: readonly number[], offset: number): numb
 
 /**
  * Selects a bounded group of rows while retaining spacer heights for all omitted rows.
- * A pinned message takes precedence so search navigation can mount its DOM anchor on demand.
+ * Offscreen navigation targets mount in a separate range without replacing the viewport.
  */
 export function getVirtualChatMessageWindow({
   messages,
@@ -97,6 +98,7 @@ export function getVirtualChatMessageWindow({
       topSpacerHeight: 0,
       bottomSpacerHeight: 0,
       totalHeight: 0,
+      ranges: [],
     };
   }
 
@@ -117,6 +119,7 @@ export function getVirtualChatMessageWindow({
       topSpacerHeight: 0,
       bottomSpacerHeight: 0,
       totalHeight: Math.max(0, totalHeight - chatMessageVirtualRowGap),
+      ranges: [{ startIndex: 0, messages: [...messages], spacerHeightBefore: 0 }],
     };
   }
 
@@ -133,26 +136,40 @@ export function getVirtualChatMessageWindow({
   const safeViewportHeight = Math.max(1, viewportHeight || chatMessageVirtualFallbackViewportHeight);
   const firstVisibleIndex = firstIndexAfterOffset(offsets, safeScrollTop);
   const visibleEnd = Math.min(totalHeight, safeScrollTop + safeViewportHeight);
-  let startIndex = firstIndexAfterOffset(offsets, Math.max(0, safeScrollTop - overscanPixels));
-  let endIndex = Math.min(
+  const startIndex = firstIndexAfterOffset(offsets, Math.max(0, safeScrollTop - overscanPixels));
+  const endIndex = Math.min(
     messages.length,
     firstIndexAfterOffset(offsets, Math.min(totalHeight, visibleEnd + overscanPixels)) + 1,
   );
 
-  if (pinnedMessageIndex >= 0 && (pinnedMessageIndex < startIndex || pinnedMessageIndex >= endIndex)) {
-    startIndex = Math.max(0, pinnedMessageIndex - 12);
-    endIndex = Math.min(messages.length, pinnedMessageIndex + 13);
+  const bounds = [{ startIndex, endIndex }];
+  if (pinnedMessageIndex >= 0 && pinnedMessageIndex < messages.length
+    && (pinnedMessageIndex < startIndex || pinnedMessageIndex >= endIndex)) {
+    bounds.push({ startIndex: Math.max(0, pinnedMessageIndex - 12), endIndex: Math.min(messages.length, pinnedMessageIndex + 13) });
+    bounds.sort((left, right) => left.startIndex - right.startIndex);
+    if (bounds[0]!.endIndex >= bounds[1]!.startIndex) {
+      bounds[0]!.endIndex = Math.max(bounds[0]!.endIndex, bounds[1]!.endIndex);
+      bounds.pop();
+    }
   }
+  const ranges = bounds.map((bound, index) => ({
+    startIndex: bound.startIndex,
+    messages: messages.slice(bound.startIndex, bound.endIndex),
+    // The grid contributes a gap on each side of an internal spacer.
+    spacerHeightBefore: Math.max(0,
+      offsets[bound.startIndex]! - (index === 0 ? 0 : offsets[bounds[index - 1]!.endIndex]!) - chatMessageVirtualRowGap),
+  }));
 
   return {
-    startIndex,
-    endIndex,
+    startIndex: bounds[0]!.startIndex,
+    endIndex: bounds.at(-1)!.endIndex,
     firstVisibleIndex,
-    messages: messages.slice(startIndex, endIndex),
+    messages: ranges.flatMap((range) => range.messages),
+    ranges,
     // The grid supplies the boundary gap beside each spacer. Keeping that gap
     // out of spacer heights prevents the virtual positions drifting per slice.
-    topSpacerHeight: Math.max(0, (offsets[startIndex] ?? 0) - chatMessageVirtualRowGap),
-    bottomSpacerHeight: Math.max(0, totalHeight - (offsets[endIndex] ?? totalHeight)),
+    topSpacerHeight: ranges[0]!.spacerHeightBefore,
+    bottomSpacerHeight: Math.max(0, totalHeight - offsets[bounds.at(-1)!.endIndex]!),
     totalHeight,
   };
 }

--- a/apps/desktop/renderer/src/chat/chatSessionMerge.test.ts
+++ b/apps/desktop/renderer/src/chat/chatSessionMerge.test.ts
@@ -21,6 +21,16 @@ function createSession(messages: SessionMessage[]): SessionPayload {
 }
 
 describe("mergeIncomingSessionDuringSend", () => {
+  it("does not reinsert an already present anonymous overlay on a diverging snapshot", () => {
+    const pending = { role: "user", content: "pending", render_id: "local:user:pending" };
+    const current = createSession([{ id: "a", role: "assistant", content: "old" }, pending]);
+    const incoming = createSession([{ id: "a", role: "assistant", content: "edited" }, { ...pending }]);
+    const merged = mergeIncomingSessionDuringSend(current, incoming, true, pending)!;
+    assert.equal(merged.messages.length, 2);
+    assert.equal(merged.messages[1]!.render_id, pending.render_id);
+    assert.equal(isPendingUserMessageAcknowledged(pending, merged), false);
+  });
+
   it("keeps the optimistic user turn when a stale shorter snapshot arrives during sending", () => {
     const currentSession = createSession([
       {

--- a/apps/desktop/renderer/src/chat/chatSessionMerge.ts
+++ b/apps/desktop/renderer/src/chat/chatSessionMerge.ts
@@ -1,5 +1,6 @@
 import type { SessionMessage, SessionPayload } from "../shared/types.js";
 import { normalizeSessionMediaPaths } from "./chatMedia.js";
+import { getChatMessageMatchStrength } from "./chatMessageMatching";
 
 function normalizeMessageId(message: SessionMessage): string {
   return String(message.id ?? "").trim();
@@ -99,14 +100,9 @@ function findMissingOptimisticUserMessage(
   if (!optimisticUserMessage || !isOptimisticUserMessage(optimisticUserMessage)) {
     return null;
   }
-  const clientMessageId = normalizeClientMessageId(optimisticUserMessage);
-  const alreadyPersisted = incomingSession.messages.some((message) => {
-    if (clientMessageId) {
-      return message.role === optimisticUserMessage.role
-        && normalizeClientMessageId(message) === clientMessageId;
-    }
-    return areEquivalentMessagesIgnoringMissingIds(optimisticUserMessage, message);
-  });
+  const alreadyPersisted = incomingSession.messages.some((message) => (
+    getChatMessageMatchStrength(optimisticUserMessage, message) > 0
+  ));
   return alreadyPersisted ? null : optimisticUserMessage;
 }
 
@@ -212,16 +208,10 @@ export function isPendingUserMessageAcknowledged(
   pendingUserMessage: SessionMessage,
   incomingSession: SessionPayload,
 ): boolean {
-  const clientMessageId = normalizeClientMessageId(pendingUserMessage);
-  return incomingSession.messages.some((message) => {
-    if (clientMessageId) {
-      // 助手回复携带同一 client_message_id 时不算确认，必须是同角色的持久化副本。
-      return message.role === pendingUserMessage.role
-        && normalizeClientMessageId(message) === clientMessageId;
-    }
-    return Boolean(normalizeMessageId(message))
-      && areEquivalentMessagesIgnoringMissingIds(pendingUserMessage, message);
-  });
+  return incomingSession.messages.some((message) => (
+    Boolean(normalizeMessageId(message) || message.seq != null)
+      && getChatMessageMatchStrength(pendingUserMessage, message) > 0
+  ));
 }
 
 /** Clears a pending user overlay only after its chat turn has finished and a snapshot confirms it. */

--- a/apps/desktop/renderer/src/chat/useChatScrollController.test.tsx
+++ b/apps/desktop/renderer/src/chat/useChatScrollController.test.tsx
@@ -1,0 +1,45 @@
+import assert from "node:assert/strict";
+import { describe, it } from "node:test";
+import { act, useRef } from "react";
+import { mountTestComponent } from "../shared/testing/domTestHarness";
+import { useChatScrollController } from "./useChatScrollController";
+
+describe("useChatScrollController", () => {
+  it("settles detached navigation exactly once so its owner can release pending state and highlighting", async () => {
+    let controller!: ReturnType<typeof useChatScrollController>;
+    function Harness() {
+      const containerRef = useRef<HTMLDivElement>(null);
+      controller = useChatScrollController({ conversationListRef: containerRef, sessionKey: "role:test" });
+      return <div ref={containerRef}><div data-target="true" /></div>;
+    }
+    const view = await mountTestComponent(<Harness />);
+    const frames = new Map<number, FrameRequestCallback>();
+    let nextFrame = 0;
+    window.requestAnimationFrame = (callback) => { frames.set(++nextFrame, callback); return nextFrame; };
+    window.cancelAnimationFrame = (frame) => { frames.delete(frame); };
+    try {
+      const container = view.container.firstElementChild as HTMLDivElement;
+      const target = container.firstElementChild as HTMLDivElement;
+      Object.defineProperties(container, { clientHeight: { value: 600 }, scrollHeight: { value: 6000 } });
+      target.getBoundingClientRect = () => ({ x: 0, y: 4000, top: 4000, bottom: 4100, left: 0, right: 100, width: 100, height: 100, toJSON: () => ({}) });
+      let pending = true;
+      let highlighted = "target";
+      let settleCount = 0;
+      await act(async () => controller.scrollToMessage(target, () => {
+        pending = false;
+        highlighted = "";
+        settleCount += 1;
+      }));
+      assert.equal(controller.isAutoScrollingRef.current, true);
+      target.remove();
+      const frame = frames.values().next().value!;
+      await act(async () => frame(window.performance.now() + 16));
+      assert.equal(pending, false);
+      assert.equal(highlighted, "");
+      assert.equal(controller.isAutoScrollingRef.current, false);
+      await act(async () => window.dispatchEvent(new Event("wheel")));
+      assert.equal(settleCount, 1);
+      assert.equal(frames.size, 0);
+    } finally { await view.cleanup(); }
+  });
+});

--- a/apps/desktop/renderer/src/chat/useChatScrollController.ts
+++ b/apps/desktop/renderer/src/chat/useChatScrollController.ts
@@ -179,7 +179,8 @@ export function useChatScrollController({
         !currentContainer
         || !target.isConnected
       ) {
-        stopAnimation(false);
+        // A removed target cannot resume; settle so navigation releases its pin.
+        stopAnimation(true);
         return;
       }
       const progress = Math.min(1, Math.max(0, (now - startedAt) / duration));


### PR DESCRIPTION
Fixes #138

Concurrent session updates could duplicate local rows, reuse another message's render key, and move an optimistic user message below its reply. In long histories, an old highlighted row also replaced the bottom viewport, and a detached navigation target left its pin active indefinitely.

- Share indexed identity matching between pagination, snapshot reconciliation, and pending overlays. Persisted identity conflicts are distinct messages; meaningful text fallback stays within the user turn, while Thinking and tool-call identities retain streaming keys.
- Reserve existing incoming keys before allocating unique render IDs, and keep transient messages anchored before their following persisted reply.
- Render bounded viewport and pinned ranges with exact intervening spacers, and settle navigation when its target detaches.

Validation: 79 related tests passed across identity, pagination, pending overlays, streaming/turn flow, virtual windows, list rendering, and the scroll-controller DOM hook. Renderer TypeScript check, ESLint for all changed files, production renderer build, and git diff --check passed. Independent review rechecked failed-turn boundaries and virtual spacer geometry.

Known blockers: none. Vite reports the existing minified chunk-size warning (>500 kB). Packaged Electron end-to-end validation and unrelated full-suite regression were not run.
