### PR TITLE
restyle(5/7): 设置 — token 化与品牌化

### DIFF
--- a/apps/desktop/renderer/src/settings/ModelRegistrationDetails.tsx
+++ b/apps/desktop/renderer/src/settings/ModelRegistrationDetails.tsx
@@ -22,9 +22,9 @@ export function ModelRegistrationDetails({
 }: ModelRegistrationDetailsProps) {
   return (
     <section className="grid">
-      <header className="flex min-h-10 items-center gap-3 border-b border-[#E7ECF1] pb-3">
+      <header className="flex min-h-10 items-center gap-3 border-b border-line-soft pb-3">
         <button
-          className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-[#667085] transition hover:bg-[#F3F6FA] hover:text-[#182230] focus:outline-none"
+          className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-ink-muted transition hover:bg-surface-soft hover:text-ink focus:outline-none"
           type="button"
           aria-label="返回模型注册列表"
           title="返回模型注册列表"
@@ -32,11 +32,11 @@ export function ModelRegistrationDetails({
         >
           <ArrowLeft className="h-3.5 w-3.5" weight="bold" />
         </button>
-        <strong className="min-w-0 flex-1 truncate text-[13px] font-semibold text-[#182230]">
+        <strong className="min-w-0 flex-1 truncate text-[13px] font-semibold text-ink">
           {registration.model || "未配置模型"}
         </strong>
         <button
-          className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-[#8A94A3] transition hover:bg-[#FFF1F1] hover:text-[#C83E3E] focus:outline-none disabled:cursor-not-allowed disabled:opacity-35"
+          className="grid h-8 w-8 shrink-0 place-items-center rounded-md text-ink-faint transition hover:bg-danger-soft hover:text-danger-text focus:outline-none disabled:cursor-not-allowed disabled:opacity-35"
           type="button"
           aria-label="删除模型注册"
           title="删除模型注册"

--- a/apps/desktop/renderer/src/settings/ModelRegistrationList.tsx
+++ b/apps/desktop/renderer/src/settings/ModelRegistrationList.tsx
@@ -29,7 +29,7 @@ export function ModelRegistrationList({
     <section className="grid gap-3">
       <div className="flex justify-end">
         <button
-          className="grid h-8 w-8 place-items-center rounded-md border border-[#D8DFE7] bg-white text-[#344054] transition hover:border-[#B9C6D4] hover:bg-[#F7F9FB] focus:outline-none"
+          className="grid h-8 w-8 place-items-center rounded-md border border-line-soft bg-white text-ink-secondary transition hover:border-line-strong hover:bg-surface-soft focus:outline-none"
           type="button"
           aria-label="新建模型注册"
           title="新建模型注册"
@@ -41,32 +41,32 @@ export function ModelRegistrationList({
       <div className="grid gap-3">
         {registrations.map((registration) => (
           <button
-            className="group grid min-h-[84px] w-full grid-cols-[40px_minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-[#DDE4EC] bg-white px-3 py-2.5 text-left transition hover:border-[#9FC5E8] hover:bg-[#F7FBFF] focus:outline-none"
+            className="group grid min-h-[84px] w-full grid-cols-[40px_minmax(0,1fr)_auto] items-center gap-3 rounded-md border border-line-soft bg-white px-3 py-2.5 text-left transition hover:border-accent hover:bg-accent-softer focus:outline-none"
             type="button"
             key={registration.id}
             onClick={() => onOpen(registration.id)}
           >
-            <span className="grid h-10 w-10 place-items-center rounded-md border border-[#DDE4EC] bg-[#F7F9FB] text-[11px] font-semibold text-[#667085]">
+            <span className="grid h-10 w-10 place-items-center rounded-md border border-line-soft bg-surface-soft text-[11px] font-semibold text-ink-muted">
               {registrationInitials(registration)}
             </span>
             <span className="min-w-0">
-              <strong className="block truncate text-[13px] font-semibold text-[#182230]">
+              <strong className="block truncate text-[13px] font-semibold text-ink">
                 {registration.model || "未配置模型"}
               </strong>
-              <span className="mt-1 block truncate text-[13px] text-[#1976D2]">
+              <span className="mt-1 block truncate text-[13px] text-accent-text">
                 {registration.baseUrl || "未配置 Base URL"}
               </span>
             </span>
             <span className="flex items-center gap-2.5 pl-2">
               <span className="hidden text-right sm:block">
-                <span className="block text-[11px] font-medium text-[#667085]">
+                <span className="block text-[11px] font-medium text-ink-muted">
                   {registration.provider || "未配置 Provider"}
                 </span>
-                <span className="mt-1 block text-[11px] text-[#98A2B3]">
+                <span className="mt-1 block text-[11px] text-ink-faint">
                   {registration.effort}
                 </span>
               </span>
-              <CaretRight className="h-3.5 w-3.5 text-[#98A2B3] transition group-hover:translate-x-0.5 group-hover:text-[#1976D2]" weight="bold" />
+              <CaretRight className="h-3.5 w-3.5 text-ink-faint transition group-hover:translate-x-0.5 group-hover:text-accent-text" weight="bold" />
             </span>
           </button>
         ))}

--- a/apps/desktop/renderer/src/settings/SettingsField.tsx
+++ b/apps/desktop/renderer/src/settings/SettingsField.tsx
@@ -28,8 +28,8 @@ export function SettingsField({
           ),
     )}>
       <div className="grid gap-1.5">
-        <div className="text-[13px] font-medium text-[#182230]">{label}</div>
-        {hint ? <div className="max-w-[680px] text-[11px] leading-[18px] text-[#7B8794]">{hint}</div> : null}
+        <div className="text-[13px] font-medium text-ink">{label}</div>
+        {hint ? <div className="max-w-[680px] text-[11px] leading-[18px] text-ink-muted">{hint}</div> : null}
       </div>
       <div className={cx("w-full", !stacked && "xl:justify-self-end")}>{children}</div>
     </div>

--- a/apps/desktop/renderer/src/settings/SettingsPage.tsx
+++ b/apps/desktop/renderer/src/settings/SettingsPage.tsx
@@ -16,10 +16,10 @@ type SettingsPageProps = {
 };
 
 /** Shared surface style for every settings page state. */
-export const settingsPageSurfaceClass = "settings-page bg-white";
+export const settingsPageSurfaceClass = "settings-page bg-gradient-app bg-fixed";
 
 /** Responsive spacing for the scrollable settings content. */
-export const settingsContentClass = "relative scrollbar-soft overflow-y-auto bg-white px-4 py-8 sm:px-10 lg:px-16 lg:py-10";
+export const settingsContentClass = "relative scrollbar-soft overflow-y-auto px-4 py-8 sm:px-10 lg:px-16 lg:py-10";
 
 /** Renders the active settings domain and delegates persistence to its controller. */
 export function SettingsPage({
@@ -34,7 +34,7 @@ export function SettingsPage({
   if (controller.loadError) {
     return (
       <section className={cx(settingsPageSurfaceClass, "grid h-full place-items-center")} data-testid="settings-page">
-        <div className={cx(cardClass, "mx-8 max-w-[680px] p-6 text-sm leading-6 text-[#8f2d2d]")}>
+        <div className={cx(cardClass, "mx-8 max-w-[680px] p-6 text-sm leading-6 text-danger-text")}>
           设置加载失败：{controller.loadError}
         </div>
       </section>
@@ -44,7 +44,7 @@ export function SettingsPage({
   if (!controller.draft) {
     return (
       <section className={cx(settingsPageSurfaceClass, "grid h-full place-items-center")} data-testid="settings-page">
-        <div className="text-sm text-[#737781]">正在加载设置...</div>
+        <div className="text-sm text-ink-muted">正在加载设置…</div>
       </section>
     );
   }
@@ -78,12 +78,12 @@ export function SettingsPage({
       <div className={settingsContentClass}>
         <div className="mx-auto w-full max-w-[840px]">
           {!currentSection ? (
-            <div className={cx(cardClass, "grid min-h-[240px] place-items-center border-dashed text-sm text-[#7f8490]")}>
+            <div className={cx(cardClass, "grid min-h-[240px] place-items-center border-dashed text-sm text-ink-muted")}>
               没有匹配的设置项
             </div>
           ) : (
             <header className="mb-6">
-              <h2 className="m-0 text-[22px] font-normal leading-tight text-[#182230]">{currentSection.label}</h2>
+              <h2 className="m-0 font-display text-headline text-ink">{currentSection.label}</h2>
               {visibleSubsections.length > 1 ? (
                 <nav className="mt-7 flex max-w-full gap-7 overflow-x-auto" aria-label="设置子区">
                   {visibleSubsections.map((item) => (
@@ -91,8 +91,8 @@ export function SettingsPage({
                       className={cx(
                         "relative shrink-0 border-0 bg-transparent px-0 pb-2 text-[13px] transition focus:outline-none",
                         item.id === currentSubsectionId
-                          ? "font-medium text-[#182230] after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-[#182230]"
-                          : "text-[#98A2B3] hover:text-[#3a4453]",
+                          ? "font-medium text-ink after:absolute after:inset-x-0 after:bottom-0 after:h-0.5 after:bg-accent"
+                          : "text-ink-faint hover:text-ink-secondary",
                       )}
                       key={item.id}
                       type="button"

--- a/apps/desktop/renderer/src/settings/SettingsSaveFeedback.tsx
+++ b/apps/desktop/renderer/src/settings/SettingsSaveFeedback.tsx
@@ -20,14 +20,14 @@ export function SettingsSaveFeedback({
     <div
       className={cx(
         "mx-auto mt-4 flex w-[calc(100%-2rem)] max-w-[560px] items-start gap-2 rounded-md border px-4 py-2.5 text-sm leading-6",
-        "border-[rgba(176,58,58,0.18)] bg-[rgba(255,241,241,0.96)] text-[#9a2f2f]",
+        "border-[var(--danger-300)] bg-danger-soft text-danger-text",
       )}
       role="status"
       aria-live="polite"
     >
       <span className="min-w-0 flex-1 break-words">{message}</span>
-      {onRetry ? <button className="shrink-0 rounded-md p-1 hover:bg-red-100" type="button" aria-label="重试保存" title="重试保存" onClick={onRetry}><ArrowClockwise size={18} /></button> : null}
-      {onReload ? <button className="shrink-0 rounded-md p-1 hover:bg-red-100" type="button" aria-label="放弃草稿并重新加载" title="放弃草稿并重新加载" onClick={onReload}><ArrowsClockwise size={18} /></button> : null}
+      {onRetry ? <button className="shrink-0 rounded-md p-1 hover:bg-danger-soft" type="button" aria-label="重试保存" title="重试保存" onClick={onRetry}><ArrowClockwise size={18} /></button> : null}
+      {onReload ? <button className="shrink-0 rounded-md p-1 hover:bg-danger-soft" type="button" aria-label="放弃草稿并重新加载" title="放弃草稿并重新加载" onClick={onReload}><ArrowsClockwise size={18} /></button> : null}
     </div>
   );
 }

--- a/apps/desktop/renderer/src/settings/SettingsToggleCard.tsx
+++ b/apps/desktop/renderer/src/settings/SettingsToggleCard.tsx
@@ -21,7 +21,7 @@ export function SettingsToggleCard({
       className={cx(
         "relative inline-flex shrink-0 appearance-none rounded-full border-0 p-0 outline-none transition-colors duration-200 focus:outline-none",
         compact ? "h-5 w-9" : "h-6 w-11",
-        checked ? "bg-primary" : "bg-[#D6DDE7]",
+        checked ? "bg-primary" : "bg-line",
         disabled ? "cursor-not-allowed opacity-60" : "cursor-pointer",
       )}
       type="button"

--- a/apps/desktop/renderer/src/settings/VoiceInputSettingsSection.tsx
+++ b/apps/desktop/renderer/src/settings/VoiceInputSettingsSection.tsx
@@ -94,7 +94,7 @@ export function VoiceInputSettingsSection({ draft, updateDraft }: VoiceInputSett
             {devices.map((device) => <option key={device.deviceId} value={device.deviceId}>{device.label || device.deviceId}</option>)}
           </select>
           <button
-            className={cx(settingsIconButtonClass, testing && "text-[#C83E3E] hover:bg-[#FFF1F1] hover:text-[#C83E3E]")}
+            className={cx(settingsIconButtonClass, testing && "text-danger-text hover:bg-danger-soft hover:text-danger-text")}
             type="button"
             aria-label={testing ? "停止麦克风测试" : "测试麦克风"}
             title={testing ? "停止麦克风测试" : "测试麦克风"}
@@ -104,7 +104,7 @@ export function VoiceInputSettingsSection({ draft, updateDraft }: VoiceInputSett
           </button>
         </div>
       </Field>
-      {testError ? <div className="text-[11px] text-[#8f2d2d]">{testError}</div> : null}
+      {testError ? <div className="text-[11px] text-danger-text">{testError}</div> : null}
     </SettingsSectionCard>
   );
 }


### PR DESCRIPTION
UIUX 改造阶段 5,closes #156。**依赖链:基于 restyle/4-roles,请先合并 #162 再合并此 PR(GitHub 会自动把 base 转到 main)。**

## 内容
- 设置页整体铺应用渐变底,区标题用 display 字面,子区激活下划线换品牌粉
- 开关控件:开=品牌粉(随 token 自动),关=中性 line 色
- 保存反馈条、模型注册列表/详情、语音输入测试态全部接 danger/accent/ink token;注册项悬停用品牌粉描边
- 设置各分区(高级/渠道/集成/记忆/模型/语音)本就复用共享原语,随 token 自动换装

## 验证
typecheck / lint 0 error / 670 单测全过 / 构建通过