### PR TITLE
fix(desktop): 修复生图角色列表被提示词栏遮挡

### DIFF
--- a/apps/desktop/renderer/src/image/ImageFormPanel.tsx
+++ b/apps/desktop/renderer/src/image/ImageFormPanel.tsx
@@ -159,7 +159,7 @@ export function ImageFormPanel({
           </svg>
         </button>
         {rolePanelOpen ? (
-          <div className="absolute inset-x-0 top-[calc(100%+0.5rem)] z-20 overflow-hidden rounded-md border border-line bg-white p-2">
+          <div className="absolute inset-x-0 top-[calc(100%+0.5rem)] z-30 overflow-hidden rounded-md border border-line bg-white p-2">
             <div className="grid gap-1">
               {roleItems.map((item) => (
                 <button


### PR DESCRIPTION
生图页展开角色列表时，后绘制的 Base Prompt 标题栏与列表同为 z-20，导致首个角色被遮挡并无法点击。将角色弹层提升至 z-30，使其位于提示词控件上方。

Closes #171

## 验证

- 使用真实 ImageStudioSidebar 与 renderer CSS，在 320px / 1280x900 和 260px / 390x844 下完成 Playwright 前后截图及真实点击验证。
- 修复前首项 10 个采样点均命中提示词控件，点击失败；修复后 10/10 命中角色，选择并收起成功。
- 点击外部收起、Prompt 设置开关与预设、提示词标签切换均通过，无浏览器错误。
- ImageStudioSidebar 定向单测 1/1 通过；修改文件 ESLint、renderer TypeScript 检查、renderer 构建及 git diff --check 均通过。
- 构建仅出现现有的大 chunk 提示。

## CI 与阻塞

[CI run 34339406604](https://github.com/YinFengWindy/Shiori-Agent/actions/runs/34339406604) 的 check-and-test 与 desktop-check-and-test 均通过，验证提交为 1bddbd3958727adac2ba9dab44be0981330af106。无已知实现阻塞，合并等待用户确认。

## Review

skipped: UI-only。本次仅一处弹层样式调整，不涉及状态、后端或业务契约。已核对 base edba27db31664743e321694a3f2138bfbc1d69c3 与 head 1bddbd3958727adac2ba9dab44be0981330af106 的实际 diff 和浏览器验证证据。
