### PR TITLE
fix(release): resolve Windows v0.2.0 packaging blockers

### DIFF
--- a/.github/workflows/windows-release.yml
+++ b/.github/workflows/windows-release.yml
@@ -56,12 +56,17 @@ jobs:
       - name: Install desktop dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Run focused release checks
-        run: |
-          .venv\Scripts\pytest.exe -q tests/backend/test_main.py
-          pnpm --filter shiori-desktop run typecheck
-          pnpm test
-          pnpm --filter shiori-desktop run test:package
+      - name: Run backend release checks
+        run: .venv\Scripts\pytest.exe -q tests/backend/test_main.py
+
+      - name: Run desktop typecheck
+        run: pnpm --filter shiori-desktop run typecheck
+
+      - name: Run desktop unit tests
+        run: pnpm test
+
+      - name: Run packaging tests
+        run: pnpm --filter shiori-desktop run test:package
 
       - name: Build Windows installer and unpacked artifact
         run: pnpm --filter shiori-desktop run package:win

--- a/apps/desktop/scripts/build-runtime.mjs
+++ b/apps/desktop/scripts/build-runtime.mjs
@@ -39,7 +39,7 @@ const args = [
   "--add-data",
   `${join(backendRoot, "skills")}${dataSeparator}skills`,
   "--add-data",
-  `${join(repositoryRoot, "apps", "desktop", "renderer", "src", "chat", "common_emojis.json")}${dataSeparator}common_emojis.json`,
+  `${join(repositoryRoot, "apps", "desktop", "renderer", "src", "chat", "common_emojis.json")}${dataSeparator}.`,
   "--collect-submodules",
   "plugins",
   "--collect-submodules",

--- a/apps/desktop/src/assets/localAssetOpen.test.ts
+++ b/apps/desktop/src/assets/localAssetOpen.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import assert from "node:assert/strict";
-import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
@@ -32,7 +32,7 @@ describe("openGrantedLocalAsset", () => {
     });
 
     assert.deepEqual(result, { ok: true, error: null });
-    assert.deepEqual(opened, [documentPath]);
+    assert.deepEqual(opened, [await realpath(documentPath)]);
   });
 
   it("does not pass an unauthorized path to the operating system", async () => {

--- a/apps/desktop/src/assets/localAssetPolicy.test.ts
+++ b/apps/desktop/src/assets/localAssetPolicy.test.ts
@@ -1,7 +1,40 @@
 import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { mkdtemp, realpath, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import test from "node:test";
 
-import { collectTrustedLocalAssetPaths } from "./localAssetPolicy.js";
+import {
+  collectTrustedLocalAssetPaths,
+  isLocalAssetInsideRoot,
+  resolveLocalAssetCandidate,
+} from "./localAssetPolicy.js";
+
+test("Windows short paths share native asset identity and root containment", {
+  skip: process.platform !== "win32",
+}, async (context) => {
+  const directory = await mkdtemp(join(tmpdir(), "shiori-asset-short-path-"));
+  try {
+    const imagePath = join(directory, "avatar.png");
+    await writeFile(imagePath, "image", "utf-8");
+    const shortPathResult = spawnSync("cmd.exe", [
+      "/d", "/c", `for %I in ("${imagePath}") do @echo %~sI`,
+    ], { encoding: "utf-8", windowsVerbatimArguments: true });
+    assert.equal(shortPathResult.status, 0, shortPathResult.stderr);
+    const shortPath = shortPathResult.stdout.trim();
+    const canonicalPath = await realpath(imagePath);
+    if (shortPath.toLowerCase() === canonicalPath.toLowerCase()) {
+      context.skip("Windows short file names are unavailable on this volume");
+      return;
+    }
+
+    assert.equal(resolveLocalAssetCandidate(shortPath)?.canonicalPath, canonicalPath);
+    assert.equal(isLocalAssetInsideRoot(canonicalPath, join(shortPath, "..")), true);
+  } finally {
+    await rm(directory, { recursive: true, force: true });
+  }
+});
 
 test("pet package renderer assets are collected from trusted bridge payloads", () => {
   const previewPath = "C:\\workspace\\roles\\assets\\role-1\\pets\\pet-1\\preview.png";

--- a/apps/desktop/src/assets/localAssetPolicy.ts
+++ b/apps/desktop/src/assets/localAssetPolicy.ts
@@ -54,7 +54,8 @@ export function resolveLocalAssetCandidate(path: string): LocalAssetCandidate | 
     return null;
   }
   try {
-    const canonicalPath = realpathSync(requestedPath);
+    // Match fs/promises.realpath when Windows inputs contain short path aliases.
+    const canonicalPath = realpathSync.native(requestedPath);
     if (!statSync(canonicalPath).isFile()) {
       return null;
     }
@@ -67,7 +68,7 @@ export function resolveLocalAssetCandidate(path: string): LocalAssetCandidate | 
 /** Checks canonical containment without accepting sibling-prefix or cross-drive paths. */
 export function isLocalAssetInsideRoot(canonicalPath: string, root: string): boolean {
   try {
-    const canonicalRoot = realpathSync(root);
+    const canonicalRoot = realpathSync.native(root);
     const relativePath = relative(canonicalRoot, canonicalPath);
     const parentPrefix = `..${process.platform === "win32" ? "\\" : "/"}`;
     return relativePath !== ""

--- a/apps/desktop/src/assets/localAssetRegistry.test.ts
+++ b/apps/desktop/src/assets/localAssetRegistry.test.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, rm, writeFile } from "node:fs/promises";
+import { mkdtemp, mkdir, realpath, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { afterEach, describe, it } from "node:test";
@@ -35,8 +35,9 @@ describe("LocalAssetRegistry", () => {
     assert.equal(reference.kind, "image");
     assert.match(reference.url, /^shiori-asset:\/\/local\/[0-9a-f-]+$/);
     assert.equal(registry.resolveUrl(reference.url.replace("shiori-asset:", "legacy-asset:")), null);
-    assert.equal(registry.resolveReference(reference.url)?.canonicalPath, grantedPath);
-    assert.equal(registry.resolveReference(grantedPath)?.canonicalPath, grantedPath);
+    const canonicalPath = await realpath(grantedPath);
+    assert.equal(registry.resolveReference(reference.url)?.canonicalPath, canonicalPath);
+    assert.equal(registry.resolveReference(grantedPath)?.canonicalPath, canonicalPath);
     assert.equal(registry.resolveReference(deniedPath), null);
     assert.equal(
       registry.resolveUrl(`shiori-asset://local?path=${encodeURIComponent(deniedPath)}`),


### PR DESCRIPTION
Closes #167

## 变更

修复 v0.2.0 Windows 发布的三个阻塞点：PyInstaller 将 `common_emojis.json` 打入同名目录、Windows 短路径导致已授权图片被误判为失效，以及 PowerShell 后续检查覆盖前序测试的失败退出码。

数据文件现在位于 `_internal/common_emojis.json`；资源授权和读取均采用原生路径解析；发布检查拆为独立步骤，失败立即阻止打包。

## 验证

- Windows 短路径回归测试：修复前失败，修复后通过。
- 资源模块测试：25 passed，1 skipped（本机不允许文件符号链接），使用 Windows 短路径临时目录再次验证通过。
- meme 后端测试：21 passed。
- 打包测试：5 passed。
- desktop typecheck 与修改文件 ESLint：通过。
- `.venv` PyInstaller runtime 实际构建：通过，确认 emoji 资源为预期路径下的文件。
- 最新提交 Windows CI：672 项桌面测试、5 项打包测试、4 项后端发布检查全部通过；安装包构建、包结构和 SHA-256 校验通过。
- 最新提交 PR CI：前后端检查、测试及前端构建全部通过。

发布构建：https://github.com/YinFengWindy/Shiori-Agent/actions/runs/34317296545

## 阻塞项

- 自动化验证阻塞项：无。
- 本轮未执行全新 Windows 环境的安装、升级和卸载人工验收。
