### PR TITLE
restyle(3/7): 聊天主流程 — 玻璃消息卡、品牌渐变操作、token 清零

### DIFF
--- a/apps/desktop/renderer/src/app/DesktopAppFrame.tsx
+++ b/apps/desktop/renderer/src/app/DesktopAppFrame.tsx
@@ -429,6 +429,15 @@ export function DesktopAppFrame({
           )}
         </div>
         <main className="chat-pane relative grid min-h-0 grid-cols-[minmax(0,1fr)] overflow-hidden rounded-l-lg border-b border-l border-t border-line-soft bg-[var(--chat-bg)] shadow-soft">
+          {sidebarState.collapsed ? (
+            <div
+              className="absolute inset-y-0 left-0 z-[7] w-1.5 cursor-col-resize transition-colors hover:bg-accent-soft"
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="拖拽展开侧边栏"
+              onPointerDown={sidebarState.onBeginResize}
+            />
+          ) : null}
           {roleWorkspaceViewActive && workspaceFeedback ? (
             <div
               className={cx(

--- a/apps/desktop/renderer/src/app/DesktopAppFrame.tsx
+++ b/apps/desktop/renderer/src/app/DesktopAppFrame.tsx
@@ -431,7 +431,7 @@ export function DesktopAppFrame({
         <main className="chat-pane relative grid min-h-0 grid-cols-[minmax(0,1fr)] overflow-hidden rounded-l-lg border-b border-l border-t border-line-soft bg-[var(--chat-bg)] shadow-soft">
           {sidebarState.collapsed ? (
             <div
-              className="absolute inset-y-0 left-0 z-[7] w-1.5 cursor-col-resize transition-colors hover:bg-accent-soft"
+              className="absolute inset-y-0 left-0 z-[7] w-[3px] cursor-col-resize transition-colors hover:bg-accent-soft"
               role="separator"
               aria-orientation="vertical"
               aria-label="拖拽展开侧边栏"

--- a/apps/desktop/renderer/src/chat/ChatComposer.tsx
+++ b/apps/desktop/renderer/src/chat/ChatComposer.tsx
@@ -138,9 +138,9 @@ export const ChatComposer = React.memo(function ChatComposer({
   return (
     <div className="composer-wrap pointer-events-none absolute inset-x-0 bottom-10 z-[2] flex min-w-0 justify-center overflow-visible">
       <div className="pointer-events-auto mx-auto w-full max-w-[700px] px-5 md:px-6">
-        <div className="composer grid w-full flex-none gap-1.5 rounded-lg border border-[#E4E4E4] bg-[#FFFEFF] px-3 pb-2 pt-2.5">
+        <div className="composer grid w-full flex-none gap-1.5 rounded-lg border border-white/75 bg-white/90 px-3 pb-2 pt-2.5 shadow-panel backdrop-blur-lg">
           {replyTarget ? (
-            <div className="flex min-w-0 items-start gap-2 rounded-md border border-[#E5E7EB] bg-[#F8FAFC] px-2.5 py-2 text-left">
+            <div className="flex min-w-0 items-start gap-2 rounded-md border border-line-soft bg-surface-soft px-2.5 py-2 text-left">
               {replyTarget.messageId ? (
                 <button
                   className="min-w-0 flex-1 border-0 bg-transparent p-0 text-left transition hover:opacity-85 focus:outline-none"
@@ -148,19 +148,19 @@ export const ChatComposer = React.memo(function ChatComposer({
                   aria-label="跳转到引用来源消息"
                   onClick={() => onJumpToMessage(replyTarget.messageId)}
                 >
-                  <div className="border-l-2 border-[#AEB7C5] pl-2.5">
-                    <div className="truncate text-[11px] font-medium leading-4 text-[#6B7280]">{replyTarget.sender || "历史消息"}</div>
-                    <div className="line-clamp-2 text-[12px] leading-5 text-[#4B5563]">{replyTarget.preview}</div>
+                  <div className="border-l-2 border-line-accent pl-2.5">
+                    <div className="truncate text-[11px] font-medium leading-4 text-ink-muted">{replyTarget.sender || "历史消息"}</div>
+                    <div className="line-clamp-2 text-[12px] leading-5 text-ink-secondary">{replyTarget.preview}</div>
                   </div>
                 </button>
               ) : (
-                <div className="min-w-0 flex-1 border-l-2 border-[#AEB7C5] pl-2.5">
-                  <div className="truncate text-[11px] font-medium leading-4 text-[#6B7280]">{replyTarget.sender || "历史消息"}</div>
-                  <div className="line-clamp-2 text-[12px] leading-5 text-[#4B5563]">{replyTarget.preview}</div>
+                <div className="min-w-0 flex-1 border-l-2 border-line-accent pl-2.5">
+                  <div className="truncate text-[11px] font-medium leading-4 text-ink-muted">{replyTarget.sender || "历史消息"}</div>
+                  <div className="line-clamp-2 text-[12px] leading-5 text-ink-secondary">{replyTarget.preview}</div>
                 </div>
               )}
               <button
-                className="grid h-6 w-6 flex-none place-items-center rounded-md border-0 bg-transparent p-0 text-[#7C8797] transition hover:bg-black/5 hover:text-[#1F2937] focus:outline-none disabled:cursor-default disabled:opacity-40"
+                className="grid h-6 w-6 flex-none place-items-center rounded-md border-0 bg-transparent p-0 text-ink-faint transition hover:bg-accent-softer hover:text-ink focus:outline-none disabled:cursor-default disabled:opacity-40"
                 type="button"
                 aria-label="取消引用"
                 onClick={onClearReplyTarget}
@@ -176,7 +176,7 @@ export const ChatComposer = React.memo(function ChatComposer({
                 isChatImageAsset(path) ? (
                   <span
                     key={path}
-                    className="relative h-14 w-14 overflow-hidden rounded-md border border-black/8 bg-[#F6F7FA]"
+                    className="relative h-14 w-14 overflow-hidden rounded-md border border-line-soft bg-surface-soft"
                   >
                     <img
                       className="h-full w-full object-cover"
@@ -184,7 +184,7 @@ export const ChatComposer = React.memo(function ChatComposer({
                       alt=""
                     />
                     <button
-                      className="absolute right-1 top-1 grid h-4 w-4 place-items-center rounded-full bg-white/92 p-0 text-[#7C8797] shadow-[0_4px_12px_rgba(15,23,42,0.12)] transition hover:text-[#1F2937] focus:outline-none disabled:cursor-default disabled:opacity-40"
+                      className="absolute right-1 top-1 grid h-4 w-4 place-items-center rounded-full bg-white/92 p-0 text-ink-faint shadow-soft transition hover:text-ink focus:outline-none disabled:cursor-default disabled:opacity-40"
                       type="button"
                       aria-label="移除图片附件"
                       onClick={() => removePendingAttachment(path)}
@@ -196,21 +196,21 @@ export const ChatComposer = React.memo(function ChatComposer({
                 ) : (
                   <span
                     key={path}
-                    className="relative inline-flex max-w-[220px] items-center gap-2 rounded-lg border border-black/8 bg-[#F6F7FA] px-3 py-2 text-left text-[#4B5563]"
+                    className="relative inline-flex max-w-[220px] items-center gap-2 rounded-md border border-line-soft bg-surface-soft px-3 py-2 text-left text-ink-secondary"
                   >
-                    <span className="grid h-9 w-9 flex-none place-items-center rounded-md bg-white text-[#6B7280] shadow-[inset_0_0_0_1px_rgba(15,23,42,0.06)]">
+                    <span className="grid h-9 w-9 flex-none place-items-center rounded-md bg-white text-ink-muted shadow-[inset_0_0_0_1px_var(--neutral-150)]">
                       <DocumentIcon className="h-4 w-4 stroke-current" />
                     </span>
                     <span className="min-w-0 flex-1 pr-4">
-                      <span className="block truncate text-[12px] font-medium leading-[1.2] text-[#1F2937]">
+                      <span className="block truncate text-[12px] font-medium leading-[1.2] text-ink">
                         {getAttachmentName(path)}
                       </span>
-                      <span className="mt-1 block text-[11px] leading-none text-[#8B95A7]">
+                      <span className="mt-1 block text-[11px] leading-none text-ink-faint">
                         {getAttachmentExtensionLabel(path)}
                       </span>
                     </span>
                     <button
-                      className="absolute right-2 top-2 grid h-4 w-4 place-items-center rounded-full border-0 bg-transparent p-0 text-[#7C8797] transition hover:text-[#1F2937] focus:outline-none disabled:cursor-default disabled:opacity-40"
+                      className="absolute right-2 top-2 grid h-4 w-4 place-items-center rounded-full border-0 bg-transparent p-0 text-ink-faint transition hover:text-ink focus:outline-none disabled:cursor-default disabled:opacity-40"
                       type="button"
                       aria-label={`移除附件 ${getAttachmentName(path)}`}
                       onClick={() => removePendingAttachment(path)}
@@ -225,7 +225,7 @@ export const ChatComposer = React.memo(function ChatComposer({
           ) : null}
           <AutosizeTextarea
             ref={textareaRef}
-            className="min-h-[24px] w-full border-0 bg-transparent p-0 text-sm leading-6 text-[#1f1f1f] outline-none"
+            className="min-h-[24px] w-full border-0 bg-transparent p-0 text-sm leading-6 text-ink outline-none placeholder:text-ink-faint focus:shadow-none"
             containerClassName="min-h-[24px]"
             mirrorClassName="min-h-[24px] text-sm leading-6"
             rows={1}
@@ -236,7 +236,7 @@ export const ChatComposer = React.memo(function ChatComposer({
           />
           <div className="composer-actions flex items-center gap-2">
             <button
-              className="grid h-[30px] w-[30px] place-items-center rounded-full border-0 bg-transparent p-0 text-[#4B5563] transition focus:outline-none disabled:cursor-default disabled:opacity-40"
+              className="grid h-[30px] w-[30px] place-items-center rounded-full border-0 bg-transparent p-0 text-ink-secondary transition hover:bg-accent-softer hover:text-accent-text focus:outline-none disabled:cursor-default disabled:opacity-40"
               type="button"
               aria-label="添加附件"
               onClick={() => void pickChatAttachments()}
@@ -255,7 +255,7 @@ export const ChatComposer = React.memo(function ChatComposer({
             />
             {sending ? (
               <button
-                className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-[#1f1f1f] p-0 text-white disabled:cursor-default disabled:opacity-40"
+                className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-gradient-accent p-0 text-white shadow-soft transition-[filter] hover:brightness-105 disabled:cursor-default disabled:opacity-40"
                 type="button"
                 aria-label="中止回复"
                 onClick={onCancelChat}
@@ -264,7 +264,7 @@ export const ChatComposer = React.memo(function ChatComposer({
                 <Stop className="h-[15px] w-[15px] fill-current" />
               </button>
             ) : (
-              <button className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-[#1f1f1f] p-0 text-white disabled:cursor-default disabled:opacity-40" type="button" aria-label="发送消息" onClick={() => void submitMessage()} disabled={!activeRoleId || !canSubmit || !bridgeReady}>
+              <button className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-gradient-accent p-0 text-white shadow-soft transition-[filter] hover:brightness-105 disabled:cursor-default disabled:opacity-40" type="button" aria-label="发送消息" onClick={() => void submitMessage()} disabled={!activeRoleId || !canSubmit || !bridgeReady}>
                 <SendIcon className="h-[15px] w-[15px] fill-current" />
               </button>
             )}

--- a/apps/desktop/renderer/src/chat/ChatComposer.tsx
+++ b/apps/desktop/renderer/src/chat/ChatComposer.tsx
@@ -255,7 +255,7 @@ export const ChatComposer = React.memo(function ChatComposer({
             />
             {sending ? (
               <button
-                className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-gradient-accent p-0 text-white shadow-soft transition-[filter] hover:brightness-105 disabled:cursor-default disabled:opacity-40"
+                className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-gradient-accent p-0 text-ink shadow-soft transition-[filter] hover:brightness-105 disabled:cursor-default disabled:opacity-40"
                 type="button"
                 aria-label="中止回复"
                 onClick={onCancelChat}
@@ -264,7 +264,7 @@ export const ChatComposer = React.memo(function ChatComposer({
                 <Stop className="h-[15px] w-[15px] fill-current" />
               </button>
             ) : (
-              <button className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-gradient-accent p-0 text-white shadow-soft transition-[filter] hover:brightness-105 disabled:cursor-default disabled:opacity-40" type="button" aria-label="发送消息" onClick={() => void submitMessage()} disabled={!activeRoleId || !canSubmit || !bridgeReady}>
+              <button className="send-btn grid h-[30px] w-[30px] cursor-pointer place-items-center rounded-full border-0 bg-gradient-accent p-0 text-ink shadow-soft transition-[filter] hover:brightness-105 disabled:cursor-default disabled:opacity-40" type="button" aria-label="发送消息" onClick={() => void submitMessage()} disabled={!activeRoleId || !canSubmit || !bridgeReady}>
                 <SendIcon className="h-[15px] w-[15px] fill-current" />
               </button>
             )}

--- a/apps/desktop/renderer/src/chat/ChatEmojiPicker.tsx
+++ b/apps/desktop/renderer/src/chat/ChatEmojiPicker.tsx
@@ -55,7 +55,7 @@ export function ChatEmojiPicker({
   return (
     <div ref={rootRef} className="relative">
       <button
-        className="grid h-[30px] w-[30px] place-items-center rounded-md border-0 bg-transparent p-0 text-[#4B5563] transition hover:bg-black/5 hover:text-[#1F2937] focus:outline-none disabled:cursor-default disabled:opacity-40"
+        className="grid h-[30px] w-[30px] place-items-center rounded-md border-0 bg-transparent p-0 text-ink-secondary transition hover:bg-black/5 hover:text-ink focus:outline-none disabled:cursor-default disabled:opacity-40"
         type="button"
         aria-label={open ? "收起常用表情面板" : "打开常用表情面板"}
         aria-expanded={open}
@@ -67,16 +67,16 @@ export function ChatEmojiPicker({
       </button>
       {open ? (
         <div
-          className="absolute bottom-[calc(100%+10px)] right-0 z-[4] w-[232px] rounded-lg border border-[#E4E7EC] bg-[rgba(255,255,255,0.98)] p-3 shadow-[0_18px_42px_rgba(15,23,42,0.14)] backdrop-blur-[10px]"
+          className="absolute bottom-[calc(100%+10px)] right-0 z-[4] w-[232px] rounded-lg border border-line-soft bg-[rgba(255,255,255,0.98)] p-3 shadow-pop backdrop-blur-[10px]"
           role="dialog"
           aria-label="常用表情面板"
         >
-          <div className="mb-2 text-[11px] font-medium tracking-[0.08em] text-[#8B95A7]">常用表情</div>
+          <div className="mb-2 text-[11px] font-medium tracking-[0.08em] text-ink-faint">常用表情</div>
           <div className="grid grid-cols-6 gap-1.5">
             {commonChatEmojis.map((emoji) => (
               <button
                 key={emoji}
-                className="grid h-8 w-8 place-items-center rounded-md border border-transparent bg-transparent p-0 text-[19px] leading-none transition hover:border-[#D8DEE8] hover:bg-[#F8FAFC] focus:outline-none"
+                className="grid h-8 w-8 place-items-center rounded-md border border-transparent bg-transparent p-0 text-[19px] leading-none transition hover:border-line-soft hover:bg-surface-soft focus:outline-none"
                 type="button"
                 aria-label={`插入表情 ${emoji}`}
                 onClick={() => onSelectEmoji(emoji)}

--- a/apps/desktop/renderer/src/chat/ChatHeader.tsx
+++ b/apps/desktop/renderer/src/chat/ChatHeader.tsx
@@ -17,9 +17,9 @@ export function ChatHeader({
   onOpenRoleDetail,
 }: ChatHeaderProps) {
   const avatarClass =
-    "chat-header-avatar grid h-[34px] w-[34px] flex-none place-items-center rounded-full border border-black/10 object-cover";
+    "chat-header-avatar grid h-[34px] w-[34px] flex-none place-items-center rounded-full border border-line-soft object-cover";
   return (
-    <header className="chat-header relative z-[1] flex min-w-0 items-center gap-3 border-b border-[#E4E4E4] bg-[rgba(255,255,255,0.55)] pl-[23px] pr-6 backdrop-blur-[3px]" data-testid="session-hero">
+    <header className="chat-header relative z-[1] flex min-w-0 items-center gap-3 border-b border-white/60 bg-white/55 pl-[23px] pr-6 backdrop-blur-[3px]" data-testid="session-hero">
       {detailRole ? (
         <button
           className="rounded-full transition hover:opacity-90 focus:outline-none"
@@ -35,7 +35,7 @@ export function ChatHeader({
               alt={`${detailRole.name} avatar`}
             />
           ) : (
-            <span className={cx(avatarClass, "chat-header-avatar-fallback bg-[#f6f6f6] text-sm font-bold text-[#333333]")}>
+            <span className={cx(avatarClass, "chat-header-avatar-fallback bg-surface-soft text-sm font-bold text-ink-secondary")}>
               {detailRole.name.slice(0, 1).toUpperCase()}
             </span>
           )}
@@ -47,11 +47,11 @@ export function ChatHeader({
           alt={`${activeRole.name} avatar`}
         />
       ) : (
-        <span className={cx(avatarClass, "chat-header-avatar-fallback bg-[#f6f6f6] text-sm font-bold text-[#333333]")}>
+        <span className={cx(avatarClass, "chat-header-avatar-fallback bg-surface-soft text-sm font-bold text-ink-secondary")}>
           {activeRole ? activeRole.name.slice(0, 1).toUpperCase() : "M"}
         </span>
       )}
-      <div className="chat-header-title min-w-0 flex-1 truncate text-sm font-semibold text-[#1f1f1f]">{title}</div>
+      <div className="chat-header-title min-w-0 flex-1 truncate text-sm font-semibold text-ink">{title}</div>
     </header>
   );
 }

--- a/apps/desktop/renderer/src/chat/ChatImageLightbox.tsx
+++ b/apps/desktop/renderer/src/chat/ChatImageLightbox.tsx
@@ -59,7 +59,7 @@ export function ChatImageLightbox({
   } | null>(null);
   const stageRef = useRef<HTMLDivElement | null>(null);
   const navigationButtonClass =
-    "pointer-events-auto grid h-10 w-10 place-items-center rounded-full border border-transparent bg-transparent text-[#4B5563] transition hover:border-black hover:bg-white/92 hover:text-[#1F2937] focus:outline-none disabled:cursor-default disabled:opacity-40";
+    "pointer-events-auto grid h-10 w-10 place-items-center rounded-full border border-transparent bg-transparent text-ink-secondary transition hover:border-black hover:bg-white/92 hover:text-ink focus:outline-none disabled:cursor-default disabled:opacity-40";
   const fittedImageSize = fitChatImageToStage(stageSize, imageNaturalSize);
 
   useEffect(() => {
@@ -185,13 +185,13 @@ export function ChatImageLightbox({
         onClick={onClose}
       />
       <section
-        className="relative z-[1] grid h-full max-h-[min(92vh,980px)] w-full max-w-[min(92vw,1400px)] min-h-0 min-w-0 place-items-center overflow-hidden rounded-[28px] bg-[#F4F7FB] p-5 shadow-[0_32px_90px_rgba(15,23,42,0.22)]"
+        className="relative z-[1] grid h-full max-h-[min(92vh,980px)] w-full max-w-[min(92vw,1400px)] min-h-0 min-w-0 place-items-center overflow-hidden rounded-[28px] bg-surface-soft p-5 shadow-pop"
         role="dialog"
         aria-modal="true"
         aria-label="聊天图片放大预览"
       >
         <button
-          className="absolute right-4 top-4 z-[3] grid h-10 w-10 place-items-center rounded-full border border-black/12 bg-white/94 text-[#272636] shadow-[0_10px_24px_rgba(15,23,42,0.12)] transition hover:border-black hover:bg-white"
+          className="absolute right-4 top-4 z-[3] grid h-10 w-10 place-items-center rounded-full border border-line-soft bg-white/94 text-ink shadow-soft transition hover:border-black hover:bg-white"
           type="button"
           aria-label="关闭聊天图片弹层"
           onClick={onClose}
@@ -200,7 +200,7 @@ export function ChatImageLightbox({
         </button>
         <div
           ref={stageRef}
-          className="relative grid h-full w-full min-h-0 min-w-0 place-items-center overflow-hidden rounded-xl bg-[#F4F7FB]"
+          className="relative grid h-full w-full min-h-0 min-w-0 place-items-center overflow-hidden rounded-xl bg-surface-soft"
           onWheel={handleWheel}
         >
           <div className="pointer-events-none absolute inset-y-0 left-0 z-[2] flex items-center pl-4">
@@ -258,7 +258,7 @@ export function ChatImageLightbox({
           </div>
           <div className="pointer-events-none absolute bottom-4 right-4 z-[2] flex items-center gap-3">
             <button
-              className="pointer-events-auto grid h-11 w-11 place-items-center rounded-full border border-black/12 bg-white/94 text-[#272636] shadow-[0_10px_24px_rgba(15,23,42,0.12)] transition hover:border-black hover:bg-white disabled:cursor-default disabled:opacity-40"
+              className="pointer-events-auto grid h-11 w-11 place-items-center rounded-full border border-line-soft bg-white/94 text-ink shadow-soft transition hover:border-black hover:bg-white disabled:cursor-default disabled:opacity-40"
               type="button"
               aria-label="重新生成图片"
               title="重新生成图片"
@@ -268,7 +268,7 @@ export function ChatImageLightbox({
               <ArrowClockwise className={`h-5 w-5 ${regenerating ? "animate-spin" : ""}`} weight="bold" />
             </button>
             <button
-              className="pointer-events-auto grid h-11 w-11 place-items-center rounded-full border border-black/12 bg-white/94 text-[#272636] shadow-[0_10px_24px_rgba(15,23,42,0.12)] transition hover:border-black hover:bg-white disabled:cursor-default disabled:opacity-40"
+              className="pointer-events-auto grid h-11 w-11 place-items-center rounded-full border border-line-soft bg-white/94 text-ink shadow-soft transition hover:border-black hover:bg-white disabled:cursor-default disabled:opacity-40"
               type="button"
               aria-label="定位到对应消息"
               onClick={onLocateMessage}
@@ -277,7 +277,7 @@ export function ChatImageLightbox({
               <LocateIcon className="h-5 w-5 fill-current" />
             </button>
             <button
-              className="pointer-events-auto grid h-11 w-11 place-items-center rounded-full border border-black/12 bg-white/94 text-[#272636] shadow-[0_10px_24px_rgba(15,23,42,0.12)] transition hover:border-black hover:bg-white disabled:cursor-default disabled:opacity-40"
+              className="pointer-events-auto grid h-11 w-11 place-items-center rounded-full border border-line-soft bg-white/94 text-ink shadow-soft transition hover:border-black hover:bg-white disabled:cursor-default disabled:opacity-40"
               type="button"
               aria-label="加入素材库"
               onClick={onAddToAssetLibrary}

--- a/apps/desktop/renderer/src/chat/ChatMarkdownContent.tsx
+++ b/apps/desktop/renderer/src/chat/ChatMarkdownContent.tsx
@@ -28,19 +28,19 @@ const markdownComponents: Components = {
     return <div className="my-2 max-w-full overflow-x-auto"><table>{children}</table></div>;
   },
   pre({ children }) {
-    return <pre className="my-2 max-w-full overflow-x-auto rounded-md bg-[#F4F5F7] p-3 font-mono text-[12px] leading-5">{children}</pre>;
+    return <pre className="my-2 max-w-full overflow-x-auto rounded-md bg-surface-soft p-3 font-mono text-[12px] leading-5">{children}</pre>;
   },
   code({ className, children }) {
     const isBlock = Boolean(className);
     return isBlock
       ? <code className={className}>{children}</code>
-      : <code className="rounded-md bg-[#F0F1F3] px-1 py-0.5 font-mono text-[0.9em]">{children}</code>;
+      : <code className="rounded-md bg-surface-soft px-1 py-0.5 font-mono text-[0.9em]">{children}</code>;
   },
   blockquote({ children }) {
-    return <blockquote className="my-2 border-l-2 border-[#C9CED8] pl-3 text-[#626A78]">{children}</blockquote>;
+    return <blockquote className="my-2 border-l-2 border-line pl-3 text-ink-muted">{children}</blockquote>;
   },
   hr() {
-    return <hr className="my-3 border-0 border-t border-[#D8DDE5]" />;
+    return <hr className="my-3 border-0 border-t border-line-soft" />;
   },
   h1({ children }) { return <h1 className="my-3 text-lg font-semibold">{children}</h1>; },
   h2({ children }) { return <h2 className="my-2.5 text-base font-semibold">{children}</h2>; },

--- a/apps/desktop/renderer/src/chat/ChatMessageAttachments.tsx
+++ b/apps/desktop/renderer/src/chat/ChatMessageAttachments.tsx
@@ -36,7 +36,7 @@ export function ChatMessageAttachments({
         isChatImageAsset(item) ? (
           <button
             key={`${messageKey}:${mediaIndex}:${item}`}
-            className="block w-fit max-w-full cursor-grab overflow-hidden rounded-md border border-black/8 bg-white/70 p-0 text-left transition hover:bg-white active:cursor-grabbing focus:outline-none"
+            className="block w-fit max-w-full cursor-grab overflow-hidden rounded-md border border-line-soft bg-white/70 p-0 text-left transition hover:bg-white active:cursor-grabbing focus:outline-none"
             type="button"
             draggable
             onDragStart={(event) => handleAttachmentDragStart(event, item)}
@@ -50,11 +50,11 @@ export function ChatMessageAttachments({
             href={toFileUrl(item)}
             target="_blank"
             rel="noreferrer"
-            className="inline-flex max-w-[280px] cursor-grab items-center gap-2.5 rounded-full border border-black/8 bg-[#F7F7F8] px-3 py-2 text-[12px] text-[#1F2937] transition hover:bg-white active:cursor-grabbing focus:outline-none"
+            className="inline-flex max-w-[280px] cursor-grab items-center gap-2.5 rounded-full border border-line-soft bg-surface-soft px-3 py-2 text-[12px] text-ink transition hover:bg-white active:cursor-grabbing focus:outline-none"
             draggable
             onDragStart={(event) => handleAttachmentDragStart(event, item)}
           >
-            <span className="grid h-6 w-6 flex-none place-items-center rounded-full bg-transparent text-[#8B95A7]">
+            <span className="grid h-6 w-6 flex-none place-items-center rounded-full bg-transparent text-ink-faint">
               <DocumentIcon className="h-[13px] w-[13px] stroke-current" />
             </span>
             <span className="truncate font-medium">{getChatAttachmentName(item)}</span>

--- a/apps/desktop/renderer/src/chat/ChatMessageContextMenu.tsx
+++ b/apps/desktop/renderer/src/chat/ChatMessageContextMenu.tsx
@@ -26,7 +26,7 @@ export function ChatMessageContextMenu({
     <div
       ref={menuRef}
       data-testid="message-context-menu"
-      className="fixed z-50 min-w-[132px] overflow-hidden rounded-md border border-[#E4E7EC] bg-white py-1 text-sm text-[#1F2937] shadow-[0_16px_40px_rgba(15,23,42,0.16)]"
+      className="fixed z-50 min-w-[132px] overflow-hidden rounded-md border border-line-soft bg-white py-1 text-sm text-ink shadow-pop"
       style={{ left: menu.x, top: menu.y }}
       role="menu"
       onClick={(event) => event.stopPropagation()}
@@ -37,7 +37,7 @@ export function ChatMessageContextMenu({
     >
       <button
         data-testid="message-context-menu-copy"
-        className="flex h-8 w-full items-center gap-2 px-3 text-left transition hover:bg-[#F5F7FA] focus:bg-[#F5F7FA] focus:outline-none disabled:cursor-default disabled:opacity-45"
+        className="flex h-8 w-full items-center gap-2 px-3 text-left transition hover:bg-surface-soft focus:bg-surface-soft focus:outline-none disabled:cursor-default disabled:opacity-45"
         type="button"
         role="menuitem"
         onClick={onCopy}
@@ -48,7 +48,7 @@ export function ChatMessageContextMenu({
       </button>
       <button
         data-testid="message-context-menu-quote"
-        className="flex h-8 w-full items-center gap-2 px-3 text-left transition hover:bg-[#F5F7FA] focus:bg-[#F5F7FA] focus:outline-none disabled:cursor-default disabled:opacity-45"
+        className="flex h-8 w-full items-center gap-2 px-3 text-left transition hover:bg-surface-soft focus:bg-surface-soft focus:outline-none disabled:cursor-default disabled:opacity-45"
         type="button"
         role="menuitem"
         onClick={onQuote}

--- a/apps/desktop/renderer/src/chat/ChatMessageRow.tsx
+++ b/apps/desktop/renderer/src/chat/ChatMessageRow.tsx
@@ -33,12 +33,12 @@ type ChatMessageRowProps = {
 };
 
 const agentAvatarClass =
-  "message-avatar grid h-8 w-8 flex-none place-items-center overflow-hidden rounded-full border border-black/10 bg-[#f6f6f6] object-cover";
+  "message-avatar grid h-8 w-8 flex-none place-items-center overflow-hidden rounded-full border border-line-soft bg-surface-soft object-cover";
 const chatMinorTextClass = "text-[12px]";
 const assistantMessageBubbleClass =
-  "message-bubble w-fit max-w-full rounded-md border border-[rgba(228,228,228,0.66)] bg-[rgba(255,255,255,0.78)] px-3.5 py-2.5 text-left shadow-[0_1px_2px_rgba(0,0,0,0.03)] transition-colors duration-150 group-hover:bg-[rgba(255,255,255,0.9)]";
+  "message-bubble w-fit max-w-full rounded-lg border border-white/70 bg-white/80 px-3.5 py-2.5 text-left shadow-soft transition-colors duration-150 group-hover:bg-white/95";
 const userMessageBubbleClass =
-  "message-bubble w-fit max-w-full rounded-md border border-[#E4E4E4] bg-white px-3.5 py-2.5 text-left shadow-[0_1px_2px_rgba(0,0,0,0.04)]";
+  "message-bubble w-fit max-w-full rounded-lg border border-line-soft bg-white px-3.5 py-2.5 text-left shadow-soft";
 
 /** Renders one independently memoized chat message so unaffected Markdown stays out of updates. */
 export const ChatMessageRow = React.memo(function ChatMessageRow({
@@ -67,7 +67,7 @@ export const ChatMessageRow = React.memo(function ChatMessageRow({
   const toolChain = presentation.toolChain;
   const hasToolCalls = toolChain.some((group) => group.calls.length > 0);
   const bubbleClass = isError
-    ? "message-bubble w-fit max-w-full rounded-md border border-[rgba(176,58,58,0.22)] bg-[rgba(255,244,244,0.96)] px-3.5 py-2.5 text-left text-[#8f2d2d] shadow-[0_1px_2px_rgba(0,0,0,0.04)]"
+    ? "message-bubble w-fit max-w-full rounded-lg border border-[var(--danger-300)] bg-danger-soft px-3.5 py-2.5 text-left text-danger-text shadow-soft"
     : isUser
       ? userMessageBubbleClass
       : assistantMessageBubbleClass;
@@ -103,9 +103,9 @@ export const ChatMessageRow = React.memo(function ChatMessageRow({
             </span>
           )
         ) : null}
-        <div className={cx("message-body flex min-w-0 w-full max-w-[82%] flex-col text-sm leading-6 text-[#1f1f1f]", isUser && "ml-auto items-end")}>
+        <div className={cx("message-body flex min-w-0 w-full max-w-[82%] flex-col text-sm leading-6 text-ink", isUser && "ml-auto items-end")}>
           {!isUser ? (
-            <div className={cx("message-author mb-1 font-medium leading-none text-[#b9b9b9]", chatMinorTextClass)}>
+            <div className={cx("message-author mb-1 font-medium leading-none text-ink-faint", chatMinorTextClass)}>
               {authorLabel}
             </div>
           ) : null}
@@ -118,7 +118,7 @@ export const ChatMessageRow = React.memo(function ChatMessageRow({
               && !hasToolCalls
               && !presentation.hasIntermediateNarrative
               && "hidden",
-            isHighlighted && "message-bubble-highlight ring-2 ring-[#111827]/10",
+            isHighlighted && "message-bubble-highlight ring-2 ring-ring-soft",
           )}>
             {storedReplyPreview ? (
               storedReplyPreview.messageId ? (
@@ -128,19 +128,19 @@ export const ChatMessageRow = React.memo(function ChatMessageRow({
                   aria-label="跳转到被引用消息"
                   onClick={() => onJumpToMessage(storedReplyPreview.messageId)}
                 >
-                  <div className="border-l-2 border-[#AEB7C5] pl-2.5">
+                  <div className="border-l-2 border-line-accent pl-2.5">
                     {storedReplyPreview.sender ? (
-                      <div className="truncate text-[11px] font-medium leading-4 text-[#6B7280]">{storedReplyPreview.sender}</div>
+                      <div className="truncate text-[11px] font-medium leading-4 text-ink-muted">{storedReplyPreview.sender}</div>
                     ) : null}
-                    <div className="line-clamp-2 text-[12px] leading-5 text-[#7B8190]">{storedReplyPreview.preview}</div>
+                    <div className="line-clamp-2 text-[12px] leading-5 text-ink-faint">{storedReplyPreview.preview}</div>
                   </div>
                 </button>
               ) : (
-                <div className="mb-2 max-w-[420px] border-l-2 border-[#AEB7C5] pl-2.5 text-left">
+                <div className="mb-2 max-w-[420px] border-l-2 border-line-accent pl-2.5 text-left">
                   {storedReplyPreview.sender ? (
-                    <div className="truncate text-[11px] font-medium leading-4 text-[#6B7280]">{storedReplyPreview.sender}</div>
+                    <div className="truncate text-[11px] font-medium leading-4 text-ink-muted">{storedReplyPreview.sender}</div>
                   ) : null}
-                  <div className="line-clamp-2 text-[12px] leading-5 text-[#7B8190]">{storedReplyPreview.preview}</div>
+                  <div className="line-clamp-2 text-[12px] leading-5 text-ink-faint">{storedReplyPreview.preview}</div>
                 </div>
               )
             ) : null}

--- a/apps/desktop/renderer/src/chat/ChatModelMenu.tsx
+++ b/apps/desktop/renderer/src/chat/ChatModelMenu.tsx
@@ -110,7 +110,7 @@ export function ChatModelMenu({ activeRoleId, bridgeReady }: ChatModelMenuProps)
   return (
     <div className="relative" ref={containerRef}>
       <button
-        className="inline-flex h-[30px] max-w-[190px] items-center rounded-md px-2 text-xs text-[#5B6472] transition hover:bg-[#F3F5F7] hover:text-[#22272E] focus:outline-none disabled:opacity-40"
+        className="inline-flex h-[30px] max-w-[190px] items-center rounded-md px-2 text-xs text-ink-secondary transition hover:bg-surface-soft hover:text-ink focus:outline-none disabled:opacity-40"
         type="button"
         aria-label="选择聊天模型"
         aria-expanded={open}
@@ -121,28 +121,28 @@ export function ChatModelMenu({ activeRoleId, bridgeReady }: ChatModelMenuProps)
       </button>
       {open && selection && menuPosition ? createPortal(
         <div ref={menuRef} className="fixed z-50 flex items-end gap-1.5" style={menuPosition}>
-          <div className="grid w-[112px] content-start gap-1 rounded-md border border-[#DDE3EA] bg-white p-1.5 shadow-[0_16px_40px_rgba(15,23,42,0.14)]">
+          <div className="grid w-[112px] content-start gap-1 rounded-md border border-line-soft bg-white p-1.5 shadow-pop">
             {(["dialogue", "visual"] as const).map((kind) => (
-              <button key={kind} type="button" className={`flex h-9 items-center justify-between rounded-md px-2 text-left text-xs transition ${submenu === kind ? "bg-[#EEF2F6] text-[#182230]" : "text-[#344054] hover:bg-[#F3F5F7]"}`} aria-current={submenu === kind ? "true" : undefined} onMouseEnter={() => { setSubmenu(kind); setHoveredModelId(null); }} onClick={() => { setSubmenu(kind); setHoveredModelId(null); }}>
+              <button key={kind} type="button" className={`flex h-9 items-center justify-between rounded-md px-2 text-left text-xs transition ${submenu === kind ? "bg-surface-soft text-ink" : "text-ink-secondary hover:bg-surface-soft"}`} aria-current={submenu === kind ? "true" : undefined} onMouseEnter={() => { setSubmenu(kind); setHoveredModelId(null); }} onClick={() => { setSubmenu(kind); setHoveredModelId(null); }}>
                 <span>{kind === "dialogue" ? "聊天模型" : "识图模型"}</span><CaretRight className="h-3 w-3" weight="bold" aria-hidden="true" />
               </button>
             ))}
           </div>
           {submenu ? (
-            <div className="relative min-w-[132px] rounded-md border border-[#DDE3EA] bg-white p-1.5 shadow-[0_16px_40px_rgba(15,23,42,0.14)]">
+            <div className="relative min-w-[132px] rounded-md border border-line-soft bg-white p-1.5 shadow-pop">
               <div className="grid gap-1">
                 {(submenu === "visual" ? [{ id: "", model: "沿用对话模型" }, ...registrations] : registrations).map((registration) => (
-                  <button key={registration.id || "dialogue-fallback"} type="button" className={`flex h-9 items-center justify-between gap-2 rounded-md px-2 text-left text-xs transition ${(submenu === "dialogue" ? selection.dialogueId : selection.visualId) === registration.id ? "bg-[#EEF2F6] text-[#182230]" : "text-[#344054] hover:bg-[#F3F5F7]"}`} aria-current={(submenu === "dialogue" ? selection.dialogueId : selection.visualId) === registration.id ? "true" : undefined} onMouseEnter={() => setHoveredModelId(registration.id)} onClick={() => void updateSelection(submenu, registration.id)}>
+                  <button key={registration.id || "dialogue-fallback"} type="button" className={`flex h-9 items-center justify-between gap-2 rounded-md px-2 text-left text-xs transition ${(submenu === "dialogue" ? selection.dialogueId : selection.visualId) === registration.id ? "bg-surface-soft text-ink" : "text-ink-secondary hover:bg-surface-soft"}`} aria-current={(submenu === "dialogue" ? selection.dialogueId : selection.visualId) === registration.id ? "true" : undefined} onMouseEnter={() => setHoveredModelId(registration.id)} onClick={() => void updateSelection(submenu, registration.id)}>
                     <span className="max-w-[150px] truncate">{registration.model}</span><span className="flex items-center gap-1" aria-hidden="true">{(submenu === "dialogue" ? selection.dialogueId : selection.visualId) === registration.id ? <Check className="h-3 w-3" weight="bold" /> : null}<CaretRight className="h-3 w-3" weight="bold" /></span>
                   </button>
                 ))}
               </div>
               {hoveredModelId !== null ? (
-                <div className="absolute left-full top-0 ml-1 grid min-w-[150px] gap-1 rounded-md border border-[#DDE3EA] bg-white p-1.5 shadow-[0_16px_40px_rgba(15,23,42,0.14)]">
-                  <span className="px-2 py-1 text-[11px] text-[#667085]">思考强度</span>
+                <div className="absolute left-full top-0 ml-1 grid min-w-[150px] gap-1 rounded-md border border-line-soft bg-white p-1.5 shadow-pop">
+                  <span className="px-2 py-1 text-[11px] text-ink-muted">思考强度</span>
                   {(["none", "low", "high", "max"] as const).map((effort) => {
                     const selected = (submenu === "dialogue" ? selection.dialogueEffort : selection.visualEffort) === effort;
-                    return <button key={effort} type="button" className={`flex items-center justify-between rounded-md px-2 py-2 text-left text-xs transition ${selected ? "bg-[#EEF2F6] text-[#182230]" : "text-[#344054] hover:bg-[#F3F5F7]"}`} aria-current={selected ? "true" : undefined} onClick={() => void updateSelection(submenu === "dialogue" ? "dialogueEffort" : "visualEffort", effort)}><span>{effort === "none" ? "关闭" : effort === "low" ? "低" : effort === "high" ? "高" : "最大"}</span>{selected ? <Check className="h-3 w-3" weight="bold" aria-hidden="true" /> : null}</button>;
+                    return <button key={effort} type="button" className={`flex items-center justify-between rounded-md px-2 py-2 text-left text-xs transition ${selected ? "bg-surface-soft text-ink" : "text-ink-secondary hover:bg-surface-soft"}`} aria-current={selected ? "true" : undefined} onClick={() => void updateSelection(submenu === "dialogue" ? "dialogueEffort" : "visualEffort", effort)}><span>{effort === "none" ? "关闭" : effort === "low" ? "低" : effort === "high" ? "高" : "最大"}</span>{selected ? <Check className="h-3 w-3" weight="bold" aria-hidden="true" /> : null}</button>;
                   })}
                 </div>
               ) : null}

--- a/apps/desktop/renderer/src/chat/ChatReplyMetrics.tsx
+++ b/apps/desktop/renderer/src/chat/ChatReplyMetrics.tsx
@@ -16,7 +16,7 @@ export const ChatReplyMetrics = React.memo(function ChatReplyMetrics({
   if (!showDuration && metrics.total_tokens === undefined) return null;
 
   return (
-    <div className="mt-2 flex items-center gap-2 text-[11px] tabular-nums text-[#98A0AD]">
+    <div className="mt-2 flex items-center gap-2 text-[11px] tabular-nums text-ink-faint">
       {showDuration ? <span>{formatThinkingDuration(metrics.thinking_duration_ms!)}</span> : null}
       {metrics.total_tokens !== undefined ? <span>{metrics.total_tokens.toLocaleString()} tokens</span> : null}
     </div>

--- a/apps/desktop/renderer/src/chat/ChatRightSidebar.tsx
+++ b/apps/desktop/renderer/src/chat/ChatRightSidebar.tsx
@@ -54,7 +54,7 @@ export const ChatRightSidebar = React.memo(function ChatRightSidebar({
   onOpenImageLightbox,
 }: ChatRightSidebarProps) {
   const navButtonClass =
-    "pointer-events-auto grid h-9 w-9 place-items-center rounded-md border border-[#DCE3EC] bg-white/75 text-[#4B5563] shadow-[0_2px_8px_rgba(15,23,42,0.06)] transition-colors hover:border-[#B8C2CE] hover:bg-white hover:text-[#1F2937] focus:outline-none focus:ring-0 disabled:cursor-default disabled:opacity-40";
+    "pointer-events-auto grid h-9 w-9 place-items-center rounded-md border border-line-soft bg-white/75 text-ink-secondary shadow-soft transition-colors hover:border-line hover:bg-white hover:text-ink focus:outline-none focus:ring-0 disabled:cursor-default disabled:opacity-40";
   if (mode === "status") {
     return (
       <ChatStatusSidebar
@@ -97,7 +97,7 @@ export const ChatRightSidebar = React.memo(function ChatRightSidebar({
         ) : (
           <div className="grid gap-2 px-6 text-center">
             <div className="mx-auto h-10 w-10 rounded-md bg-white/70" />
-            <div className="text-[12px] text-[#6B7280]">当前聊天里出现的图片会显示在这里</div>
+            <div className="text-[12px] text-ink-muted">当前聊天里出现的图片会显示在这里</div>
           </div>
         )}
         <div className="pointer-events-none absolute inset-y-0 right-0 z-[2] flex items-center pr-3">

--- a/apps/desktop/renderer/src/chat/ChatStatusSidebar.tsx
+++ b/apps/desktop/renderer/src/chat/ChatStatusSidebar.tsx
@@ -33,20 +33,20 @@ export function ChatStatusSidebar({
             decoding="async"
           />
         ) : (
-          <div className="grid h-full w-full place-items-center rounded-md bg-[#EEF2F6] text-[12px] text-[#98A2B3]">
+          <div className="grid h-full w-full place-items-center rounded-md bg-accent-softer text-[12px] text-ink-faint">
             {visualsActive ? "当前状态图还没生成" : "窗口隐藏时已暂停图片渲染"}
           </div>
         )}
       </div>
       <div className="text-center">
-        <div className="text-[11px] uppercase tracking-[0.16em] text-[#7A8593]">当前状态</div>
-        <div className="mt-1 text-sm font-semibold text-[#1F2937]">
+        <div className="text-[11px] uppercase tracking-[0.16em] text-ink-faint">当前状态</div>
+        <div className="mt-1 text-sm font-semibold text-accent-text">
           {currentMood || "未生成"}
         </div>
       </div>
       <div className="rounded-md px-3 py-3 text-left">
-        <div className="text-[11px] uppercase tracking-[0.16em] text-[#7A8593]">当下想法</div>
-        <div className="mt-2 text-[13px] leading-6 text-[#334155]">
+        <div className="text-[11px] uppercase tracking-[0.16em] text-ink-faint">当下想法</div>
+        <div className="mt-2 text-[13px] leading-6 text-ink-secondary">
           {roleSelfView || "我还在慢慢整理自己现在对你的想法。"}
         </div>
       </div>
@@ -55,23 +55,23 @@ export function ChatStatusSidebar({
           {relationshipTags.map((tag) => (
             <span
               key={tag}
-              className="rounded-md px-2.5 py-1 text-[11px] leading-none text-[#556070]"
+              className="rounded-full bg-accent-soft px-2.5 py-1 text-[11px] leading-none text-accent-text"
             >
               {tag}
             </span>
           ))}
         </div>
       ) : (
-        <div className="text-[11px] text-[#8A94A3]">关系标签还在生成中</div>
+        <div className="text-[11px] text-ink-faint">关系标签还在生成中</div>
       )}
       <div className="rounded-md px-3 py-3">
         <div className="flex items-center justify-between gap-3">
-          <div className="text-[11px] uppercase tracking-[0.16em] text-[#7A8593]">寂寞值</div>
-          <div className="text-sm font-semibold text-[#1F2937]">{Math.round(normalizedLoneliness)}</div>
+          <div className="text-[11px] uppercase tracking-[0.16em] text-ink-faint">寂寞值</div>
+          <div className="text-sm font-semibold tabular-nums text-ink">{Math.round(normalizedLoneliness)}</div>
         </div>
-        <div className="mt-2 h-2 overflow-hidden rounded-full bg-[#E6EBF2]">
+        <div className="mt-2 h-2 overflow-hidden rounded-full bg-accent-soft">
           <div
-            className="h-full rounded-full bg-[linear-gradient(90deg,#A6B8D6_0%,#65758E_100%)] transition-[width] duration-300"
+            className="h-full rounded-full bg-gradient-accent transition-[width] duration-300"
             style={{ width: `${normalizedLoneliness}%` }}
           />
         </div>

--- a/apps/desktop/renderer/src/chat/ChatStatusSidebar.tsx
+++ b/apps/desktop/renderer/src/chat/ChatStatusSidebar.tsx
@@ -71,7 +71,7 @@ export function ChatStatusSidebar({
         </div>
         <div className="mt-2 h-2 overflow-hidden rounded-full bg-accent-soft">
           <div
-            className="h-full rounded-full bg-gradient-accent-strong transition-[width] duration-300"
+            className="h-full rounded-full bg-gradient-accent-medium transition-[width] duration-300"
             style={{ width: `${normalizedLoneliness}%` }}
           />
         </div>

--- a/apps/desktop/renderer/src/chat/ChatStatusSidebar.tsx
+++ b/apps/desktop/renderer/src/chat/ChatStatusSidebar.tsx
@@ -71,7 +71,7 @@ export function ChatStatusSidebar({
         </div>
         <div className="mt-2 h-2 overflow-hidden rounded-full bg-accent-soft">
           <div
-            className="h-full rounded-full bg-gradient-accent transition-[width] duration-300"
+            className="h-full rounded-full bg-gradient-accent-strong transition-[width] duration-300"
             style={{ width: `${normalizedLoneliness}%` }}
           />
         </div>

--- a/apps/desktop/renderer/src/chat/ChatSurface.test.tsx
+++ b/apps/desktop/renderer/src/chat/ChatSurface.test.tsx
@@ -146,7 +146,7 @@ describe("ChatSurface", () => {
     const bubbleClass = markup.match(/class="([^"]*message-bubble[^"]*)"/)?.[1];
 
     assert.ok(bubbleClass);
-    assert.match(bubbleClass, /bg-\[rgba\(255,255,255,0\.78\)\]/);
+    assert.match(bubbleClass, /bg-white\/80/);
     assert.doesNotMatch(bubbleClass, /backdrop-blur/);
   });
 
@@ -221,7 +221,7 @@ describe("ChatSurface", () => {
 
     assert.match(markup, /class="group w-full"/);
     assert.match(markup, /message-row flex w-full items-start gap-3/);
-    assert.match(markup, /message-body flex min-w-0 w-full max-w-\[82%\] flex-col text-sm leading-6 text-\[#1f1f1f\]/);
+    assert.match(markup, /message-body flex min-w-0 w-full max-w-\[82%\] flex-col text-sm leading-6 text-ink/);
     assert.match(markup, /ml-auto items-end/);
   });
 

--- a/apps/desktop/renderer/src/chat/ChatSurface.tsx
+++ b/apps/desktop/renderer/src/chat/ChatSurface.tsx
@@ -554,7 +554,7 @@ export function ChatSurface({
       </div>
       <div
         className={cx(
-          "relative h-full overflow-hidden border-l border-line-soft bg-transparent",
+          "relative h-full overflow-hidden border-l border-line-soft bg-gradient-app bg-fixed",
           chatLatestImageSidebarAnimating && "transition-[width] duration-[480ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
           chatLatestImageSidebarResizing && !chatLatestImageSidebarAnimating && "transition-[width] duration-100 ease-out",
         )}

--- a/apps/desktop/renderer/src/chat/ChatSurface.tsx
+++ b/apps/desktop/renderer/src/chat/ChatSurface.tsx
@@ -463,7 +463,7 @@ export function ChatSurface({
   return (
     <section className="chat-surface relative grid h-full min-h-0 grid-cols-[minmax(0,1fr)_auto] overflow-hidden bg-[var(--chat-bg)]">
       <button
-        className="absolute right-4 top-4 z-[5] m-0 grid h-6 w-6 place-items-center rounded-md border-0 bg-transparent p-0 text-[#747474] transition hover:bg-black/5 hover:text-[#4B4B4B] focus:outline-none"
+        className="absolute right-4 top-4 z-[5] m-0 grid h-6 w-6 place-items-center rounded-md border-0 bg-transparent p-0 text-ink-muted transition hover:bg-black/5 hover:text-ink-secondary focus:outline-none"
         type="button"
         aria-label={chatLatestImageSidebarCollapsed ? "展开最新图片侧栏" : "收起最新图片侧栏"}
         aria-expanded={!chatLatestImageSidebarCollapsed}
@@ -507,7 +507,7 @@ export function ChatSurface({
         onOpenRoleDetail={handleOpenRoleDetail}
       />
       <section className="conversation-panel relative z-[1] h-full min-h-0 overflow-hidden bg-transparent">
-        {notice ? <div className="notice-chip absolute left-1/2 top-4 z-[2] -translate-x-1/2 rounded-md border border-[rgba(26,106,58,0.18)] bg-[#edf8f0] px-3.5 py-2.5 text-[#1a6a3a]">{notice}</div> : null}
+        {notice ? <div className="notice-chip absolute left-1/2 top-4 z-[2] -translate-x-1/2 rounded-md border border-[var(--success-300)] bg-success-soft px-3.5 py-2.5 text-success-text">{notice}</div> : null}
         <ChatMessageList
           activeRole={activeRole}
           sessionKey={activeSession?.key ?? ""}
@@ -526,7 +526,7 @@ export function ChatSurface({
         {showScrollToBottom ? (
           <div className="pointer-events-none absolute inset-x-0 bottom-[132px] z-[2] flex justify-center">
             <button
-              className="pointer-events-auto grid h-9 w-9 place-items-center rounded-full border border-[#E4E4E4] bg-[rgba(255,255,255,0.96)] text-[#4b5563] shadow-[0_10px_24px_rgba(17,24,39,0.08)] transition hover:border-[#d5d5d5] hover:bg-white hover:text-[#1f2937] focus:outline-none"
+              className="pointer-events-auto grid h-9 w-9 place-items-center rounded-full border border-line-soft bg-[rgba(255,255,255,0.96)] text-ink-secondary shadow-soft transition hover:border-line hover:bg-white hover:text-ink focus:outline-none"
               type="button"
               aria-label="滑到最下方"
               onClick={handleScrollToBottom}
@@ -554,7 +554,7 @@ export function ChatSurface({
       </div>
       <div
         className={cx(
-          "relative h-full overflow-hidden border-l border-[#E0E6EE] bg-[rgba(244,247,251,0.92)]",
+          "relative h-full overflow-hidden border-l border-line-soft bg-transparent",
           chatLatestImageSidebarAnimating && "transition-[width] duration-[480ms] ease-[cubic-bezier(0.22,1,0.36,1)]",
           chatLatestImageSidebarResizing && !chatLatestImageSidebarAnimating && "transition-[width] duration-100 ease-out",
         )}
@@ -562,7 +562,7 @@ export function ChatSurface({
       >
         {!chatLatestImageSidebarCollapsed ? (
           <div
-            className="absolute inset-y-0 left-0 z-[3] w-3 -translate-x-1/2 cursor-col-resize before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-[#D8DEE8] before:content-['']"
+            className="absolute inset-y-0 left-0 z-[3] w-3 -translate-x-1/2 cursor-col-resize before:absolute before:inset-y-0 before:left-1/2 before:w-px before:-translate-x-1/2 before:bg-line-soft before:content-['']"
             onPointerDown={onBeginChatLatestImageSidebarResize}
           />
         ) : null}
@@ -596,12 +596,12 @@ export function ChatSurface({
                 onGoToPreviousImage={onGoToPreviousChatImage}
                 onOpenImageLightbox={onOpenChatImageLightbox}
               />
-              <div className="justify-self-center inline-flex w-fit rounded-full border border-[#D8DFE7] bg-[#F6F8FB] p-1">
+              <div className="justify-self-center inline-flex w-fit rounded-full border border-line-soft bg-surface-soft p-1">
                 <button
                   className={cx(
                     sidebarModeButtonClass,
-                    sidebarMode === "status" ? "bg-[#272536] text-white shadow-[0_6px_16px_rgba(39,37,54,0.18)]" : "text-[#5B6472] hover:text-[#272536]",
-                    !hasStatusContent && "cursor-default opacity-45 hover:text-[#5B6472]",
+                    sidebarMode === "status" ? "bg-gradient-accent text-white shadow-soft" : "text-ink-secondary hover:text-ink",
+                    !hasStatusContent && "cursor-default opacity-45 hover:text-ink-secondary",
                   )}
                   type="button"
                   aria-label="状态侧栏"
@@ -613,7 +613,7 @@ export function ChatSurface({
                   </svg>
                 </button>
                 <button
-                  className={cx(sidebarModeButtonClass, sidebarMode === "tasks" ? "bg-[#272536] text-white shadow-[0_6px_16px_rgba(39,37,54,0.18)]" : "text-[#5B6472] hover:text-[#272536]")}
+                  className={cx(sidebarModeButtonClass, sidebarMode === "tasks" ? "bg-gradient-accent text-white shadow-soft" : "text-ink-secondary hover:text-ink")}
                   type="button"
                   aria-label="任务侧栏"
                   onClick={() => setSidebarMode("tasks")}
@@ -623,7 +623,7 @@ export function ChatSurface({
                 <button
                   className={cx(
                     sidebarModeButtonClass,
-                    sidebarMode === "images" ? "bg-[#272536] text-white shadow-[0_6px_16px_rgba(39,37,54,0.18)]" : "text-[#5B6472] hover:text-[#272536]",
+                    sidebarMode === "images" ? "bg-gradient-accent text-white shadow-soft" : "text-ink-secondary hover:text-ink",
                   )}
                   type="button"
                   aria-label="图片侧栏"

--- a/apps/desktop/renderer/src/chat/ChatSurface.tsx
+++ b/apps/desktop/renderer/src/chat/ChatSurface.tsx
@@ -461,7 +461,7 @@ export function ChatSurface({
   }
 
   return (
-    <section className="chat-surface relative grid h-full min-h-0 grid-cols-[minmax(0,1fr)_auto] overflow-hidden bg-[var(--chat-bg)]">
+    <section className="chat-surface relative grid h-full min-h-0 grid-cols-[minmax(0,1fr)_auto] overflow-hidden bg-gradient-app bg-fixed">
       <button
         className="absolute right-4 top-4 z-[5] m-0 grid h-6 w-6 place-items-center rounded-md border-0 bg-transparent p-0 text-ink-muted transition hover:bg-black/5 hover:text-ink-secondary focus:outline-none"
         type="button"
@@ -600,7 +600,7 @@ export function ChatSurface({
                 <button
                   className={cx(
                     sidebarModeButtonClass,
-                    sidebarMode === "status" ? "bg-gradient-accent text-white shadow-soft" : "text-ink-secondary hover:text-ink",
+                    sidebarMode === "status" ? "bg-gradient-accent text-ink shadow-soft" : "text-ink-secondary hover:text-ink",
                     !hasStatusContent && "cursor-default opacity-45 hover:text-ink-secondary",
                   )}
                   type="button"
@@ -613,7 +613,7 @@ export function ChatSurface({
                   </svg>
                 </button>
                 <button
-                  className={cx(sidebarModeButtonClass, sidebarMode === "tasks" ? "bg-gradient-accent text-white shadow-soft" : "text-ink-secondary hover:text-ink")}
+                  className={cx(sidebarModeButtonClass, sidebarMode === "tasks" ? "bg-gradient-accent text-ink shadow-soft" : "text-ink-secondary hover:text-ink")}
                   type="button"
                   aria-label="任务侧栏"
                   onClick={() => setSidebarMode("tasks")}
@@ -623,7 +623,7 @@ export function ChatSurface({
                 <button
                   className={cx(
                     sidebarModeButtonClass,
-                    sidebarMode === "images" ? "bg-gradient-accent text-white shadow-soft" : "text-ink-secondary hover:text-ink",
+                    sidebarMode === "images" ? "bg-gradient-accent text-ink shadow-soft" : "text-ink-secondary hover:text-ink",
                   )}
                   type="button"
                   aria-label="图片侧栏"

--- a/apps/desktop/renderer/src/chat/ChatThinkingBlock.tsx
+++ b/apps/desktop/renderer/src/chat/ChatThinkingBlock.tsx
@@ -23,21 +23,21 @@ export const ChatThinkingBlock = React.memo(function ChatThinkingBlock({
       <button
         type="button"
         aria-expanded={expanded}
-        className="-mx-1.5 flex items-center gap-2 rounded-md px-1.5 py-1 text-left text-[13px] font-medium text-[#626A78] transition-colors duration-150 hover:bg-black/[0.04]"
+        className="-mx-1.5 flex items-center gap-2 rounded-md px-1.5 py-1 text-left text-[13px] font-medium text-ink-muted transition-colors duration-150 hover:bg-black/[0.04]"
         onClick={() => setExpanded((current) => !current)}
       >
-        <Sparkle size={15} weight="fill" className="text-[#8B95A7]" aria-hidden="true" />
+        <Sparkle size={15} weight="fill" className="text-ink-faint" aria-hidden="true" />
         <span className={cx("chat-thinking-label", streaming && "chat-thinking-label-streaming")}>
           {streaming || thinkingDurationMs === undefined ? "Thinking" : formatThinkingDuration(thinkingDurationMs)}
         </span>
         <CaretDown
           size={14}
-          className={cx("text-[#8B95A7] transition-transform duration-200", expanded && "rotate-180")}
+          className={cx("text-ink-faint transition-transform duration-200", expanded && "rotate-180")}
           aria-hidden="true"
         />
       </button>
       <div className={cx("chat-thinking-content", expanded && "chat-thinking-content-expanded")}>
-        <div className="relative ml-[5px] border-l border-[#E1E5EA] pl-4 pt-1 text-[12px] leading-5 text-[#7A8290]">
+        <div className="relative ml-[5px] border-l border-line-soft pl-4 pt-1 text-[12px] leading-5 text-ink-muted">
           <div className="whitespace-pre-wrap break-words">{content}</div>
           {streaming ? <span className="chat-stream-cursor ml-0.5" aria-hidden="true" /> : null}
         </div>

--- a/apps/desktop/renderer/src/chat/ChatToolCalls.tsx
+++ b/apps/desktop/renderer/src/chat/ChatToolCalls.tsx
@@ -52,7 +52,7 @@ export const ChatToolCalls = React.memo(function ChatToolCalls({
       <button
         type="button"
         aria-expanded={expanded}
-        className="-mx-1.5 flex items-center gap-1.5 rounded-md px-1.5 py-1 text-[12.5px] text-[#626A78] transition-colors duration-150 hover:bg-black/[0.04]"
+        className="-mx-1.5 flex items-center gap-1.5 rounded-md px-1.5 py-1 text-[12.5px] text-ink-muted transition-colors duration-150 hover:bg-black/[0.04]"
         onClick={() => setExpanded((current) => !current)}
       >
         <CaretDown
@@ -62,7 +62,7 @@ export const ChatToolCalls = React.memo(function ChatToolCalls({
         />
         <Wrench size={13} aria-hidden="true" />
         <span>{`${calls.length} 次工具调用`}</span>
-        {runningCount > 0 ? <span className="text-[#8B95A7]">{`${runningCount} 个执行中`}</span> : null}
+        {runningCount > 0 ? <span className="text-ink-faint">{`${runningCount} 个执行中`}</span> : null}
       </button>
       <div className={cx("chat-tool-call-content", expanded && "chat-tool-call-content-expanded")}>
         <div className="min-h-0 overflow-hidden">
@@ -82,7 +82,7 @@ export const ChatToolCalls = React.memo(function ChatToolCalls({
                     className="group/tool-row -mx-[3px] flex h-7 w-[calc(100%+6px)] min-w-0 items-center gap-2 rounded-md px-[3px] text-left transition-colors duration-100 hover:bg-black/[0.04]"
                     onClick={() => toggleCall(call.call_id)}
                   >
-                    <span className="relative flex size-4 shrink-0 items-center justify-center text-[#8B95A7]">
+                    <span className="relative flex size-4 shrink-0 items-center justify-center text-ink-faint">
                       <ToolStatusIcon name={call.name} status={call.status} />
                       {call.status !== "running" ? (
                         <CaretDown
@@ -95,20 +95,20 @@ export const ChatToolCalls = React.memo(function ChatToolCalls({
                         />
                       ) : null}
                     </span>
-                    <span className="shrink-0 text-[12.5px] font-medium text-[#343B47]">{call.name}</span>
-                    <span className="chat-tool-argument-chip inline-flex h-[22px] min-w-0 flex-1 items-center truncate rounded-md bg-black/[0.045] px-1.5 font-mono text-[11.5px] text-[#606875] shadow-[inset_0_0_0_1px_rgba(17,24,39,0.04)] transition-colors duration-100 group-hover/tool-row:bg-black/[0.065]">
+                    <span className="shrink-0 text-[12.5px] font-medium text-ink">{call.name}</span>
+                    <span className="chat-tool-argument-chip inline-flex h-[22px] min-w-0 flex-1 items-center truncate rounded-md bg-black/[0.045] px-1.5 font-mono text-[11.5px] text-ink-muted shadow-[inset_0_0_0_1px_rgba(17,24,39,0.04)] transition-colors duration-100 group-hover/tool-row:bg-black/[0.065]">
                       {details}
                     </span>
                   </button>
                   <div className={cx("chat-tool-call-detail", callExpanded && "chat-tool-call-detail-expanded")}>
                     <div className="min-h-0 overflow-hidden">
-                      <div className="mb-1 ml-2 mt-0.5 border-l border-[#E1E5EA] py-0.5 pl-3.5">
+                      <div className="mb-1 ml-2 mt-0.5 border-l border-line-soft py-0.5 pl-3.5">
                         {call.result ? (
                           <pre className={cx(
-                            "max-h-36 overflow-auto whitespace-pre-wrap break-words font-mono text-[11.5px] leading-[1.6] text-[#667085]",
-                            call.status !== "success" && call.status !== "running" && "text-[#A55454]",
+                            "max-h-36 overflow-auto whitespace-pre-wrap break-words font-mono text-[11.5px] leading-[1.6] text-ink-muted",
+                            call.status !== "success" && call.status !== "running" && "text-danger-text",
                           )}>{call.result}</pre>
-                        ) : <span className="text-[11.5px] leading-[1.6] text-[#98A0AD]">暂无结果</span>}
+                        ) : <span className="text-[11.5px] leading-[1.6] text-ink-faint">暂无结果</span>}
                       </div>
                     </div>
                   </div>
@@ -127,7 +127,7 @@ function ToolStatusIcon({ name, status }: { name: string; status: ChatToolCall["
     return <CircleNotch size={13} className="chat-tool-status-icon chat-tool-running absolute inset-0 m-auto" aria-label="执行中" />;
   }
   if (status !== "success") {
-    return <WarningCircle size={13} weight="fill" className="chat-tool-status-icon absolute inset-0 m-auto text-[#B25D5D] transition-opacity duration-100 group-hover/tool-row:opacity-0" aria-label="执行失败" />;
+    return <WarningCircle size={13} weight="fill" className="chat-tool-status-icon absolute inset-0 m-auto text-danger-text transition-opacity duration-100 group-hover/tool-row:opacity-0" aria-label="执行失败" />;
   }
   const normalized = name.toLowerCase();
   const Icon = normalized.includes("search")

--- a/apps/desktop/renderer/src/chat/RoleTaskDetails.tsx
+++ b/apps/desktop/renderer/src/chat/RoleTaskDetails.tsx
@@ -18,8 +18,8 @@ import {
 function DetailRow({ label, value }: { label: string; value: string }) {
   return (
     <div className="grid gap-1 rounded-md px-3 py-2.5">
-      <span className="text-[10px] font-medium tracking-wide text-[#8A94A3]">{label}</span>
-      <span className="break-words text-xs leading-5 text-[#344054]">{value || "—"}</span>
+      <span className="text-[10px] font-medium tracking-wide text-ink-faint">{label}</span>
+      <span className="break-words text-xs leading-5 text-ink-secondary">{value || "—"}</span>
     </div>
   );
 }
@@ -43,7 +43,7 @@ export function RoleTaskDetails({ task, cancelling, error, confirmingCancel, onB
         <button className={chatSidebarBackButtonClass} type="button" aria-label="返回任务列表" onClick={onBack}>
           <ArrowLeft className="h-4 w-4" />
         </button>
-        <span className="min-w-0 truncate font-semibold text-[#272536]">{task.label}</span>
+        <span className="min-w-0 truncate font-semibold text-ink">{task.label}</span>
       </div>
       <div className={cx(chatSidebarScrollableClass, "grid content-start gap-2")}>
         <DetailRow label="类型" value={taskKindLabels[task.kind]} />
@@ -56,23 +56,23 @@ export function RoleTaskDetails({ task, cancelling, error, confirmingCancel, onB
         {task.next_run_at ? <DetailRow label="下次运行" value={formatTimestamp(task.next_run_at)} /> : null}
       </div>
       <div className="grid gap-2 pt-3">
-        {task.kind === "schedule" && !task.editable ? <div className="text-xs text-[#B45309]">任务运行期间不可编辑</div> : null}
-        {error ? <div className="text-xs text-[#B42318]">{error}</div> : null}
+        {task.kind === "schedule" && !task.editable ? <div className="text-xs text-warning-text">任务运行期间不可编辑</div> : null}
+        {error ? <div className="text-xs text-danger-text">{error}</div> : null}
         {confirmingCancel ? (
           <div className="flex items-center justify-end gap-2 rounded-md p-2">
-            <span className="mr-auto text-xs text-[#667085]">确认取消此任务？</span>
-            <button className={cx("rounded-md px-3 py-2 text-xs transition-colors hover:bg-[#EEF2F6]", focusResetClass)} type="button" disabled={cancelling} onClick={onDismissCancel}>返回</button>
-            <button className={cx("rounded-md bg-[#B42318] px-3 py-2 text-xs text-white transition hover:bg-[#912018] disabled:opacity-50", focusResetClass)} type="button" disabled={cancelling} onClick={onCancel}>{cancelling ? "取消中…" : "确认取消"}</button>
+            <span className="mr-auto text-xs text-ink-muted">确认取消此任务？</span>
+            <button className={cx("rounded-md px-3 py-2 text-xs transition-colors hover:bg-surface-soft", focusResetClass)} type="button" disabled={cancelling} onClick={onDismissCancel}>返回</button>
+            <button className={cx("rounded-md bg-danger px-3 py-2 text-xs text-white transition hover:bg-[var(--danger-700)] disabled:opacity-50", focusResetClass)} type="button" disabled={cancelling} onClick={onCancel}>{cancelling ? "取消中…" : "确认取消"}</button>
           </div>
         ) : (
           <div className="flex justify-end gap-2">
             {task.kind === "schedule" ? (
-              <button className={cx("inline-flex items-center gap-1 rounded-md border border-[#D8DFE7] bg-white/70 px-3 py-2 text-xs transition-colors hover:border-[#B8C2CE] hover:bg-white disabled:opacity-50", focusResetClass)} type="button" disabled={!task.editable} onClick={onEdit}>
+              <button className={cx("inline-flex items-center gap-1 rounded-md border border-line-soft bg-white/70 px-3 py-2 text-xs transition-colors hover:border-line hover:bg-white disabled:opacity-50", focusResetClass)} type="button" disabled={!task.editable} onClick={onEdit}>
                 <PencilSimple className="h-4 w-4" />编辑
               </button>
             ) : null}
             {task.cancellable ? (
-              <button className={cx("inline-flex items-center gap-1 rounded-md border border-[#E6B8B3] bg-white/70 px-3 py-2 text-xs text-[#B42318] transition-colors hover:border-[#B42318] hover:bg-white", focusResetClass)} type="button" onClick={onBeginCancel}>
+              <button className={cx("inline-flex items-center gap-1 rounded-md border border-[var(--danger-300)] bg-white/70 px-3 py-2 text-xs text-danger-text transition-colors hover:border-danger hover:bg-white", focusResetClass)} type="button" onClick={onBeginCancel}>
                 <Trash className="h-4 w-4" />取消
               </button>
             ) : null}

--- a/apps/desktop/renderer/src/chat/RoleTaskForm.tsx
+++ b/apps/desktop/renderer/src/chat/RoleTaskForm.tsx
@@ -34,7 +34,7 @@ const scheduleTriggerOptions = [
   { value: "every", label: "循环执行" },
 ] as const;
 
-const sectionHeadingClass = "text-[11px] font-semibold tracking-[0.12em] text-[#7A8593]";
+const sectionHeadingClass = "text-[11px] font-semibold tracking-[0.12em] text-ink-muted";
 
 /** Renders the create/edit form for a scheduled role task. */
 export function RoleTaskForm({ title, initialData, saving, error, onBack, onSave }: {
@@ -68,7 +68,7 @@ export function RoleTaskForm({ title, initialData, saving, error, onBack, onSave
         <button className={chatSidebarBackButtonClass} type="button" aria-label="返回" disabled={saving} onClick={onBack}>
           <ArrowLeft className="h-4 w-4" />
         </button>
-        <span className="font-semibold text-[#272536]">{title}</span>
+        <span className="font-semibold text-ink">{title}</span>
       </div>
       <div className={cx(chatSidebarScrollableClass, "space-y-5 px-1 pb-5")}>
         <section className="grid gap-3">
@@ -79,9 +79,9 @@ export function RoleTaskForm({ title, initialData, saving, error, onBack, onSave
             <RoleTaskFieldError message={errors.name} />
           </label>
         </section>
-        <section className="grid gap-3 border-t border-[#E1E7EF] pt-4">
+        <section className="grid gap-3 border-t border-line-soft pt-4">
           <h3 className={sectionHeadingClass}>执行设置</h3>
-          <div className="grid gap-1.5 text-xs text-[#667085]">
+          <div className="grid gap-1.5 text-xs text-ink-muted">
             <span>执行模式</span>
             <RoleTaskSegmentedControl
               label="执行模式"
@@ -91,7 +91,7 @@ export function RoleTaskForm({ title, initialData, saving, error, onBack, onSave
               onChange={(tier: ScheduleTaskTier) => setData((current) => ({ ...current, tier }))}
             />
           </div>
-          <div className="grid gap-1.5 text-xs text-[#667085]">
+          <div className="grid gap-1.5 text-xs text-ink-muted">
             <span>触发方式</span>
             <RoleTaskSegmentedControl
               label="触发方式"
@@ -111,7 +111,7 @@ export function RoleTaskForm({ title, initialData, saving, error, onBack, onSave
             onRecurringRuleChange={setRecurringRule}
           />
         </section>
-        <section className="grid gap-3 border-t border-[#E1E7EF] pt-4">
+        <section className="grid gap-3 border-t border-line-soft pt-4">
           <h3 className={sectionHeadingClass}>任务内容</h3>
           <label className={roleTaskFieldLabelClass}>
             <span>执行内容</span>
@@ -127,10 +127,10 @@ export function RoleTaskForm({ title, initialData, saving, error, onBack, onSave
             <RoleTaskFieldError message={errors.content} />
           </label>
         </section>
-        {error ? <div className="text-xs text-[#B42318]">{error}</div> : null}
+        {error ? <div className="text-xs text-danger-text">{error}</div> : null}
       </div>
       <div className="pt-3">
-        <button className={cx("flex h-10 w-full items-center justify-center rounded-md bg-[#272536] px-4 text-xs font-medium text-white shadow-[0_4px_12px_rgba(39,37,54,0.14)] transition-colors hover:bg-[#3B394D] disabled:opacity-50", focusResetClass)} type="submit" disabled={saving}>{saving ? "保存中…" : "保存"}</button>
+        <button className={cx("flex h-10 w-full items-center justify-center rounded-md bg-gradient-accent px-4 text-xs font-medium text-white shadow-soft transition-[filter] hover:brightness-105 disabled:opacity-50", focusResetClass)} type="submit" disabled={saving}>{saving ? "保存中…" : "保存"}</button>
       </div>
     </form>
   );

--- a/apps/desktop/renderer/src/chat/RoleTaskForm.tsx
+++ b/apps/desktop/renderer/src/chat/RoleTaskForm.tsx
@@ -130,7 +130,7 @@ export function RoleTaskForm({ title, initialData, saving, error, onBack, onSave
         {error ? <div className="text-xs text-danger-text">{error}</div> : null}
       </div>
       <div className="pt-3">
-        <button className={cx("flex h-10 w-full items-center justify-center rounded-md bg-gradient-accent px-4 text-xs font-medium text-white shadow-soft transition-[filter] hover:brightness-105 disabled:opacity-50", focusResetClass)} type="submit" disabled={saving}>{saving ? "保存中…" : "保存"}</button>
+        <button className={cx("flex h-10 w-full items-center justify-center rounded-md bg-gradient-accent px-4 text-xs font-medium text-ink shadow-soft transition-[filter] hover:brightness-105 disabled:opacity-50", focusResetClass)} type="submit" disabled={saving}>{saving ? "保存中…" : "保存"}</button>
       </div>
     </form>
   );

--- a/apps/desktop/renderer/src/chat/RoleTaskFormControls.tsx
+++ b/apps/desktop/renderer/src/chat/RoleTaskFormControls.tsx
@@ -2,14 +2,14 @@ import { cx, focusResetClass } from "../shared/styles";
 
 /** Shared field styling for task form controls. */
 export const roleTaskFieldClass =
-  "w-full rounded-md border border-[#D8DFE7] bg-white px-3 py-2.5 text-sm text-[#344054] transition focus:border-[#B8C2CE] focus:outline-none disabled:opacity-60";
+  "w-full rounded-md border border-line-soft bg-white px-3 py-2.5 text-sm text-ink-secondary transition focus:border-line focus:outline-none disabled:opacity-60";
 
 /** Shared label styling for task form fields. */
-export const roleTaskFieldLabelClass = "grid gap-1.5 text-xs text-[#667085]";
+export const roleTaskFieldLabelClass = "grid gap-1.5 text-xs text-ink-muted";
 
 /** Renders one inline task-form validation message. */
 export function RoleTaskFieldError({ message }: { message?: string }) {
-  return message ? <span className="text-[11px] text-[#B42318]">{message}</span> : null;
+  return message ? <span className="text-[11px] text-danger-text">{message}</span> : null;
 }
 
 /** Renders a compact single-choice control for task form enums. */
@@ -29,7 +29,7 @@ export function RoleTaskSegmentedControl<Value extends string>({
   return (
     <div
       className={cx(
-        "grid gap-1 rounded-md bg-[#E9EDF2] p-1",
+        "grid gap-1 rounded-md bg-surface-soft p-1",
         options.length === 2 ? "grid-cols-2" : "grid-cols-3",
       )}
       role="group"
@@ -42,7 +42,7 @@ export function RoleTaskSegmentedControl<Value extends string>({
             key={option.value}
             className={cx(
               "h-8 rounded-md px-2 text-[11px] font-medium transition-colors disabled:cursor-default disabled:opacity-50",
-              selected ? "bg-[#272536] text-white shadow-[0_2px_6px_rgba(39,37,54,0.14)]" : "text-[#667085] hover:bg-white/70 hover:text-[#344054]",
+              selected ? "bg-gradient-accent text-white shadow-soft" : "text-ink-muted hover:bg-white/70 hover:text-ink-secondary",
               focusResetClass,
             )}
             type="button"

--- a/apps/desktop/renderer/src/chat/RoleTaskFormControls.tsx
+++ b/apps/desktop/renderer/src/chat/RoleTaskFormControls.tsx
@@ -42,7 +42,7 @@ export function RoleTaskSegmentedControl<Value extends string>({
             key={option.value}
             className={cx(
               "h-8 rounded-md px-2 text-[11px] font-medium transition-colors disabled:cursor-default disabled:opacity-50",
-              selected ? "bg-gradient-accent text-white shadow-soft" : "text-ink-muted hover:bg-white/70 hover:text-ink-secondary",
+              selected ? "bg-gradient-accent text-ink shadow-soft" : "text-ink-muted hover:bg-white/70 hover:text-ink-secondary",
               focusResetClass,
             )}
             type="button"

--- a/apps/desktop/renderer/src/chat/RoleTaskList.tsx
+++ b/apps/desktop/renderer/src/chat/RoleTaskList.tsx
@@ -14,9 +14,9 @@ export function RoleTaskList({ tasks, onCreate, onSelect }: {
   return (
     <div className={cx(chatSidebarPanelClass, "grid-rows-[auto_minmax(0,1fr)]")}>
       <div className={cx(chatSidebarHeaderClass, "gap-1")}>
-        <span className="font-semibold text-[#272536]">任务</span>
+        <span className="font-semibold text-ink">任务</span>
         <button
-          className={cx("grid h-7 w-7 place-items-center rounded-md text-[#667085] transition-colors hover:bg-white hover:text-[#272536]", focusResetClass)}
+          className={cx("grid h-7 w-7 place-items-center rounded-md text-ink-muted transition-colors hover:bg-white hover:text-ink", focusResetClass)}
           type="button"
           aria-label="新增计划任务"
           onClick={onCreate}
@@ -27,12 +27,12 @@ export function RoleTaskList({ tasks, onCreate, onSelect }: {
       <div className={cx(chatSidebarScrollableClass, "space-y-3")}>
         {groups.length ? groups.map((group) => (
           <section key={group.kind} data-testid="role-task-group" className="rounded-md p-2">
-            <div className="flex items-center gap-1.5 px-1 pb-2 text-[11px] font-medium tracking-wide text-[#667085]">
+            <div className="flex items-center gap-1.5 px-1 pb-2 text-[11px] font-medium tracking-wide text-ink-muted">
               {group.kind === "schedule" ? <CalendarDots className="h-3.5 w-3.5" weight="fill" /> : null}
               {group.kind === "subagent" ? <Robot className="h-3.5 w-3.5" weight="fill" /> : null}
               {group.kind === "memory_maintenance" ? <Brain className="h-3.5 w-3.5" weight="fill" /> : null}
               <span>{taskKindLabels[group.kind]}</span>
-              <span className="ml-auto grid min-h-5 min-w-5 place-items-center rounded-md bg-[#EEF2F6] px-1 text-[10px] text-[#667085]">{group.tasks.length}</span>
+              <span className="ml-auto grid min-h-5 min-w-5 place-items-center rounded-md bg-surface-soft px-1 text-[10px] text-ink-muted">{group.tasks.length}</span>
             </div>
             {group.tasks.length ? group.tasks.map((task) => (
               <button
@@ -42,10 +42,10 @@ export function RoleTaskList({ tasks, onCreate, onSelect }: {
                 onClick={() => onSelect(task.id)}
               >
                 <span className="min-w-0">
-                  <span data-testid="role-task-title" className="block truncate text-[13px] font-semibold text-[#344054]">{task.label}</span>
-                  <span data-testid="role-task-summary" className="mt-1 block truncate text-[11px] text-[#7A8493]">{task.detail || "—"}</span>
+                  <span data-testid="role-task-title" className="block truncate text-[13px] font-semibold text-ink-secondary">{task.label}</span>
+                  <span data-testid="role-task-summary" className="mt-1 block truncate text-[11px] text-ink-muted">{task.detail || "—"}</span>
                 </span>
-                <CaretRight className="h-3.5 w-3.5 text-[#B0B8C4] transition-colors group-hover:text-[#667085]" />
+                <CaretRight className="h-3.5 w-3.5 text-ink-faint transition-colors group-hover:text-ink-muted" />
               </button>
             )) : null}
           </section>

--- a/apps/desktop/renderer/src/chat/chatSidebarStyles.ts
+++ b/apps/desktop/renderer/src/chat/chatSidebarStyles.ts
@@ -2,11 +2,11 @@ import { cx, focusResetClass } from "../shared/styles";
 
 /** Shared surface for every chat-sidebar view. */
 export const chatSidebarPanelClass =
-  "grid h-full min-h-0 rounded-md border border-[#E1E7EF] bg-[#F5F7FA] px-3 pb-3 pt-2 text-sm text-[#334155] shadow-[0_8px_24px_rgba(15,23,42,0.04)]";
+  "grid h-full min-h-0 rounded-md border border-white/70 bg-white/70 px-3 pb-3 pt-2 text-sm text-ink-secondary shadow-soft backdrop-blur-md";
 
 /** Shared compact header for task list, detail, and form views. */
 export const chatSidebarHeaderClass =
-  "flex min-h-11 items-center border-b border-[#E1E7EF] pl-1 pr-8";
+  "flex min-h-11 items-center border-b border-line-soft pl-1 pr-8";
 
 /** Shared scroll container for task-sidebar content. */
 export const chatSidebarScrollableClass =
@@ -14,6 +14,6 @@ export const chatSidebarScrollableClass =
 
 /** Shared back-navigation control for nested task views. */
 export const chatSidebarBackButtonClass = cx(
-  "grid h-8 w-8 shrink-0 place-items-center rounded-md text-[#5B6472] transition-colors hover:bg-white hover:text-[#272536]",
+  "grid h-8 w-8 shrink-0 place-items-center rounded-md text-ink-muted transition-colors hover:bg-white hover:text-ink",
   focusResetClass,
 );

--- a/apps/desktop/renderer/src/shared/styles.ts
+++ b/apps/desktop/renderer/src/shared/styles.ts
@@ -25,7 +25,7 @@ export const textareaClass = cx(inputClass, "min-h-24 resize-y");
 
 /** Shared primary action button styling. */
 export const primaryButtonClass =
-  "cursor-pointer rounded-md border border-transparent bg-gradient-accent px-[18px] py-3 text-white shadow-soft transition-[box-shadow,filter] duration-150 hover:brightness-105 hover:shadow-panel active:brightness-95 disabled:cursor-default disabled:opacity-50 disabled:shadow-none";
+  "cursor-pointer rounded-md border border-white/70 bg-gradient-accent px-[18px] py-3 text-ink shadow-soft transition-[box-shadow,filter] duration-150 hover:brightness-[1.03] hover:shadow-panel active:brightness-[0.97] disabled:cursor-default disabled:opacity-50 disabled:shadow-none";
 
 /** Shared secondary action button styling. */
 export const ghostButtonClass =

--- a/apps/desktop/renderer/src/styles.css
+++ b/apps/desktop/renderer/src/styles.css
@@ -123,8 +123,13 @@
     --color-danger-text: var(--danger-700);     /* 6.0:1 */
 
     /* ---------- gradients ---------- */
-    --gradient-accent: linear-gradient(135deg in oklab, var(--blue-grad), var(--pink-grad));
-    --gradient-accent-soft: linear-gradient(135deg in oklab, var(--blue-100), var(--pink-100));
+    /* pastel accent gradient: same blue->pink family as the app base, one
+       tint deeper so controls read as controls; pair with ink text (13:1) */
+    --gradient-accent: linear-gradient(135deg in oklab, var(--blue-150), var(--pink-150));
+    /* saturated variant for text gradients and thin data marks that would
+       vanish in pastel; white/ink both pass on it (see --blue-grad note) */
+    --gradient-accent-strong: linear-gradient(135deg in oklab, var(--blue-grad), var(--pink-grad));
+    --gradient-accent-soft: linear-gradient(135deg in oklab, var(--blue-50), var(--pink-50));
     --gradient-app: linear-gradient(160deg in oklab, var(--blue-100), var(--lavender-50) 45%, var(--pink-100));
 
     /* ---------- radius ---------- */
@@ -307,12 +312,16 @@
     background-image: var(--gradient-accent-soft);
   }
 
+  .bg-gradient-accent-strong {
+    background-image: var(--gradient-accent-strong);
+  }
+
   .bg-gradient-app {
     background-image: var(--gradient-app);
   }
 
   .text-gradient-accent {
-    background-image: var(--gradient-accent);
+    background-image: var(--gradient-accent-strong);
     background-clip: text;
     -webkit-background-clip: text;
     color: transparent;

--- a/apps/desktop/renderer/src/styles.css
+++ b/apps/desktop/renderer/src/styles.css
@@ -41,11 +41,15 @@
     --pink-800: #852652;
     --pink-900: #5f1a3a;
 
-    /* powder blue tints (hue 240) — app-base gradient only */
+    /* powder blue tints (hue 240) — app-base gradient + accent gradient */
     --blue-50: #f6fbfe;
     --blue-100: #e9f5ff;
     --blue-150: #dcf0ff;
     --blue-200: #c9e8fe;
+    /* accent-gradient endpoints: white text stays >=4.5:1 across the whole
+       blue->pink sweep (endpoints 4.78/5.20, oklab midpoint 4.93) */
+    --blue-grad: #1e79ad;
+    --pink-grad: #b93f76;
 
     /* lavender secondary (hue 302) */
     --lavender-50: #fbf9ff;
@@ -119,8 +123,8 @@
     --color-danger-text: var(--danger-700);     /* 6.0:1 */
 
     /* ---------- gradients ---------- */
-    --gradient-accent: linear-gradient(135deg in oklab, var(--pink-600), var(--lavender-grad));
-    --gradient-accent-soft: linear-gradient(135deg in oklab, var(--pink-100), var(--lavender-150));
+    --gradient-accent: linear-gradient(135deg in oklab, var(--blue-grad), var(--pink-grad));
+    --gradient-accent-soft: linear-gradient(135deg in oklab, var(--blue-100), var(--pink-100));
     --gradient-app: linear-gradient(160deg in oklab, var(--blue-100), var(--lavender-50) 45%, var(--pink-100));
 
     /* ---------- radius ---------- */

--- a/apps/desktop/renderer/src/styles.css
+++ b/apps/desktop/renderer/src/styles.css
@@ -46,6 +46,7 @@
     --blue-100: #e9f5ff;
     --blue-150: #dcf0ff;
     --blue-200: #c9e8fe;
+    --blue-300: #a6d6f9;
     /* accent-gradient endpoints: white text stays >=4.5:1 across the whole
        blue->pink sweep (endpoints 4.78/5.20, oklab midpoint 4.93) */
     --blue-grad: #1e79ad;
@@ -130,6 +131,8 @@
        vanish in pastel; white/ink both pass on it (see --blue-grad note) */
     --gradient-accent-strong: linear-gradient(135deg in oklab, var(--blue-grad), var(--pink-grad));
     --gradient-accent-soft: linear-gradient(135deg in oklab, var(--blue-50), var(--pink-50));
+    /* mid-tint sweep for meters/bars: pastel family but readable on soft tracks */
+    --gradient-accent-medium: linear-gradient(90deg in oklab, var(--blue-300), var(--pink-300));
     --gradient-app: linear-gradient(160deg in oklab, var(--blue-100), var(--lavender-50) 45%, var(--pink-100));
 
     /* ---------- radius ---------- */
@@ -221,7 +224,7 @@
 
 @layer utilities {
   .scrollbar-soft {
-    scrollbar-color: var(--neutral-200) transparent;
+    scrollbar-color: var(--pink-200) transparent;
     scrollbar-gutter: stable;
     scrollbar-width: thin;
   }
@@ -237,7 +240,7 @@
   .scrollbar-soft::-webkit-scrollbar-thumb {
     border: 3px solid transparent;
     border-radius: 999px;
-    background: var(--neutral-200);
+    background: var(--pink-200);
     background-clip: padding-box;
   }
 
@@ -314,6 +317,10 @@
 
   .bg-gradient-accent-strong {
     background-image: var(--gradient-accent-strong);
+  }
+
+  .bg-gradient-accent-medium {
+    background-image: var(--gradient-accent-medium);
   }
 
   .bg-gradient-app {


### PR DESCRIPTION
UIUX 改造阶段 3,closes #154。

## 内容
- **消息卡**:AI 消息暖白玻璃(白 80% + 白描边 + 柔影,悬停提亮);用户消息保持白底(验收反馈);错误消息接 danger token;引用条用品牌粉左线;逐条消息不加 backdrop-filter 的性能守卫保留并更新断言
- **输入区**:玻璃容器(白 90% + 背景模糊 + 面板柔影);发送/停止按钮黑色→品牌渐变圆钮;附件芯片与引用预览 token 化
- **右侧栏**:整列底色透明(验收反馈,立绘渐隐区透出);状态面板玻璃化,「当前状态」品牌粉、关系标签粉色药丸、寂寞值进度条品牌渐变 + 等宽数字;状态/任务/图片切换胶囊激活态品牌渐变
- **任务面板**:保存按钮与分段选择器深灰实底→品牌渐变;运行中提示接 warning token
- **收尾**:chat/ 目录硬编码 hex 全部清零(测试文件除外),菜单/灯箱/表情面板全部 token 化

## 验证
typecheck / lint 0 error / 670 单测全过 / renderer 构建通过

## 验收方式
重启 dev server(本轮无 tailwind 配置改动,理论上热更新即可,保险起见重启),重点看:聊天页整体、发消息/停止、引用回复、右侧三个模式、任务表单