### PR TITLE
feat(desktop): add application updates in settings

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -20,7 +20,7 @@
     "build:runtime": "node scripts/build-runtime.mjs",
     "package:win": "pnpm run build && pnpm run build:runtime && node scripts/package-win.mjs",
     "verify:package": "node scripts/verify-packaged.mjs",
-    "test:package": "node --test scripts/release-manifest.test.mjs scripts/verify-packaged.test.mjs scripts/hash-release.test.mjs scripts/release-version.test.mjs",
+    "test:package": "node --test scripts/release-manifest.test.mjs scripts/verify-packaged.test.mjs scripts/hash-release.test.mjs scripts/release-version.test.mjs scripts/dev-version.test.mjs",
     "hash:release": "node scripts/hash-release.mjs"
   },
   "dependencies": {

--- a/apps/desktop/renderer/src/settings/AboutSettingsPage.test.tsx
+++ b/apps/desktop/renderer/src/settings/AboutSettingsPage.test.tsx
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { act } from "react";
+import type { DesktopUpdateApi, DesktopUpdateState } from "../../../src/updateContract.js";
+import { mountTestComponent } from "../shared/testing/domTestHarness";
+import { AboutSettingsPage } from "./AboutSettingsPage";
+
+test("the visible update action checks, reports progress and installs only a ready update", async () => {
+  const view = await mountTestComponent(null);
+  let notify!: (state: DesktopUpdateState) => void;
+  let checks = 0;
+  let installs = 0;
+  const snapshot: DesktopUpdateState = { revision: 0, currentVersion: "0.2.0", phase: "idle", latestVersion: null, progress: 0, error: null };
+  const api: DesktopUpdateApi = {
+    getState: async () => snapshot,
+    check: async () => { checks += 1; return { ...snapshot, revision: 1, phase: "current" }; },
+    install: async () => { installs += 1; },
+    onState: (listener) => { notify = listener; return () => undefined; },
+  };
+  Object.defineProperty(window, "miraDesktop", { configurable: true, value: { updates: api } });
+  try {
+    await view.render(<AboutSettingsPage />);
+    assert.match(view.container.textContent ?? "", /当前版本 v0.2.0/);
+    const button = view.container.querySelector("button");
+    assert.ok(button);
+    await act(async () => button.click());
+    assert.equal(checks, 1);
+    assert.match(view.container.textContent ?? "", /已是最新版本/);
+    await act(async () => notify({ ...snapshot, revision: 2, phase: "downloading", latestVersion: "0.3.0", progress: 45 }));
+    assert.equal(button.disabled, true);
+    assert.equal(view.container.querySelector("progress")?.value, 45);
+    await act(async () => notify({ ...snapshot, revision: 3, phase: "downloaded", latestVersion: "0.3.0", progress: 100 }));
+    assert.equal(button.textContent?.trim(), "重启并安装");
+    assert.equal(button.disabled, false);
+    await act(async () => button.click());
+    assert.equal(installs, 1);
+  } finally { await view.cleanup(); }
+});
+
+test("failed status loading remains retryable", async () => {
+  const view = await mountTestComponent(null);
+  const api: DesktopUpdateApi = {
+    getState: async () => { throw new Error("connection lost"); },
+    check: async () => ({ revision: 1, currentVersion: "0.2.0", phase: "current", latestVersion: null, progress: 0, error: null }),
+    install: async () => undefined,
+    onState: () => () => undefined,
+  };
+  Object.defineProperty(window, "miraDesktop", { configurable: true, value: { updates: api } });
+  try {
+    await view.render(<AboutSettingsPage />);
+    assert.match(view.container.querySelector('[role="alert"]')?.textContent ?? "", /connection lost/);
+    const button = view.container.querySelector("button");
+    assert.ok(button);
+    assert.equal(button.disabled, false);
+    await act(async () => button.click());
+    assert.equal(view.container.querySelector('[role="alert"]'), null);
+    assert.match(view.container.textContent ?? "", /已是最新版本/);
+  } finally { await view.cleanup(); }
+});

--- a/apps/desktop/renderer/src/settings/AboutSettingsPage.test.tsx
+++ b/apps/desktop/renderer/src/settings/AboutSettingsPage.test.tsx
@@ -10,6 +10,7 @@ test("the visible update action checks, reports progress and installs only a rea
   let notify!: (state: DesktopUpdateState) => void;
   let checks = 0;
   let installs = 0;
+  const opened: string[] = [];
   const snapshot: DesktopUpdateState = { revision: 0, currentVersion: "0.2.0", phase: "idle", latestVersion: null, progress: 0, error: null };
   const api: DesktopUpdateApi = {
     getState: async () => snapshot,
@@ -17,7 +18,10 @@ test("the visible update action checks, reports progress and installs only a rea
     install: async () => { installs += 1; },
     onState: (listener) => { notify = listener; return () => undefined; },
   };
-  Object.defineProperty(window, "miraDesktop", { configurable: true, value: { updates: api } });
+  Object.defineProperty(window, "miraDesktop", { configurable: true, value: {
+    updates: api,
+    openExternal: async (url: string) => { opened.push(url); return { ok: true, error: null }; },
+  } });
   try {
     await view.render(<AboutSettingsPage />);
     assert.match(view.container.textContent ?? "", /当前版本 v0.2.0/);
@@ -34,6 +38,12 @@ test("the visible update action checks, reports progress and installs only a rea
     assert.equal(button.disabled, false);
     await act(async () => button.click());
     assert.equal(installs, 1);
+    for (const link of Array.from(view.container.querySelectorAll("a"))) await act(async () => link.click());
+    assert.deepEqual(opened, [
+      "https://github.com/YinFengWindy/Shiori-Agent/releases/latest",
+      "https://github.com/YinFengWindy/Shiori-Agent",
+      "mailto:3174898512@qq.com",
+    ]);
   } finally { await view.cleanup(); }
 });
 

--- a/apps/desktop/renderer/src/settings/AboutSettingsPage.tsx
+++ b/apps/desktop/renderer/src/settings/AboutSettingsPage.tsx
@@ -1,0 +1,53 @@
+import { ArrowClockwise, ArrowSquareOut } from "@phosphor-icons/react";
+import { cx, ghostButtonClass, primaryButtonClass } from "../shared/styles";
+import { useDesktopUpdates } from "./useDesktopUpdates";
+
+const releaseUrl = "https://github.com/YinFengWindy/Shiori-Agent/releases/latest";
+const statusLabels = {
+  unsupported: "开发模式", idle: "尚未检查更新", checking: "正在检查更新…",
+  current: "已是最新版本", downloading: "正在下载更新…", downloaded: "更新已就绪",
+  installing: "正在重启安装…", error: "更新失败",
+};
+
+/** Shows the installed version and the desktop-owned update lifecycle. */
+export function AboutSettingsPage() {
+  const { state, error, check, install } = useDesktopUpdates();
+  const busy = state ? ["unsupported", "checking", "downloading", "installing"].includes(state.phase) : !error;
+  const downloaded = state?.phase === "downloaded";
+
+  return (
+    <section className="settings-page scrollbar-soft h-full overflow-y-auto bg-gradient-app bg-fixed px-4 py-8 sm:px-10 lg:px-16 lg:py-10" data-testid="about-settings">
+      <div className="mx-auto w-full max-w-[840px]">
+        <h2 className="m-0 font-display text-headline text-ink">关于</h2>
+        <div className="mt-8 flex items-center gap-4 border-b border-line-soft pb-8">
+          <img src={new URL("../../../../../assets/shiori-app-icon.png", import.meta.url).href} alt="" className="h-16 w-16 shrink-0 object-contain" />
+          <div className="min-w-0">
+            <h3 className="font-display text-title text-ink">Shiori</h3>
+            <p className="mt-1 break-all text-sm text-ink-muted">当前版本 {state ? `v${state.currentVersion}` : "…"}</p>
+          </div>
+        </div>
+        <div className="py-8">
+          <h3 className="text-base font-medium text-ink">应用更新</h3>
+          <p className="mt-3 text-sm text-ink-secondary" role="status">{state ? statusLabels[state.phase] : "正在读取版本…"}</p>
+          {state?.latestVersion ? <p className="mt-2 break-all text-sm text-ink-muted">新版本 v{state.latestVersion}</p> : null}
+          {state?.phase === "downloading" ? (
+            <div className="mt-4 flex max-w-md items-center gap-3">
+              <progress aria-label="更新下载进度" max={100} value={state.progress} className="h-2 min-w-0 flex-1 accent-accent" />
+              <span className="w-12 text-right text-sm tabular-nums text-ink-secondary">{Math.floor(state.progress)}%</span>
+            </div>
+          ) : null}
+          {error ? <p role="alert" className="mt-3 break-words text-sm text-danger-text">{error}</p> : null}
+          <div className="mt-6 flex flex-wrap gap-3">
+            <button type="button" disabled={busy} onClick={() => void (downloaded ? install() : check())} className={cx(primaryButtonClass, "inline-flex min-h-11 items-center justify-center gap-2 text-sm")}>
+              <ArrowClockwise size={18} aria-hidden="true" />
+              {downloaded ? "重启并安装" : state?.phase === "error" || error ? "重新检查" : "检查更新"}
+            </button>
+            <a href={releaseUrl} target="_blank" rel="noreferrer" className={cx(ghostButtonClass, "inline-flex min-h-11 items-center justify-center gap-2 text-sm no-underline")}>
+              <ArrowSquareOut size={18} aria-hidden="true" />更新日志
+            </a>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/desktop/renderer/src/settings/AboutSettingsPage.tsx
+++ b/apps/desktop/renderer/src/settings/AboutSettingsPage.tsx
@@ -1,10 +1,11 @@
-import { ArrowClockwise, ArrowSquareOut } from "@phosphor-icons/react";
+import { ArrowClockwise, ArrowSquareOut, Envelope, GithubLogo } from "@phosphor-icons/react";
 import { cx, ghostButtonClass, primaryButtonClass } from "../shared/styles";
+import { DesktopExternalLink } from "../shared/DesktopExternalLink";
 import { useDesktopUpdates } from "./useDesktopUpdates";
 
 const releaseUrl = "https://github.com/YinFengWindy/Shiori-Agent/releases/latest";
 const statusLabels = {
-  unsupported: "开发模式", idle: "尚未检查更新", checking: "正在检查更新…",
+  unsupported: null, idle: "尚未检查更新", checking: "正在检查更新…",
   current: "已是最新版本", downloading: "正在下载更新…", downloaded: "更新已就绪",
   installing: "正在重启安装…", error: "更新失败",
 };
@@ -19,34 +20,45 @@ export function AboutSettingsPage() {
     <section className="settings-page scrollbar-soft h-full overflow-y-auto bg-gradient-app bg-fixed px-4 py-8 sm:px-10 lg:px-16 lg:py-10" data-testid="about-settings">
       <div className="mx-auto w-full max-w-[840px]">
         <h2 className="m-0 font-display text-headline text-ink">关于</h2>
-        <div className="mt-8 flex items-center gap-4 border-b border-line-soft pb-8">
-          <img src={new URL("../../../../../assets/shiori-app-icon.png", import.meta.url).href} alt="" className="h-16 w-16 shrink-0 object-contain" />
-          <div className="min-w-0">
-            <h3 className="font-display text-title text-ink">Shiori</h3>
-            <p className="mt-1 break-all text-sm text-ink-muted">当前版本 {state ? `v${state.currentVersion}` : "…"}</p>
-          </div>
-        </div>
-        <div className="py-8">
-          <h3 className="text-base font-medium text-ink">应用更新</h3>
-          <p className="mt-3 text-sm text-ink-secondary" role="status">{state ? statusLabels[state.phase] : "正在读取版本…"}</p>
-          {state?.latestVersion ? <p className="mt-2 break-all text-sm text-ink-muted">新版本 v{state.latestVersion}</p> : null}
-          {state?.phase === "downloading" ? (
-            <div className="mt-4 flex max-w-md items-center gap-3">
-              <progress aria-label="更新下载进度" max={100} value={state.progress} className="h-2 min-w-0 flex-1 accent-accent" />
-              <span className="w-12 text-right text-sm tabular-nums text-ink-secondary">{Math.floor(state.progress)}%</span>
+        <div className="mt-8 flex flex-wrap items-start justify-between gap-x-10 gap-y-6 pb-8">
+          <div className="flex min-w-0 shrink-0 items-center gap-4">
+            <img src={new URL("../../../../../assets/shiori-app-icon.png", import.meta.url).href} alt="" className="h-16 w-16 shrink-0 object-contain" />
+            <div className="min-w-0">
+              <h3 className="font-display text-title text-ink">Shiori</h3>
+              <p className="mt-1 break-all text-sm text-ink-muted">当前版本 {state ? `v${state.currentVersion}` : "…"}</p>
             </div>
-          ) : null}
-          {error ? <p role="alert" className="mt-3 break-words text-sm text-danger-text">{error}</p> : null}
-          <div className="mt-6 flex flex-wrap gap-3">
-            <button type="button" disabled={busy} onClick={() => void (downloaded ? install() : check())} className={cx(primaryButtonClass, "inline-flex min-h-11 items-center justify-center gap-2 text-sm")}>
-              <ArrowClockwise size={18} aria-hidden="true" />
-              {downloaded ? "重启并安装" : state?.phase === "error" || error ? "重新检查" : "检查更新"}
-            </button>
-            <a href={releaseUrl} target="_blank" rel="noreferrer" className={cx(ghostButtonClass, "inline-flex min-h-11 items-center justify-center gap-2 text-sm no-underline")}>
-              <ArrowSquareOut size={18} aria-hidden="true" />更新日志
-            </a>
+          </div>
+          <div className="min-w-0 flex-1 basis-[280px] sm:text-right" aria-label="应用更新">
+            {state?.phase !== "unsupported" ? <p className="text-sm text-ink-secondary" role="status">{state ? statusLabels[state.phase] : "正在读取版本…"}</p> : null}
+            {state?.latestVersion ? <p className="mt-1 break-all text-sm text-ink-muted">新版本 v{state.latestVersion}</p> : null}
+            {state?.phase === "downloading" ? (
+              <div className="mt-3 flex max-w-md items-center gap-3 sm:ml-auto">
+                <progress aria-label="更新下载进度" max={100} value={state.progress} className="h-2 min-w-0 flex-1 accent-accent" />
+                <span className="w-12 text-right text-sm tabular-nums text-ink-secondary">{Math.floor(state.progress)}%</span>
+              </div>
+            ) : null}
+            {error ? <p role="alert" className="mt-3 break-words text-sm text-danger-text">{error}</p> : null}
+            <div className={cx("flex flex-wrap gap-3 sm:justify-end", state?.phase !== "unsupported" && "mt-3")}>
+              <button type="button" disabled={busy} onClick={() => void (downloaded ? install() : check())} className={cx(primaryButtonClass, "inline-flex min-h-11 items-center justify-center gap-2 text-sm")}>
+                <ArrowClockwise size={18} aria-hidden="true" />
+                {downloaded ? "重启并安装" : state?.phase === "error" || error ? "重新检查" : "检查更新"}
+              </button>
+              <DesktopExternalLink href={releaseUrl} className={cx(ghostButtonClass, "inline-flex min-h-11 items-center justify-center gap-2 text-sm no-underline")}>
+                <ArrowSquareOut size={18} aria-hidden="true" />更新日志
+              </DesktopExternalLink>
+            </div>
           </div>
         </div>
+        <dl className="grid gap-6 border-t border-line-soft py-8 text-sm">
+          <div className="grid gap-2 sm:grid-cols-[120px_minmax(0,1fr)] sm:items-start">
+            <dt className="flex items-center gap-2 text-ink-secondary"><GithubLogo size={18} aria-hidden="true" />GitHub</dt>
+            <dd className="min-w-0"><DesktopExternalLink href="https://github.com/YinFengWindy/Shiori-Agent" className="break-all text-accent-text underline-offset-4 hover:underline">YinFengWindy/Shiori-Agent</DesktopExternalLink></dd>
+          </div>
+          <div className="grid gap-2 sm:grid-cols-[120px_minmax(0,1fr)] sm:items-start">
+            <dt className="flex items-center gap-2 text-ink-secondary"><Envelope size={18} aria-hidden="true" />联系作者</dt>
+            <dd className="min-w-0"><DesktopExternalLink href="mailto:3174898512@qq.com" className="break-all text-accent-text underline-offset-4 hover:underline">3174898512@qq.com</DesktopExternalLink></dd>
+          </div>
+        </dl>
       </div>
     </section>
   );

--- a/apps/desktop/renderer/src/settings/SettingsPage.test.tsx
+++ b/apps/desktop/renderer/src/settings/SettingsPage.test.tsx
@@ -19,6 +19,7 @@ test("the about route stays available while the backend is offline", async () =>
   try {
     await view.render(<SettingsPage bridgeReady={false} section="about" />);
     assert.match(view.container.textContent ?? "", /当前版本 v0.2.0/);
+    assert.doesNotMatch(view.container.textContent ?? "", /开发模式/);
     assert.equal(view.container.querySelector("button")?.disabled, true);
     assert.equal(settingsReads, 0);
   } finally { await view.cleanup(); }

--- a/apps/desktop/renderer/src/settings/SettingsPage.test.tsx
+++ b/apps/desktop/renderer/src/settings/SettingsPage.test.tsx
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { mountTestComponent } from "../shared/testing/domTestHarness";
+import { SettingsPage } from "./SettingsPage";
+
+test("the about route stays available while the backend is offline", async () => {
+  const view = await mountTestComponent(null);
+  let settingsReads = 0;
+  Object.defineProperty(window, "miraDesktop", {
+    configurable: true,
+    value: {
+      updates: {
+        getState: async () => ({ revision: 0, currentVersion: "0.2.0", phase: "unsupported", latestVersion: null, progress: 0, error: null }),
+        onState: () => () => undefined,
+      },
+      readSettings: async () => { settingsReads += 1; throw new Error("backend offline"); },
+    },
+  });
+  try {
+    await view.render(<SettingsPage bridgeReady={false} section="about" />);
+    assert.match(view.container.textContent ?? "", /当前版本 v0.2.0/);
+    assert.equal(view.container.querySelector("button")?.disabled, true);
+    assert.equal(settingsReads, 0);
+  } finally { await view.cleanup(); }
+});

--- a/apps/desktop/renderer/src/settings/SettingsPage.tsx
+++ b/apps/desktop/renderer/src/settings/SettingsPage.tsx
@@ -9,6 +9,7 @@ import {
 } from "./settingsSectionMetadata";
 import { useSettingsPageController } from "./useSettingsPageController";
 import { cardClass, cx } from "../shared/styles";
+import { AboutSettingsPage } from "./AboutSettingsPage";
 
 type SettingsPageProps = {
   bridgeReady: boolean;
@@ -23,6 +24,13 @@ export const settingsContentClass = "relative scrollbar-soft overflow-y-auto px-
 
 /** Renders the active settings domain and delegates persistence to its controller. */
 export function SettingsPage({
+  bridgeReady,
+  section,
+}: SettingsPageProps) {
+  return section === "about" ? <AboutSettingsPage /> : <EditableSettingsPage bridgeReady={bridgeReady} section={section} />;
+}
+
+function EditableSettingsPage({
   bridgeReady,
   section,
 }: SettingsPageProps) {
@@ -106,7 +114,7 @@ export function SettingsPage({
               ) : null}
             </header>
           )}
-          {currentId && currentSubsectionId ? (
+          {currentId && currentId !== "about" && currentSubsectionId ? (
             <SettingsSectionContent
               sectionId={currentId}
               subsectionId={currentSubsectionId}

--- a/apps/desktop/renderer/src/settings/SettingsSectionContent.tsx
+++ b/apps/desktop/renderer/src/settings/SettingsSectionContent.tsx
@@ -8,7 +8,7 @@ import type { SettingsSectionId } from "./SettingsSidebar";
 import type { SettingsSectionEditorProps } from "./settingsPageTypes";
 
 type SettingsSectionContentProps = SettingsSectionEditorProps & {
-  sectionId: SettingsSectionId;
+  sectionId: Exclude<SettingsSectionId, "about">;
 };
 
 /** Routes the active settings domain to its focused editor component. */

--- a/apps/desktop/renderer/src/settings/SettingsSidebar.tsx
+++ b/apps/desktop/renderer/src/settings/SettingsSidebar.tsx
@@ -7,7 +7,8 @@ export type SettingsSectionId =
   | "memory"
   | "integrations"
   | "voice"
-  | "advanced";
+  | "advanced"
+  | "about";
 
 export const settingsSections: Array<{ id: SettingsSectionId; label: string }> = [
   { id: "models", label: "模型" },
@@ -16,6 +17,7 @@ export const settingsSections: Array<{ id: SettingsSectionId; label: string }> =
   { id: "integrations", label: "集成" },
   { id: "voice", label: "语音" },
   { id: "advanced", label: "高级" },
+  { id: "about", label: "关于" },
 ];
 
 type SettingsSidebarProps = {

--- a/apps/desktop/renderer/src/settings/settingsSectionMetadata.ts
+++ b/apps/desktop/renderer/src/settings/settingsSectionMetadata.ts
@@ -29,6 +29,7 @@ export const settingsSubsections: Record<SettingsSectionId, SettingsSubsection[]
   advanced: [
     { id: "general", label: "基础" },
   ],
+  about: [{ id: "updates", label: "应用更新" }],
 };
 
 /** Builds the initial active subsection for each settings domain. */
@@ -40,6 +41,7 @@ export function createInitialSettingsSubsectionState(): Record<SettingsSectionId
     integrations: settingsSubsections.integrations[0]?.id ?? "",
     voice: settingsSubsections.voice[0]?.id ?? "",
     advanced: settingsSubsections.advanced[0]?.id ?? "",
+    about: settingsSubsections.about[0]?.id ?? "",
   };
 }
 

--- a/apps/desktop/renderer/src/settings/useDesktopUpdates.test.tsx
+++ b/apps/desktop/renderer/src/settings/useDesktopUpdates.test.tsx
@@ -1,0 +1,34 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { act } from "react";
+import type { DesktopUpdateApi, DesktopUpdateState } from "../../../src/updateContract.js";
+import { mountTestComponent } from "../shared/testing/domTestHarness";
+import { useDesktopUpdates } from "./useDesktopUpdates";
+
+test("a late initial snapshot cannot overwrite a newer update event and subscriptions are cleaned up", async () => {
+  const view = await mountTestComponent(null);
+  let completeSnapshot!: (state: DesktopUpdateState) => void;
+  let notify!: (state: DesktopUpdateState) => void;
+  let unsubscribed = false;
+  const snapshot: DesktopUpdateState = { revision: 0, currentVersion: "0.2.0", phase: "idle", latestVersion: null, progress: 0, error: null };
+  const api: DesktopUpdateApi = {
+    getState: () => new Promise((resolve) => { completeSnapshot = resolve; }),
+    check: async () => snapshot,
+    install: async () => undefined,
+    onState: (listener) => { notify = listener; return () => { unsubscribed = true; }; },
+  };
+  Object.defineProperty(window, "miraDesktop", { configurable: true, value: { updates: api } });
+  function Harness() {
+    const { state } = useDesktopUpdates();
+    return <output>{state?.phase}</output>;
+  }
+  try {
+    await view.render(<Harness />);
+    await act(async () => notify({ ...snapshot, revision: 2, phase: "downloaded" }));
+    await act(async () => completeSnapshot(snapshot));
+    assert.equal(view.container.textContent, "downloaded");
+  } finally {
+    await view.cleanup();
+  }
+  assert.equal(unsubscribed, true);
+});

--- a/apps/desktop/renderer/src/settings/useDesktopUpdates.ts
+++ b/apps/desktop/renderer/src/settings/useDesktopUpdates.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useState } from "react";
+import type { DesktopUpdateState } from "../../../src/updateContract.js";
+
+/** Subscribes to desktop updates without coupling them to backend settings loading. */
+export function useDesktopUpdates() {
+  const [state, setState] = useState<DesktopUpdateState | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const acceptState = useCallback((next: DesktopUpdateState) => {
+    setState((current) => current && current.revision >= next.revision ? current : next);
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+    let receivedEvent = false;
+    const unsubscribe = window.miraDesktop.updates.onState((next) => {
+      receivedEvent = true;
+      acceptState(next);
+      setError(null);
+    });
+    void window.miraDesktop.updates.getState().then((snapshot) => {
+      if (active) acceptState(snapshot);
+    }).catch((reason: unknown) => {
+      if (active && !receivedEvent) setError(reason instanceof Error ? reason.message : String(reason));
+    });
+    return () => { active = false; unsubscribe(); };
+  }, [acceptState]);
+
+  async function runCommand(command: "check" | "install") {
+    setError(null);
+    try {
+      if (command === "check") acceptState(await window.miraDesktop.updates.check());
+      else await window.miraDesktop.updates.install();
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason));
+    }
+  }
+
+  return { state, error: error ?? state?.error, check: () => runCommand("check"), install: () => runCommand("install") };
+}

--- a/apps/desktop/renderer/src/shared/DesktopExternalLink.test.tsx
+++ b/apps/desktop/renderer/src/shared/DesktopExternalLink.test.tsx
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { act } from "react";
+import { mountTestComponent } from "./testing/domTestHarness";
+import { DesktopExternalLink } from "./DesktopExternalLink";
+
+test("external links prevent renderer navigation and use the desktop shell", async () => {
+  const view = await mountTestComponent(null);
+  const opened: string[] = [];
+  Object.defineProperty(window, "miraDesktop", { configurable: true, value: {
+    openExternal: async (url: string) => { opened.push(url); return { ok: true, error: null }; },
+  } });
+  try {
+    await view.render(<DesktopExternalLink href="mailto:3174898512@qq.com">联系作者</DesktopExternalLink>);
+    const link = view.container.querySelector("a");
+    assert.ok(link);
+    const event = new MouseEvent("click", { bubbles: true, cancelable: true });
+    await act(async () => { link.dispatchEvent(event); });
+    assert.equal(event.defaultPrevented, true);
+    assert.deepEqual(opened, ["mailto:3174898512@qq.com"]);
+  } finally { await view.cleanup(); }
+});
+
+test("shell failures are visible and a successful retry clears the error", async () => {
+  const view = await mountTestComponent(null);
+  let calls = 0;
+  Object.defineProperty(window, "miraDesktop", { configurable: true, value: {
+    openExternal: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("无法启动邮件客户端");
+      return { ok: true, error: null };
+    },
+  } });
+  try {
+    await view.render(<DesktopExternalLink href="mailto:3174898512@qq.com">联系作者</DesktopExternalLink>);
+    const link = view.container.querySelector("a");
+    assert.ok(link);
+    await act(async () => link.click());
+    assert.equal(view.container.querySelector('[role="alert"]')?.textContent, "无法启动邮件客户端");
+    await act(async () => link.click());
+    assert.equal(view.container.querySelector('[role="alert"]'), null);
+  } finally { await view.cleanup(); }
+});

--- a/apps/desktop/renderer/src/shared/DesktopExternalLink.tsx
+++ b/apps/desktop/renderer/src/shared/DesktopExternalLink.tsx
@@ -1,0 +1,25 @@
+import { useState, type ComponentProps } from "react";
+
+type DesktopExternalLinkProps = Omit<ComponentProps<"a">, "href" | "onClick"> & { href: string };
+
+/** Opens an external destination through Electron and exposes shell failures inline. */
+export function DesktopExternalLink({ href, children, ...props }: DesktopExternalLinkProps) {
+  const [error, setError] = useState<string | null>(null);
+
+  async function open() {
+    setError(null);
+    try {
+      const result = await window.miraDesktop.openExternal(href);
+      if (!result.ok) throw new Error(result.error ?? "无法打开链接");
+    } catch (reason) {
+      setError(reason instanceof Error ? reason.message : String(reason));
+    }
+  }
+
+  return (
+    <>
+      <a {...props} href={href} onClick={(event) => { event.preventDefault(); void open(); }}>{children}</a>
+      {error ? <span role="alert" className="block break-words text-sm text-danger-text">{error}</span> : null}
+    </>
+  );
+}

--- a/apps/desktop/scripts/dev-version.mjs
+++ b/apps/desktop/scripts/dev-version.mjs
@@ -1,0 +1,12 @@
+import { execFileSync } from "node:child_process";
+import { resolveReleaseVersion } from "./release-version.mjs";
+
+/** Reads the nearest release tag reachable from HEAD; untagged history keeps the package version. */
+export function resolveDevVersion(repositoryRoot) {
+  const revision = execFileSync("git", [
+    "describe", "--tags", "--match", "v[0-9]*", "--abbrev=0", "--always",
+  ], { cwd: repositoryRoot, encoding: "utf8", windowsHide: true }).trim();
+  // With no reachable release tag, --always returns the commit hash.
+  if (!revision.startsWith("v")) return undefined;
+  return resolveReleaseVersion(revision.slice(1));
+}

--- a/apps/desktop/scripts/dev-version.test.mjs
+++ b/apps/desktop/scripts/dev-version.test.mjs
@@ -1,0 +1,56 @@
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import test from "node:test";
+import { resolveDevVersion } from "./dev-version.mjs";
+
+function createRepository(t) {
+  const directory = mkdtempSync(join(tmpdir(), "shiori-dev-version-"));
+  t.after(() => rmSync(directory, { recursive: true, force: true }));
+  const git = (...args) => execFileSync("git", [
+    "-c", "user.name=Version Test", "-c", "user.email=version@example.invalid",
+    "-c", "commit.gpgSign=false", "-c", "tag.gpgSign=false", ...args,
+  ], { cwd: directory, encoding: "utf8", windowsHide: true });
+  git("init", "--initial-branch=main");
+  git("commit", "--allow-empty", "-m", "Initial commit");
+  return { directory, git };
+}
+
+test("dev version follows new release tags and commits after the release", (t) => {
+  const { directory, git } = createRepository(t);
+  git("tag", "v0.1.0");
+  assert.equal(resolveDevVersion(directory), "0.1.0");
+  git("commit", "--allow-empty", "-m", "Next release");
+  git("tag", "v0.2.0");
+  assert.equal(resolveDevVersion(directory), "0.2.0");
+  git("commit", "--allow-empty", "-m", "Development");
+  git("tag", "unrelated-tag");
+  assert.equal(resolveDevVersion(directory), "0.2.0");
+});
+
+test("dev version ignores release tags outside the current history", (t) => {
+  const { directory, git } = createRepository(t);
+  git("tag", "v0.1.0");
+  git("branch", "older-development");
+  git("commit", "--allow-empty", "-m", "Next release");
+  git("tag", "v0.2.0");
+  git("checkout", "older-development");
+  assert.equal(resolveDevVersion(directory), "0.1.0");
+});
+
+test("dev version leaves untagged history on the package version", (t) => {
+  const { directory, git } = createRepository(t);
+  git("tag", "unrelated-tag");
+  assert.equal(resolveDevVersion(directory), undefined);
+});
+
+test("dev version shares release validation including prerelease tags", (t) => {
+  const { directory, git } = createRepository(t);
+  git("tag", "-a", "v0.3.0-beta.1", "-m", "Prerelease");
+  assert.equal(resolveDevVersion(directory), "0.3.0-beta.1");
+  git("commit", "--allow-empty", "-m", "Invalid release");
+  git("tag", "v0.invalid");
+  assert.throws(() => resolveDevVersion(directory), /Invalid release version/);
+});

--- a/apps/desktop/scripts/dev.mjs
+++ b/apps/desktop/scripts/dev.mjs
@@ -4,11 +4,13 @@ import { createServer as createNetServer } from "node:net";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import { createServer } from "vite";
+import { resolveDevVersion } from "./dev-version.mjs";
 
 const require = createRequire(import.meta.url);
 const electronExe = require("electron");
 const here = dirname(fileURLToPath(import.meta.url));
 const desktopRoot = resolve(here, "..");
+const devVersion = resolveDevVersion(desktopRoot);
 const rendererConfig = resolve(desktopRoot, "renderer", "vite.config.ts");
 const userDataDir = resolve(desktopRoot, ".dev-user-data");
 const preferredPort = Number(process.env.SHIORI_RENDERER_DEV_SERVER_PORT || "5173");
@@ -78,6 +80,7 @@ electronProc = spawn(electronExe, ["."], {
   stdio: "inherit",
   env: {
     ...process.env,
+    SHIORI_DEV_VERSION: devVersion ?? "",
     SHIORI_RENDERER_DEV_SERVER_URL: devServerUrl,
     SHIORI_DESKTOP_USER_DATA_DIR: userDataDir,
   },

--- a/apps/desktop/src/bridge/shared.ts
+++ b/apps/desktop/src/bridge/shared.ts
@@ -220,6 +220,8 @@ export type RendererDiagnosticPayload = {
 };
 
 export type DesktopApi = {
+  /** Reads and controls the Electron application update lifecycle. */
+  updates: import("../updateContract.js").DesktopUpdateApi;
   /** Identifies one main-process lifetime, including renderer reloads. */
   applicationSessionId(): Promise<string>;
   invoke(request: Omit<BridgeRequest, "id">): Promise<BridgeResponse>;

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -9,7 +9,7 @@ import { registerDesktopIpc } from "./bridge/ipc.js";
 import { openGrantedLocalAsset } from "./assets/localAssetOpen.js";
 import { LocalAssetRegistry, localAssetScheme } from "./assets/localAssetRegistry.js";
 import { ensureDesktopRuntimeConfig, resolveDesktopRuntimePaths } from "./runtimePaths.js";
-import { checkForDesktopUpdates } from "./updater.js";
+import { registerDesktopUpdates } from "./updater.js";
 import { createDesktopTray } from "./tray.js";
 import { createDesktopWindow, showDesktopWindow } from "./window.js";
 import {
@@ -281,7 +281,7 @@ void app.whenReady().then(() => {
   );
   registerLocalAssetProtocol(protocol, localAssets);
   void startBridge(bridge);
-  checkForDesktopUpdates(app.isPackaged, (error) => {
+  registerDesktopUpdates(app.isPackaged, app.getVersion(), (error) => {
     logDesktopDiagnostic({ scope: "main", event: "updater.check.failed", payload: { error } });
   });
   desktopPet = new DesktopPetController({

--- a/apps/desktop/src/main.ts
+++ b/apps/desktop/src/main.ts
@@ -281,7 +281,8 @@ void app.whenReady().then(() => {
   );
   registerLocalAssetProtocol(protocol, localAssets);
   void startBridge(bridge);
-  registerDesktopUpdates(app.isPackaged, app.getVersion(), (error) => {
+  const currentVersion = !app.isPackaged && process.env.SHIORI_DEV_VERSION || app.getVersion();
+  registerDesktopUpdates(app.isPackaged, currentVersion, (error) => {
     logDesktopDiagnostic({ scope: "main", event: "updater.check.failed", payload: { error } });
   });
   desktopPet = new DesktopPetController({

--- a/apps/desktop/src/preload.ts
+++ b/apps/desktop/src/preload.ts
@@ -29,6 +29,16 @@ window.addEventListener("click", (event) => {
 });
 
 const api: DesktopApi = {
+  updates: {
+    getState: () => ipcRenderer.invoke("desktop:update-state"),
+    check: () => ipcRenderer.invoke("desktop:update-check"),
+    install: () => ipcRenderer.invoke("desktop:update-install"),
+    onState(listener) {
+      const wrapped = (_event: unknown, state: import("./updateContract.js").DesktopUpdateState) => listener(state);
+      ipcRenderer.on("desktop:update-state", wrapped);
+      return () => ipcRenderer.off("desktop:update-state", wrapped);
+    },
+  },
   applicationSessionId() {
     return ipcRenderer.invoke("desktop:application-session-id") as Promise<string>;
   },

--- a/apps/desktop/src/updateContract.ts
+++ b/apps/desktop/src/updateContract.ts
@@ -1,0 +1,17 @@
+/** Serializable update status shared by the main process and settings UI. */
+export type DesktopUpdateState = {
+  revision: number;
+  currentVersion: string;
+  phase: "unsupported" | "idle" | "checking" | "current" | "downloading" | "downloaded" | "installing" | "error";
+  latestVersion: string | null;
+  progress: number;
+  error: string | null;
+};
+
+/** Desktop-owned update commands; no backend bridge connection is required. */
+export type DesktopUpdateApi = {
+  getState(): Promise<DesktopUpdateState>;
+  check(): Promise<DesktopUpdateState>;
+  install(): Promise<void>;
+  onState(listener: (state: DesktopUpdateState) => void): () => void;
+};

--- a/apps/desktop/src/updateController.test.ts
+++ b/apps/desktop/src/updateController.test.ts
@@ -1,0 +1,93 @@
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import test from "node:test";
+import type { UpdateCheckResult, UpdateInfo } from "electron-updater";
+import { DesktopUpdateController } from "./updateController.js";
+
+const info: UpdateInfo = { version: "0.3.0", files: [], path: "setup.exe", sha512: "hash", releaseDate: "2026-09-09" };
+const result: UpdateCheckResult = { isUpdateAvailable: false, updateInfo: info, versionInfo: info };
+
+class FakeUpdater extends EventEmitter {
+  autoDownload = false;
+  checks = 0;
+  installs: boolean[][] = [];
+  checkResult: () => Promise<UpdateCheckResult | null> = async () => {
+    this.emit("update-not-available", info);
+    return result;
+  };
+  checkForUpdates() { this.checks += 1; return this.checkResult(); }
+  quitAndInstall(silent = false, relaunch = false) { this.installs.push([silent, relaunch]); }
+}
+
+function fixture(engine: FakeUpdater | null = new FakeUpdater()) {
+  const errors: unknown[] = [];
+  const controller = new DesktopUpdateController({ version: "0.2.0", engine, publish: () => undefined, onError: (error) => errors.push(error) });
+  return { controller, errors };
+}
+
+test("development builds expose version without creating an update engine", async () => {
+  const { controller } = fixture(null);
+  assert.equal(controller.getState().currentVersion, "0.2.0");
+  assert.equal(controller.getState().phase, "unsupported");
+  await assert.rejects(controller.check(), /开发模式/);
+  assert.throws(() => controller.install(), /尚未下载完成/);
+});
+
+test("startup and manual checks share one request and expose current status", async () => {
+  const engine = new FakeUpdater();
+  const { controller } = fixture(engine);
+  const first = controller.check();
+  assert.equal(controller.check(), first);
+  await first;
+  assert.equal(engine.checks, 1);
+  assert.equal(engine.autoDownload, true);
+  assert.equal(controller.getState().phase, "current");
+});
+
+test("download progress survives manual checks and installation requires a ready update", async () => {
+  const engine = new FakeUpdater();
+  const { controller } = fixture(engine);
+  engine.emit("update-available", info);
+  engine.emit("download-progress", { percent: 42.5 });
+  assert.equal(controller.getState().progress, 42.5);
+  assert.equal(controller.getState().latestVersion, "0.3.0");
+  await controller.check();
+  assert.equal(engine.checks, 0);
+  assert.throws(() => controller.install(), /尚未下载完成/);
+  engine.emit("update-downloaded", info);
+  controller.install();
+  assert.deepEqual(engine.installs, [[false, true]]);
+  assert.equal(controller.getState().phase, "installing");
+  assert.throws(() => controller.install(), /尚未下载完成/);
+  controller.dispose();
+  assert.equal(engine.listenerCount("download-progress"), 0);
+});
+
+test("failed checks publish an error once and can be retried", async () => {
+  const engine = new FakeUpdater();
+  const { controller, errors } = fixture(engine);
+  engine.checkResult = async () => {
+    const error = new Error("network unavailable");
+    engine.emit("error", error);
+    throw error;
+  };
+  await assert.rejects(controller.check(), /network unavailable/);
+  assert.equal(controller.getState().error, "network unavailable");
+  assert.equal(errors.length, 1);
+  engine.checkResult = async () => { engine.emit("update-not-available", info); return result; };
+  await controller.check();
+  assert.equal(controller.getState().phase, "current");
+  assert.equal(controller.getState().error, null);
+});
+
+test("asynchronous download failures are observable and do not become unhandled rejections", async () => {
+  const engine = new FakeUpdater();
+  const { controller } = fixture(engine);
+  engine.checkResult = async () => {
+    engine.emit("update-available", info);
+    return { ...result, isUpdateAvailable: true, downloadPromise: Promise.reject(new Error("download failed")) };
+  };
+  await controller.check();
+  assert.equal(controller.getState().phase, "error");
+  assert.equal(controller.getState().error, "download failed");
+});

--- a/apps/desktop/src/updateController.ts
+++ b/apps/desktop/src/updateController.ts
@@ -1,0 +1,96 @@
+import type { EventEmitter } from "node:events";
+import type { AppUpdater, UpdateInfo, ProgressInfo } from "electron-updater";
+import type { DesktopUpdateState } from "./updateContract.js";
+
+type UpdateEngine = Pick<AppUpdater, "autoDownload" | "checkForUpdates" | "quitAndInstall">
+  & Pick<EventEmitter, "on" | "removeListener">;
+
+/** Owns one update lifecycle, including concurrent checks and renderer snapshots. */
+export class DesktopUpdateController {
+  private state: DesktopUpdateState;
+  private checking: Promise<DesktopUpdateState> | null = null;
+  private readonly listeners: Array<Parameters<EventEmitter["on"]>> = [];
+
+  constructor(private readonly options: {
+    version: string;
+    engine: UpdateEngine | null;
+    publish: (state: DesktopUpdateState) => void;
+    onError: (error: unknown) => void;
+  }) {
+    this.state = {
+      revision: 0, currentVersion: options.version,
+      phase: options.engine ? "idle" : "unsupported",
+      latestVersion: null, progress: 0, error: null,
+    };
+    if (!options.engine) return;
+    options.engine.autoDownload = true;
+    this.listen("checking-for-update", () => this.update({ phase: "checking", error: null }));
+    this.listen("update-not-available", () => this.update({ phase: "current", latestVersion: null, progress: 0 }));
+    this.listen("update-available", (info: UpdateInfo) => this.update({
+      phase: "downloading", latestVersion: info.version, progress: 0,
+    }));
+    this.listen("download-progress", (info: ProgressInfo) => this.update({
+      phase: "downloading", progress: Math.max(0, Math.min(100, info.percent)),
+    }));
+    this.listen("update-downloaded", (info: UpdateInfo) => this.update({
+      phase: "downloaded", latestVersion: info.version, progress: 100, error: null,
+    }));
+    this.listen("error", (error: Error) => this.recordError(error));
+  }
+
+  /** Returns the most recent immutable status snapshot. */
+  getState() { return this.state; }
+
+  /** Checks once and preserves an in-flight download or ready installer. */
+  check(): Promise<DesktopUpdateState> {
+    const engine = this.options.engine;
+    if (!engine) return Promise.reject(new Error("开发模式不支持应用更新"));
+    if (this.checking) return this.checking;
+    if (["downloading", "downloaded", "installing"].includes(this.state.phase)) return Promise.resolve(this.state);
+    this.update({ phase: "checking", error: null, progress: 0 });
+    this.checking = Promise.resolve().then(() => engine.checkForUpdates()).then((result) => {
+      if (!result) throw new Error("当前环境无法检查应用更新");
+      void result.downloadPromise?.catch((error: unknown) => this.recordError(error));
+      return this.state;
+    }).catch((error: unknown) => {
+      this.recordError(error);
+      throw error;
+    }).finally(() => { this.checking = null; });
+    return this.checking;
+  }
+
+  /** Installs only a completely downloaded update and relaunches the application. */
+  install() {
+    if (!this.options.engine || this.state.phase !== "downloaded") throw new Error("更新尚未下载完成");
+    this.update({ phase: "installing", error: null });
+    try {
+      this.options.engine.quitAndInstall(false, true);
+    } catch (error) {
+      this.recordError(error);
+      throw error;
+    }
+  }
+
+  /** Releases the engine listeners owned by this controller. */
+  dispose() {
+    for (const [event, listener] of this.listeners) this.options.engine?.removeListener(event, listener);
+    this.listeners.length = 0;
+  }
+
+  private listen(event: string, listener: Parameters<EventEmitter["on"]>[1]) {
+    this.options.engine?.on(event, listener);
+    this.listeners.push([event, listener]);
+  }
+
+  private update(patch: Partial<DesktopUpdateState>) {
+    this.state = { ...this.state, ...patch, revision: this.state.revision + 1 };
+    this.options.publish(this.state);
+  }
+
+  private recordError(error: unknown) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (this.state.phase === "error" && this.state.error === message) return;
+    this.update({ phase: "error", error: message });
+    this.options.onError(error);
+  }
+}

--- a/apps/desktop/src/updater.ts
+++ b/apps/desktop/src/updater.ts
@@ -1,14 +1,28 @@
 import electronUpdater from "electron-updater";
+import electron from "electron";
+import { DesktopUpdateController } from "./updateController.js";
 
-/** Starts the packaged-only GitHub Releases update check without blocking desktop startup. */
-export function checkForDesktopUpdates(
+/** Connects the updater to desktop IPC and starts the packaged-only background check. */
+export function registerDesktopUpdates(
   packaged: boolean,
+  version: string,
   onError: (error: unknown) => void,
-): void {
-  if (!packaged) {
-    return;
-  }
-  electronUpdater.autoUpdater.autoDownload = true;
-  electronUpdater.autoUpdater.on("error", onError);
-  void electronUpdater.autoUpdater.checkForUpdatesAndNotify().catch(onError);
+) {
+  const { BrowserWindow, ipcMain, Notification } = electron;
+  const controller = new DesktopUpdateController({
+    version,
+    engine: packaged ? electronUpdater.autoUpdater : null,
+    publish: (state) => {
+      for (const window of BrowserWindow.getAllWindows()) window.webContents.send("desktop:update-state", state);
+      if (state.phase === "downloaded" && Notification.isSupported()) {
+        new Notification({ title: "Shiori 更新已就绪", body: `v${state.latestVersion} 已下载，可在设置中重启安装。` }).show();
+      }
+    },
+    onError,
+  });
+  ipcMain.handle("desktop:update-state", () => controller.getState());
+  ipcMain.handle("desktop:update-check", () => controller.check());
+  ipcMain.handle("desktop:update-install", () => controller.install());
+  if (packaged) void controller.check().catch(() => { /* The controller publishes and logs startup failures. */ });
+  return controller;
 }

--- a/docs/knowledge/modules/desktop-and-bridge.md
+++ b/docs/knowledge/modules/desktop-and-bridge.md
@@ -30,7 +30,7 @@ related:
 
 Windows packaged desktop uses an Electron-builder NSIS bundle with a PyInstaller onedir runtime under `resources/runtime`. The main process resolves packaged resources from `process.resourcesPath`, keeps the workspace and `config.toml` under `%USERPROFILE%\.shiori\workspace`, and starts the sidecar with explicit `bridge`, `--workspace`, and `--config` arguments. Release tags provide the application version and CI emits `SHA256SUMS.txt` alongside the installer; clean Windows installation, upgrade, uninstall, and feature smoke remain release-owner acceptance work.
 
-应用更新由 Electron 主进程的 `DesktopUpdateController` 管理，启动检查与设置中的手动检查共用同一生命周期。安装版自动下载新版本，下载完成后保留系统通知，并可从“设置 → 关于”重启安装；开发模式只显示版本并禁用更新操作。`DesktopApi.updates` 通过独立 IPC 传递带 revision 的状态快照和事件，避免初始读取覆盖更晚的下载事件。关于页不加载后端配置，即使 Python bridge 离线也能显示更新状态。
+应用更新由 Electron 主进程的 `DesktopUpdateController` 管理，启动检查与设置中的手动检查共用同一生命周期。安装版自动下载新版本，下载完成后保留系统通知，并可从“设置 → 关于”重启安装；开发模式只显示版本并禁用更新操作。`pnpm dev` 每次启动读取当前提交可追溯的最近一个本地 `v*` 版本 tag，通过 `SHIORI_DEV_VERSION` 传给主进程；没有版本 tag 时使用 `package.json` 版本，不会改写文件。远端新 tag 需先 fetch 到本地并重启 dev。安装包始终使用打包元数据版本。`DesktopApi.updates` 通过独立 IPC 传递带 revision 的状态快照和事件，避免初始读取覆盖更晚的下载事件。关于页不加载后端配置，即使 Python bridge 离线也能显示更新状态。
 
 桌宠语音的 Electron 主进程控制、隐藏 renderer 采集/播放与 Python provider 协调边界见 [桌宠语音交互](voice.md)。通用 `ipc.ts` 不拥有语音业务，语音 IPC 统一注册在 `apps/desktop/src/voice/ipc.ts`。
 

--- a/docs/knowledge/modules/desktop-and-bridge.md
+++ b/docs/knowledge/modules/desktop-and-bridge.md
@@ -30,6 +30,8 @@ related:
 
 Windows packaged desktop uses an Electron-builder NSIS bundle with a PyInstaller onedir runtime under `resources/runtime`. The main process resolves packaged resources from `process.resourcesPath`, keeps the workspace and `config.toml` under `%USERPROFILE%\.shiori\workspace`, and starts the sidecar with explicit `bridge`, `--workspace`, and `--config` arguments. Release tags provide the application version and CI emits `SHA256SUMS.txt` alongside the installer; clean Windows installation, upgrade, uninstall, and feature smoke remain release-owner acceptance work.
 
+应用更新由 Electron 主进程的 `DesktopUpdateController` 管理，启动检查与设置中的手动检查共用同一生命周期。安装版自动下载新版本，下载完成后保留系统通知，并可从“设置 → 关于”重启安装；开发模式只显示版本并禁用更新操作。`DesktopApi.updates` 通过独立 IPC 传递带 revision 的状态快照和事件，避免初始读取覆盖更晚的下载事件。关于页不加载后端配置，即使 Python bridge 离线也能显示更新状态。
+
 桌宠语音的 Electron 主进程控制、隐藏 renderer 采集/播放与 Python provider 协调边界见 [桌宠语音交互](voice.md)。通用 `ipc.ts` 不拥有语音业务，语音 IPC 统一注册在 `apps/desktop/src/voice/ipc.ts`。
 
 ## 数据流


### PR DESCRIPTION
Closes #169

依赖 #168 已合并，本 PR 目标为 main。保留发布提交历史，使开发模式可以追溯已发布的 v0.2.0 tag。

## 变更

安装版原先只在启动时后台检查更新，没有可见入口。新增“设置 → 关于”：显示当前版本，提供检查更新、下载进度、失败重试、更新日志和下载完成后的重启安装。

更新状态及操作与 Shiori 版本信息处于同一栏右侧，窄窗口自动换行。页面不显示开发模式文案，下方提供 GitHub 仓库和联系作者邮箱 `3174898512@qq.com`。更新日志、仓库及邮箱共用系统外链接口，避免新窗口被桌面导航策略拦截，并显示外部应用打开失败的信息。

更新生命周期由 Electron 独立管理，自动检查与手动检查共用请求，下载完成前拒绝安装。关于页不依赖 Python bridge 或设置表单加载；开发模式禁用更新。保留自动下载与完成通知，状态 revision 防止较早的初始响应覆盖下载事件。

开发模式原先始终显示 package.json 中的 0.1.0，即使当前提交已包含 v0.2.0。现在 pnpm dev 启动时读取当前提交可追溯的最近一个本地版本 tag，复用发布版本校验并传给主进程；无版本 tag 时使用 package.json，不改写源码。远端新 tag 需先 fetch 到本地并重启 dev。安装版继续读取打包版本元数据。

## 验证

- 16 项相关测试通过：更新状态、检查去重、失败重试、安装门禁、订阅清理、快照乱序、页面交互及离线入口。
- desktop typecheck、修改范围 ESLint、production build 通过。
- Playwright 1280×800 / 390×844 检查通过：布局无横向溢出、图标加载、检查/重试/安装操作及下载进度。
- 浏览器验证使用模拟更新事件；未执行真实下载后重启安装。
- 后续 UI 调整：5 项相关交互测试通过；外链策略的 3 项测试通过；typecheck、修改范围 ESLint、production build 通过。桌面与窄窗口截图检查通过，三个链接均验证调用系统外链接口。
- dev 版本修复：6 项相关测试通过，覆盖版本 tag 更新、发布后提交、旧分支隔离、无 tag、预发布版本及非法版本校验；主进程构建、main.ts ESLint 和 git diff --check 通过。当前仓库实际解析得到 0.2.0；未重启正在运行的桌面应用。
- 合并前最新提交 1a021a11 的前后端 CI 均通过，包含类型检查、lint、测试和生产构建：https://github.com/YinFengWindy/Shiori-Agent/actions/runs/34321189827

## 阻塞项

- 无合并阻塞项。
- 本 PR 未发布新安装包，已发布的 v0.2.0 保持不变；真实下载后重启安装仍属后续发布验收范围。
