### PR TITLE
fix: 补全 message_push 桌面端调用说明

### DIFF
--- a/apps/backend/agent/tools/message_push.py
+++ b/apps/backend/agent/tools/message_push.py
@@ -20,7 +20,8 @@ class MessagePushTool(Tool):
     description = (
         "向指定渠道的用户主动发送消息、文件或图片。"
         "需要提供当前会话对应的渠道名和目标 chat_id。"
-        "渠道名必须使用渠道原名：telegram、qq（NapCat QQ）或 qqbot（官方 QQBot）；"
+        "渠道名必须使用渠道原名：desktop（桌面端）、telegram、qq（NapCat QQ）或 qqbot（官方 QQBot）；"
+        "桌面端使用 channel=desktop，chat_id 使用当前角色会话 ID（role:<角色ID>）。"
         "官方 QQBot 不能写成 qq。QQBot 私聊 chat_id 格式为 c2c:<user_openid>。"
         "message/file/image 三者至少提供一个。"
     )
@@ -30,13 +31,16 @@ class MessagePushTool(Tool):
             "channel": {
                 "type": "string",
                 "description": (
-                    "目标渠道原名：telegram、qq（NapCat QQ）或 qqbot（官方 QQBot）。"
+                    "目标渠道原名：desktop（桌面端）、telegram、qq（NapCat QQ）或 qqbot（官方 QQBot）。"
                     "官方 QQBot 必须填写 qqbot，不能填写 qq。"
                 ),
             },
             "chat_id": {
                 "type": "string",
-                "description": "目标会话 ID；官方 QQBot 私聊使用 c2c:<user_openid>",
+                "description": (
+                    "目标会话 ID；桌面端使用当前角色会话 ID（role:<角色ID>）；"
+                    "官方 QQBot 私聊使用 c2c:<user_openid>"
+                ),
             },
             "message": {
                 "type": "string",


### PR DESCRIPTION
## 变更摘要

message_push 的桌面发送链路已存在，但工具描述遗漏 desktop，可能使模型误判桌面端不可用。补全工具总说明、channel 参数及 chat_id 参数，明确桌面调用使用 channel=desktop、chat_id=role:<角色ID>。

Closes #148

## 实际验证

- `.venv\Scripts\pytest.exe -q tests/backend/agent/tools/test_message_push.py tests/backend/agent/tools/test_message_push_role_target.py tests/backend/desktop_bridge/test_integration.py -k "message_push or desktop_push or push_rolls_back or subset_media"`：23 passed，26 deselected。
- `.venv\Scripts\ruff.exe check apps/backend/agent/tools/message_push.py`：通过。
- `git diff --check`：通过。
- 仅修改 Python 工具描述，未运行桌面构建或真实 LLM 调用验证。

## 已知阻塞项

无。保持 Draft，等待审阅。
