### PR TITLE
refactor(plugin): 建立 capability 内核与旧插件适配器 (#176)

### DIFF
--- a/apps/backend/agent/plugin_host/__init__.py
+++ b/apps/backend/agent/plugin_host/__init__.py
@@ -1,0 +1,35 @@
+"""插件内核公共入口：内核、manifest、运行时上下文与 capability 契约。"""
+
+from agent.plugin_host.capabilities import PHASE_SLOTS, PluginContributions
+from agent.plugin_host.effects import EffectScope
+from agent.plugin_host.events import ScopedEventBus
+from agent.plugin_host.handle import PluginHandle, PluginRecord, PluginState
+from agent.plugin_host.kernel import HostServices, PluginKernel
+from agent.plugin_host.manifest import (
+    KNOWN_CAPABILITIES,
+    ManifestError,
+    PluginManifest,
+    load_manifest,
+)
+from agent.plugin_host.runtime_context import (
+    CapabilityNotGranted,
+    PluginRuntimeContext,
+)
+
+__all__ = [
+    "CapabilityNotGranted",
+    "EffectScope",
+    "HostServices",
+    "KNOWN_CAPABILITIES",
+    "ManifestError",
+    "PHASE_SLOTS",
+    "PluginContributions",
+    "PluginHandle",
+    "PluginKernel",
+    "PluginManifest",
+    "PluginRecord",
+    "PluginRuntimeContext",
+    "PluginState",
+    "ScopedEventBus",
+    "load_manifest",
+]

--- a/apps/backend/agent/plugin_host/capabilities.py
+++ b/apps/backend/agent/plugin_host/capabilities.py
@@ -94,10 +94,13 @@ class LifecycleCapability:
             raise ValueError(f"未知 phase 槽位: {slot}")
         target = self._contributions.phase_modules[slot]
         target.extend(modules)
-        self._effects.add(
-            f"phase:{slot}:{len(modules)}",
-            lambda: [target.remove(m) for m in modules if m in target],
-        )
+
+        def remove_contributed() -> None:
+            for module in modules:
+                if module in target:
+                    target.remove(module)
+
+        self._effects.add(f"phase:{slot}:{len(modules)}", remove_contributed)
 
 
 class ToolHooksCapability:

--- a/apps/backend/agent/plugin_host/capabilities.py
+++ b/apps/backend/agent/plugin_host/capabilities.py
@@ -1,0 +1,182 @@
+"""按产品扩展点划分的 capability 实现：插件只拿到 manifest 声明的窄接口。"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import TYPE_CHECKING, Any
+
+from agent.plugin_host.effects import EffectScope
+
+if TYPE_CHECKING:
+    from agent.core.proactive_turn.gates import ProactiveGate
+    from agent.tool_hooks.base import ToolHook
+    from infra.channels.contract import Channel
+
+logger = logging.getLogger(__name__)
+
+# Shiori 定义的 7 个 phase 槽位；顺序与 AgentLoop 接线一致
+PHASE_SLOTS = (
+    "before_turn",
+    "before_reasoning",
+    "prompt_render",
+    "before_step",
+    "after_step",
+    "after_reasoning",
+    "after_turn",
+)
+
+
+class PluginContributions:
+    """单个插件贡献的运行时对象集合；随插件卸载整体废弃。"""
+
+    def __init__(self) -> None:
+        self.phase_modules: dict[str, list[object]] = {slot: [] for slot in PHASE_SLOTS}
+        self.tool_hooks: list[ToolHook] = []
+        self.proactive_gates: list[ProactiveGate] = []
+        self.channels: list[Channel] = []
+        self.tool_names: list[str] = []
+
+
+class ToolsCapability:
+    """注册插件工具到 ToolRegistry；卸载时通过 effect 反注册。"""
+
+    def __init__(
+        self,
+        registry: Any,
+        effects: EffectScope,
+        contributions: PluginContributions,
+        plugin_id: str,
+    ) -> None:
+        self._registry = registry
+        self._effects = effects
+        self._contributions = contributions
+        self._plugin_id = plugin_id
+
+    def register(
+        self,
+        tool: Any,
+        *,
+        risk: str = "read-write",
+        always_on: bool = False,
+        search_hint: str | None = None,
+    ) -> None:
+        if self._registry is None:
+            raise RuntimeError(f"插件 {self._plugin_id} 请求 tools 能力，但宿主未提供 ToolRegistry")
+        name = str(tool.name)
+        self._registry.register(
+            tool,
+            risk=risk,
+            always_on=always_on,
+            search_hint=search_hint,
+            source_type="plugin",
+            source_name=self._plugin_id,
+        )
+        self._contributions.tool_names.append(name)
+        self._effects.add(f"tool:{name}", lambda: self._unregister(name))
+
+    def _unregister(self, name: str) -> None:
+        if self._registry is not None:
+            self._registry.unregister(name)
+        if name in self._contributions.tool_names:
+            self._contributions.tool_names.remove(name)
+
+
+class LifecycleCapability:
+    """向 Shiori 定义的 phase 槽位贡献模块；槽位顺序语义仍由核心拥有。"""
+
+    def __init__(self, contributions: PluginContributions, effects: EffectScope) -> None:
+        self._contributions = contributions
+        self._effects = effects
+
+    def contribute(self, slot: str, modules: list[object]) -> None:
+        if slot not in PHASE_SLOTS:
+            raise ValueError(f"未知 phase 槽位: {slot}")
+        target = self._contributions.phase_modules[slot]
+        target.extend(modules)
+        self._effects.add(
+            f"phase:{slot}:{len(modules)}",
+            lambda: [target.remove(m) for m in modules if m in target],
+        )
+
+
+class ToolHooksCapability:
+    """贡献工具执行前置 hook（ToolExecutor pre_hook 链）。"""
+
+    def __init__(self, contributions: PluginContributions, effects: EffectScope) -> None:
+        self._contributions = contributions
+        self._effects = effects
+
+    def add(self, hook: "ToolHook") -> None:
+        self._contributions.tool_hooks.append(hook)
+        self._effects.add(
+            f"tool_hook:{getattr(hook, 'name', hook)}",
+            lambda: self._discard(hook),
+        )
+
+    def _discard(self, hook: "ToolHook") -> None:
+        if hook in self._contributions.tool_hooks:
+            self._contributions.tool_hooks.remove(hook)
+
+
+class ProactiveGatesCapability:
+    """贡献参与主动 tick 准入的 gate；不允许直接投递消息。"""
+
+    def __init__(self, contributions: PluginContributions, effects: EffectScope) -> None:
+        self._contributions = contributions
+        self._effects = effects
+
+    def add(self, gate: "ProactiveGate") -> None:
+        self._contributions.proactive_gates.append(gate)
+        self._effects.add(
+            f"proactive_gate:{getattr(gate, 'name', gate)}",
+            lambda: self._discard(gate),
+        )
+
+    def _discard(self, gate: "ProactiveGate") -> None:
+        if gate in self._contributions.proactive_gates:
+            self._contributions.proactive_gates.remove(gate)
+
+
+class ChannelsCapability:
+    """贡献渠道 adapter；渠道宿主接管其生命周期。"""
+
+    def __init__(self, contributions: PluginContributions, effects: EffectScope) -> None:
+        self._contributions = contributions
+        self._effects = effects
+
+    def add(self, channel: "Channel") -> None:
+        self._contributions.channels.append(channel)
+        self._effects.add(
+            f"channel:{getattr(channel, 'name', channel)}",
+            lambda: self._discard(channel),
+        )
+
+    def _discard(self, channel: "Channel") -> None:
+        if channel in self._contributions.channels:
+            self._contributions.channels.remove(channel)
+
+
+class BackgroundCapability:
+    """启动可取消后台任务；插件卸载时任务被取消并等待退出。"""
+
+    def __init__(self, effects: EffectScope, plugin_id: str) -> None:
+        self._effects = effects
+        self._plugin_id = plugin_id
+
+    def spawn(self, coro: Any, *, name: str) -> asyncio.Task[Any]:
+        task: asyncio.Task[Any] = asyncio.create_task(
+            coro, name=f"plugin:{self._plugin_id}:{name}"
+        )
+        self._effects.add(f"background:{name}", lambda: self._cancel(task))
+        return task
+
+    @staticmethod
+    async def _cancel(task: asyncio.Task[Any]) -> None:
+        if task.done():
+            return
+        _ = task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001 - 卸载路径只收敛不传播
+            pass

--- a/apps/backend/agent/plugin_host/capabilities.py
+++ b/apps/backend/agent/plugin_host/capabilities.py
@@ -38,6 +38,27 @@ class PluginContributions:
         self.tool_names: list[str] = []
 
 
+def contribute_to_list[T](
+    target: list[T],
+    item: T,
+    *,
+    effects: EffectScope,
+    label: str,
+) -> None:
+    """把一项贡献登记进目标列表，并登记"从列表移除"的可回滚 effect。
+
+    三类列表型 capability（tool hook / proactive gate / channel）共用此实现，
+    保证登记与撤销形状一致；移除守卫使重复处置保持幂等。
+    """
+    target.append(item)
+
+    def discard() -> None:
+        if item in target:
+            target.remove(item)
+
+    effects.add(label, discard)
+
+
 class ToolsCapability:
     """注册插件工具到 ToolRegistry；卸载时通过 effect 反注册。"""
 
@@ -72,6 +93,7 @@ class ToolsCapability:
             source_type="plugin",
             source_name=self._plugin_id,
         )
+        # 工具除了从贡献清单移除，还要反注册出 ToolRegistry，故不复用列表 helper
         self._contributions.tool_names.append(name)
         self._effects.add(f"tool:{name}", lambda: self._unregister(name))
 
@@ -111,15 +133,12 @@ class ToolHooksCapability:
         self._effects = effects
 
     def add(self, hook: "ToolHook") -> None:
-        self._contributions.tool_hooks.append(hook)
-        self._effects.add(
-            f"tool_hook:{getattr(hook, 'name', hook)}",
-            lambda: self._discard(hook),
+        contribute_to_list(
+            self._contributions.tool_hooks,
+            hook,
+            effects=self._effects,
+            label=f"tool_hook:{getattr(hook, 'name', hook)}",
         )
-
-    def _discard(self, hook: "ToolHook") -> None:
-        if hook in self._contributions.tool_hooks:
-            self._contributions.tool_hooks.remove(hook)
 
 
 class ProactiveGatesCapability:
@@ -130,15 +149,12 @@ class ProactiveGatesCapability:
         self._effects = effects
 
     def add(self, gate: "ProactiveGate") -> None:
-        self._contributions.proactive_gates.append(gate)
-        self._effects.add(
-            f"proactive_gate:{getattr(gate, 'name', gate)}",
-            lambda: self._discard(gate),
+        contribute_to_list(
+            self._contributions.proactive_gates,
+            gate,
+            effects=self._effects,
+            label=f"proactive_gate:{getattr(gate, 'name', gate)}",
         )
-
-    def _discard(self, gate: "ProactiveGate") -> None:
-        if gate in self._contributions.proactive_gates:
-            self._contributions.proactive_gates.remove(gate)
 
 
 class ChannelsCapability:
@@ -149,15 +165,12 @@ class ChannelsCapability:
         self._effects = effects
 
     def add(self, channel: "Channel") -> None:
-        self._contributions.channels.append(channel)
-        self._effects.add(
-            f"channel:{getattr(channel, 'name', channel)}",
-            lambda: self._discard(channel),
+        contribute_to_list(
+            self._contributions.channels,
+            channel,
+            effects=self._effects,
+            label=f"channel:{getattr(channel, 'name', channel)}",
         )
-
-    def _discard(self, channel: "Channel") -> None:
-        if channel in self._contributions.channels:
-            self._contributions.channels.remove(channel)
 
 
 class BackgroundCapability:

--- a/apps/backend/agent/plugin_host/effects.py
+++ b/apps/backend/agent/plugin_host/effects.py
@@ -1,0 +1,61 @@
+"""可回滚副作用登记：插件的每次注册都以 effect 形式记录，卸载时逆序处置。"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+Dispose = Callable[[], Awaitable[None] | None]
+
+
+@dataclass
+class Effect:
+    """单条已登记副作用：label 用于诊断，dispose 负责撤销。"""
+
+    label: str
+    dispose: Dispose
+
+
+class EffectScope:
+    """一个插件作用域内的全部副作用；dispose_all 逆序清理并汇总错误。"""
+
+    def __init__(self, owner: str) -> None:
+        self._owner = owner
+        self._effects: list[Effect] = []
+        self._disposed = False
+
+    @property
+    def owner(self) -> str:
+        return self._owner
+
+    @property
+    def labels(self) -> list[str]:
+        """Returns registration labels in registration order, for diagnostics."""
+        return [effect.label for effect in self._effects]
+
+    def add(self, label: str, dispose: Dispose) -> None:
+        # 已处置的作用域拒绝新登记，避免泄漏无人清理的资源
+        if self._disposed:
+            raise RuntimeError(f"EffectScope({self._owner}) 已处置，拒绝登记: {label}")
+        self._effects.append(Effect(label=label, dispose=dispose))
+
+    async def dispose_all(self) -> list[Exception]:
+        """逆序执行全部 dispose；单条失败不阻断其余清理，返回收集到的错误。"""
+        errors: list[Exception] = []
+        while self._effects:
+            effect = self._effects.pop()
+            try:
+                result = effect.dispose()
+                if inspect.isawaitable(result):
+                    await result
+            except Exception as e:
+                logger.warning(
+                    "插件副作用清理失败 (%s / %s): %s", self._owner, effect.label, e
+                )
+                errors.append(e)
+        self._disposed = True
+        return errors

--- a/apps/backend/agent/plugin_host/events.py
+++ b/apps/backend/agent/plugin_host/events.py
@@ -1,0 +1,34 @@
+"""作用域事件总线：拦截订阅并登记为 effect，修复插件直接 on() 后卸载不解绑的缺陷。"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from agent.plugin_host.effects import EffectScope
+from bus.event_bus import EventBus
+
+
+class ScopedEventBus:
+    """插件视角的事件总线代理。
+
+    on/off 被拦截并登记进 EffectScope，卸载插件时统一解绑；
+    其余方法（emit/observe/fanout/enqueue 等）原样委托真实 EventBus。
+    """
+
+    def __init__(self, bus: EventBus, effects: EffectScope) -> None:
+        self._bus = bus
+        self._effects = effects
+
+    def on(self, event_type: type, handler: Any) -> None:
+        self._bus.on(event_type, handler)
+        # EventBus.off 对已移除的 handler 幂等，插件在 terminate 里自行 off 也安全
+        self._effects.add(
+            f"event:{getattr(event_type, '__name__', event_type)}",
+            lambda: self._bus.off(event_type, handler),
+        )
+
+    def off(self, event_type: type, handler: Any) -> None:
+        self._bus.off(event_type, handler)
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._bus, name)

--- a/apps/backend/agent/plugin_host/handle.py
+++ b/apps/backend/agent/plugin_host/handle.py
@@ -1,0 +1,60 @@
+"""插件句柄与生命周期状态机：内核对每个插件包的全部运行时记账。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum, auto
+from pathlib import Path
+from typing import Any
+
+from agent.plugin_host.capabilities import PluginContributions
+from agent.plugin_host.effects import EffectScope
+from agent.plugin_host.manifest import PluginManifest
+
+
+class PluginState(Enum):
+    """显式生命周期状态；失败与禁用是终态，ACTIVE 可转 UNLOADING。"""
+
+    DISCOVERED = auto()
+    DISABLED = auto()
+    LOADING = auto()
+    ACTIVE = auto()
+    UNLOADING = auto()
+    DISPOSED = auto()
+    FAILED = auto()
+
+
+@dataclass
+class PluginRecord:
+    """discover() 产出的静态描述：目录、入口与 manifest。"""
+
+    name: str
+    plugin_dir: Path
+    entry_file: Path
+    import_path: str
+    manifest: PluginManifest
+
+
+@dataclass
+class PluginHandle:
+    """单个插件的运行时记账：状态、效果作用域、贡献与实例。"""
+
+    record: PluginRecord
+    state: PluginState = PluginState.DISCOVERED
+    effects: EffectScope = field(default_factory=lambda: EffectScope("unbound"))
+    contributions: PluginContributions = field(default_factory=PluginContributions)
+    instance: Any = None
+    error: Exception | None = None
+
+    @property
+    def plugin_id(self) -> str:
+        return self.record.manifest.id
+
+    def describe(self) -> dict[str, str]:
+        """Returns a diagnostic snapshot used by logs and inspection."""
+        return {
+            "id": self.plugin_id,
+            "state": self.state.name,
+            "dir": str(self.record.plugin_dir),
+            "error": str(self.error) if self.error else "",
+        }

--- a/apps/backend/agent/plugin_host/kernel.py
+++ b/apps/backend/agent/plugin_host/kernel.py
@@ -1,0 +1,380 @@
+"""插件内核：发现、装配、生命周期与失败回滚；对宿主暴露与旧 manager 同构的聚合面。
+
+内核只拥有"插件如何被装配、启动、停止和清理"；phase 顺序、事件语义、
+工具错误路径等产品语义仍由 Shiori 核心模块定义。
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import logging
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from agent.plugin_host.capabilities import (
+    BackgroundCapability,
+    ChannelsCapability,
+    LifecycleCapability,
+    PHASE_SLOTS,
+    ProactiveGatesCapability,
+    ToolHooksCapability,
+    ToolsCapability,
+)
+from agent.plugin_host.effects import EffectScope
+from agent.plugin_host.events import ScopedEventBus
+from agent.plugin_host.handle import PluginHandle, PluginRecord, PluginState
+from agent.plugin_host.legacy import LegacyPluginError, load_legacy_plugin
+from agent.plugin_host.manifest import (
+    ManifestError,
+    load_manifest,
+    synthesize_legacy_manifest,
+)
+from agent.plugin_host.runtime_context import PluginRuntimeContext
+from bus.event_bus import EventBus
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class HostServices:
+    """宿主提供给插件装配的服务集合；capability 只暴露其中被声明的切面。"""
+
+    event_bus: EventBus
+    tool_registry: Any = None
+    workspace: Path | None = None
+    session_manager: Any = None
+    memory_engine: Any = None
+    app_config: Any = None
+    light_provider: Any = None
+    light_model: str = ""
+    plugin_configs: dict[str, dict[str, Any]] = field(default_factory=dict)
+    relationship_runtime: Any = None
+
+
+class PluginKernel:
+    """cordis 风格插件内核：作用域 effect 回滚 + capability 注入。
+
+    对 bootstrap 暴露与旧 PluginManager 相同的聚合属性（load_all、
+    loaded_count、七个 phase 列表、tool_hooks、channels、proactive_gates、
+    telegram_bot_commands、terminate_all），使宿主接线保持不变。
+    """
+
+    def __init__(
+        self,
+        plugin_dirs: list[Path],
+        *,
+        services: HostServices,
+        namespace: str = "",
+        strict: bool = False,
+    ) -> None:
+        self._dirs = plugin_dirs
+        self._services = services
+        self._namespace = namespace
+        self._strict = strict
+        self._handles: dict[str, PluginHandle] = {}
+        self._active_order: list[str] = []
+
+    # ── 发现 ──────────────────────────────────────────────────────────────
+
+    def discover(self) -> list[PluginRecord]:
+        """扫描插件目录；同名 first-wins，legacy 目录必须含 plugin.py。"""
+        records: list[PluginRecord] = []
+        seen_names: set[str] = set()
+        for d in self._dirs:
+            if not d.is_dir():
+                continue
+            source = d.name
+            for child in sorted(d.iterdir()):
+                if not child.is_dir():
+                    continue
+                if child.name in seen_names:
+                    logger.warning("插件名重复，跳过: %s (%s)", child.name, child)
+                    continue
+                record = self._build_record(child, source)
+                if record is None:
+                    continue
+                seen_names.add(child.name)
+                records.append(record)
+        return records
+
+    def _build_record(self, child: Path, source: str) -> PluginRecord | None:
+        try:
+            manifest = load_manifest(child)
+        except ManifestError as e:
+            logger.warning("插件 manifest 无效，跳过: %s (%s)", child.name, e)
+            if self._strict:
+                raise
+            return None
+        except Exception as e:
+            logger.warning("manifest.yaml 读取失败 (%s): %s", child, e)
+            manifest = None
+        if manifest is None or not manifest.is_v2:
+            # legacy 目录（含旧四字段 manifest）以 plugin.py 为准入条件
+            if not (child / "plugin.py").exists():
+                return None
+            manifest = synthesize_legacy_manifest(child)
+        entry_file = child / manifest.entry
+        suffix = f"_{self._namespace}" if self._namespace else ""
+        return PluginRecord(
+            name=child.name,
+            plugin_dir=child,
+            entry_file=entry_file,
+            import_path=f"akasic_plugin_{source}_{child.name}{suffix}",
+            manifest=manifest,
+        )
+
+    # ── 加载 ──────────────────────────────────────────────────────────────
+
+    async def load_all(self) -> None:
+        for record in self.discover():
+            await self._load_one(record)
+
+    async def load(self, name: str) -> bool:
+        """按目录名加载单个已发现插件；已激活时幂等返回 True。"""
+        for record in self.discover():
+            if record.name == name:
+                await self._load_one(record)
+                handle = self._handles.get(name)
+                return handle is not None and handle.state is PluginState.ACTIVE
+        return False
+
+    async def _load_one(self, record: PluginRecord) -> None:
+        existing = self._handles.get(record.name)
+        if existing is not None and existing.state is PluginState.ACTIVE:
+            return
+        handle = PluginHandle(record=record, effects=EffectScope(record.manifest.id))
+        self._handles[record.name] = handle
+        if (record.plugin_dir / "plugin.disabled").exists():
+            handle.state = PluginState.DISABLED
+            logger.info("插件已禁用（plugin.disabled）: %s", record.name)
+            return
+        handle.state = PluginState.LOADING
+        try:
+            self._import_entry(handle)
+            if record.manifest.is_v2:
+                await self._setup_v2(handle)
+            else:
+                scoped_bus = ScopedEventBus(self._services.event_bus, handle.effects)
+                handle.instance = await load_legacy_plugin(
+                    handle, scoped_bus=scoped_bus, deps=self._services
+                )
+        except Exception as e:
+            await self._rollback_failed_load(handle, e)
+            if self._strict:
+                raise
+            return
+        handle.state = PluginState.ACTIVE
+        self._active_order.append(record.name)
+        logger.info("插件已加载: %s", record.name)
+
+    def _import_entry(self, handle: PluginHandle) -> None:
+        record = handle.record
+        # 先登记命名空间清理（最后处置），代际热重载时不残留 sys.modules 条目
+        if self._namespace:
+            handle.effects.add(
+                "import:namespace",
+                lambda: _purge_modules(record.import_path),
+            )
+        try:
+            _import_module(record.import_path, record.entry_file)
+        except Exception as e:
+            # 导入可能已部分触发 __init_subclass__ 注册，回滚 registry
+            from agent.plugins.registry import plugin_registry
+
+            plugin_registry.remove_plugin(record.import_path)
+            raise LegacyPluginError(f"插件 {record.name} 导入失败: {e}") from e
+
+    async def _setup_v2(self, handle: PluginHandle) -> None:
+        module = sys.modules[handle.record.import_path]
+        setup = getattr(module, "setup", None)
+        if not callable(setup):
+            raise ManifestError(
+                f"v2 插件 {handle.record.name} 的入口缺少 setup(ctx) 函数"
+            )
+        context = PluginRuntimeContext(
+            plugin_id=handle.plugin_id,
+            plugin_dir=handle.record.plugin_dir,
+            manifest=handle.record.manifest,
+            effects=handle.effects,
+            capabilities=self._build_capabilities(handle),
+        )
+        await setup(context)
+
+    def _build_capabilities(self, handle: PluginHandle) -> dict[str, Any]:
+        from agent.plugins.config import PluginConfig
+        from agent.plugins.context import PluginKVStore
+
+        services = self._services
+        builders: dict[str, Any] = {
+            "events": lambda: ScopedEventBus(services.event_bus, handle.effects),
+            "kv": lambda: PluginKVStore(handle.record.plugin_dir / ".kv.json"),
+            "config": lambda: PluginConfig(
+                services.plugin_configs.get(handle.plugin_id, {})
+            ),
+            "tools": lambda: ToolsCapability(
+                services.tool_registry,
+                handle.effects,
+                handle.contributions,
+                handle.plugin_id,
+            ),
+            "lifecycle": lambda: LifecycleCapability(
+                handle.contributions, handle.effects
+            ),
+            "tool_hooks": lambda: ToolHooksCapability(
+                handle.contributions, handle.effects
+            ),
+            "proactive_gates": lambda: ProactiveGatesCapability(
+                handle.contributions, handle.effects
+            ),
+            "channels": lambda: ChannelsCapability(
+                handle.contributions, handle.effects
+            ),
+            "background": lambda: BackgroundCapability(
+                handle.effects, handle.plugin_id
+            ),
+        }
+        return {
+            name: builders[name]()
+            for name in handle.record.manifest.capabilities
+            if name in builders
+        }
+
+    async def _rollback_failed_load(
+        self, handle: PluginHandle, error: Exception
+    ) -> None:
+        logger.warning("插件 %s 加载失败，回滚: %s", handle.record.name, error)
+        _ = await handle.effects.dispose_all()
+        handle.contributions = type(handle.contributions)()
+        handle.state = PluginState.FAILED
+        handle.error = error
+
+    # ── 卸载 ──────────────────────────────────────────────────────────────
+
+    async def unload(self, name: str) -> list[Exception]:
+        """卸载单个插件：逆序处置其全部 effect，其他插件不受影响。"""
+        handle = self._handles.get(name)
+        if handle is None or handle.state is not PluginState.ACTIVE:
+            return []
+        handle.state = PluginState.UNLOADING
+        errors = await handle.effects.dispose_all()
+        handle.contributions = type(handle.contributions)()
+        handle.instance = None
+        handle.state = PluginState.DISPOSED
+        if name in self._active_order:
+            self._active_order.remove(name)
+        # 允许再次 load：丢弃已处置句柄
+        self._handles.pop(name, None)
+        return errors
+
+    async def terminate_all(self) -> None:
+        """Releases only this kernel's subscriptions, plugins and import namespace."""
+        errors: list[Exception] = []
+        for name in list(self._active_order):
+            errors.extend(await self.unload(name))
+        self._handles.clear()
+        if errors:
+            raise ExceptionGroup("Plugin cleanup failed", errors)
+
+    # ── 聚合面（与旧 PluginManager 同构，供 bootstrap 接线） ────────────────
+
+    @property
+    def loaded_count(self) -> int:
+        return len(self._active_order)
+
+    def states(self) -> list[dict[str, str]]:
+        """Returns per-plugin lifecycle snapshots for diagnostics."""
+        return [handle.describe() for handle in self._handles.values()]
+
+    def _active_handles(self) -> list[PluginHandle]:
+        return [self._handles[name] for name in self._active_order if name in self._handles]
+
+    def _collect_phase(self, slot: str) -> list[object]:
+        modules: list[object] = []
+        for handle in self._active_handles():
+            modules.extend(handle.contributions.phase_modules[slot])
+        return modules
+
+    @property
+    def before_turn_modules(self) -> list[object]:
+        return self._collect_phase("before_turn")
+
+    @property
+    def before_reasoning_modules(self) -> list[object]:
+        return self._collect_phase("before_reasoning")
+
+    @property
+    def prompt_render_modules(self) -> list[object]:
+        return self._collect_phase("prompt_render")
+
+    @property
+    def before_step_modules(self) -> list[object]:
+        return self._collect_phase("before_step")
+
+    @property
+    def after_step_modules(self) -> list[object]:
+        return self._collect_phase("after_step")
+
+    @property
+    def after_reasoning_modules(self) -> list[object]:
+        return self._collect_phase("after_reasoning")
+
+    @property
+    def after_turn_modules(self) -> list[object]:
+        return self._collect_phase("after_turn")
+
+    @property
+    def tool_hooks(self) -> list[Any]:
+        return [h for handle in self._active_handles() for h in handle.contributions.tool_hooks]
+
+    @property
+    def channels(self) -> list[Any]:
+        return [c for handle in self._active_handles() for c in handle.contributions.channels]
+
+    @property
+    def proactive_gates(self) -> list[Any]:
+        return [g for handle in self._active_handles() for g in handle.contributions.proactive_gates]
+
+    @property
+    def telegram_bot_commands(self) -> list[tuple[str, str]]:
+        commands: list[tuple[str, str]] = []
+        for handle in self._active_handles():
+            getter = getattr(handle.instance, "telegram_bot_commands", None)
+            if getter is None:
+                continue
+            for command, description in getter():
+                commands.append((str(command), str(description)))
+        return commands
+
+
+# 断言 v2/legacy 使用同一批槽位名，防止两处清单漂移
+assert set(PHASE_SLOTS) == {
+    "before_turn",
+    "before_reasoning",
+    "prompt_render",
+    "before_step",
+    "after_step",
+    "after_reasoning",
+    "after_turn",
+}
+
+
+def _import_module(module_name: str, path: Path) -> None:
+    # 把入口文件当成包加载，允许插件内部相对 import；先入 sys.modules 再执行
+    spec = importlib.util.spec_from_file_location(
+        module_name,
+        path,
+        submodule_search_locations=[str(path.parent)],
+    )
+    if spec is None or spec.loader is None:
+        raise ImportError(f"无法加载插件文件: {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    spec.loader.exec_module(module)
+
+
+def _purge_modules(import_path: str) -> None:
+    for module_name in tuple(sys.modules):
+        if module_name == import_path or module_name.startswith(import_path + "."):
+            _ = sys.modules.pop(module_name, None)

--- a/apps/backend/agent/plugin_host/kernel.py
+++ b/apps/backend/agent/plugin_host/kernel.py
@@ -9,9 +9,10 @@ from __future__ import annotations
 import importlib.util
 import logging
 import sys
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from agent.plugin_host.capabilities import (
     BackgroundCapability,
@@ -193,6 +194,9 @@ class PluginKernel:
             raise ManifestError(
                 f"v2 插件 {handle.record.name} 的入口缺少 setup(ctx) 函数"
             )
+        setup_fn = cast(
+            "Callable[[PluginRuntimeContext], Awaitable[None]]", setup
+        )
         context = PluginRuntimeContext(
             plugin_id=handle.plugin_id,
             plugin_dir=handle.record.plugin_dir,
@@ -200,7 +204,7 @@ class PluginKernel:
             effects=handle.effects,
             capabilities=self._build_capabilities(handle),
         )
-        await setup(context)
+        await setup_fn(context)
 
     def _build_capabilities(self, handle: PluginHandle) -> dict[str, Any]:
         from agent.plugins.config import PluginConfig

--- a/apps/backend/agent/plugin_host/legacy.py
+++ b/apps/backend/agent/plugin_host/legacy.py
@@ -9,7 +9,10 @@ from __future__ import annotations
 
 import functools
 import logging
-from typing import Any
+from typing import TYPE_CHECKING, Any, cast
+
+if TYPE_CHECKING:
+    from infra.channels.contract import Channel
 
 from agent.plugin_host.capabilities import (
     ChannelsCapability,
@@ -115,7 +118,7 @@ async def load_legacy_plugin(
     # 渠道在 initialize 成功后收集，保持旧语义
     channels_capability = ChannelsCapability(handle.contributions, handle.effects)
     for channel in _load_module_list(instance, "channels"):
-        channels_capability.add(channel)
+        channels_capability.add(cast("Channel", channel))
 
     handle.instance = instance
     return instance

--- a/apps/backend/agent/plugin_host/legacy.py
+++ b/apps/backend/agent/plugin_host/legacy.py
@@ -1,0 +1,202 @@
+"""legacy 适配器：让旧 Plugin ABC / 装饰器插件零改动跑在新内核上。
+
+全部注册被改道经作用域上下文登记为 effect，使卸载与失败回滚和 v2 插件同构；
+配置解析、manifest 覆盖、工具包装等行为逻辑直接复用旧 manager 的实现，
+保证迁移期行为一致（旧模块的整体删除属于收尾 ticket）。
+"""
+
+from __future__ import annotations
+
+import functools
+import logging
+from typing import Any
+
+from agent.plugin_host.capabilities import (
+    ChannelsCapability,
+    LifecycleCapability,
+    PHASE_SLOTS,
+    ProactiveGatesCapability,
+    ToolHooksCapability,
+    ToolsCapability,
+)
+from agent.plugin_host.events import ScopedEventBus
+from agent.plugin_host.handle import PluginHandle
+from agent.plugins.manager import (
+    _EVENT_TYPE_MAP,
+    _PluginConfigError,
+    _PluginToolHook,
+    _apply_manifest,
+    _load_module_list,
+    _load_plugin_config,
+    _make_execute,
+)
+from agent.plugins.registry import MetadataKind, plugin_registry
+
+logger = logging.getLogger(__name__)
+
+
+class LegacyPluginError(Exception):
+    """legacy 插件加载失败（类缺失、配置无效或 initialize 抛错）。"""
+
+
+async def load_legacy_plugin(
+    handle: PluginHandle,
+    *,
+    scoped_bus: ScopedEventBus,
+    deps: Any,
+) -> Any:
+    """执行旧 _load_one 的装配流程，注册全部改走 handle.effects。
+
+    调用方（内核）负责模块导入与失败时的 effect 处置。
+    """
+    record = handle.record
+    import_path = record.import_path
+    cls = plugin_registry._classes.get(import_path)
+    if cls is None:
+        raise LegacyPluginError(f"插件 {record.name} 未注册类")
+
+    instance = cls()
+    _apply_manifest(instance, record.plugin_dir)
+    plugin_id = str(instance.name) if instance.name else record.name
+    try:
+        plugin_config = _load_plugin_config(
+            record.plugin_dir,
+            getattr(cls, "ConfigModel", None),
+            deps.plugin_configs.get(plugin_id),
+        )
+    except _PluginConfigError as e:
+        raise LegacyPluginError(f"插件 {record.name} 配置无效: {e}") from e
+
+    # 旧 PluginContext 保持原字段，但 event_bus 换成作用域代理修复卸载不解绑缺陷
+    from agent.plugins.context import PluginContext, PluginKVStore
+
+    instance.context = PluginContext(
+        event_bus=scoped_bus,
+        tool_registry=deps.tool_registry,
+        plugin_id=plugin_id,
+        plugin_dir=record.plugin_dir,
+        kv_store=PluginKVStore(record.plugin_dir / ".kv.json"),
+        config=plugin_config,
+        app_config=deps.app_config,
+        light_provider=deps.light_provider,
+        light_model=deps.light_model,
+        workspace=deps.workspace,
+        session_manager=deps.session_manager,
+        memory_engine=deps.memory_engine,
+        relationship_runtime=deps.relationship_runtime,
+    )
+    plugin_registry.register_instance(import_path, instance)
+    handle.effects.add(
+        "registry:instance",
+        lambda: plugin_registry.remove_plugin(import_path),
+    )
+
+    _bind_lifecycle_handlers(instance, import_path, scoped_bus)
+    _register_tools(instance, handle, deps)
+    _bind_tool_hooks(instance, handle, import_path)
+    _collect_phase_modules(instance, handle)
+    _collect_proactive_gates(instance, handle)
+
+    # initialize 失败：先给插件 terminate 机会（对齐旧回滚），再交内核处置 effects
+    try:
+        await instance.initialize()
+    except Exception as e:
+        try:
+            await instance.terminate()
+        except Exception as terminate_error:
+            logger.warning(
+                "插件 %s 回滚 terminate 失败: %s", record.name, terminate_error
+            )
+        raise LegacyPluginError(f"插件 {record.name} 初始化失败: {e}") from e
+
+    # terminate 作为最后登记的 effect，卸载时最先执行（先 terminate 再解绑）
+    handle.effects.add("legacy:terminate", instance.terminate)
+
+    # 渠道在 initialize 成功后收集，保持旧语义
+    channels_capability = ChannelsCapability(handle.contributions, handle.effects)
+    for channel in _load_module_list(instance, "channels"):
+        channels_capability.add(channel)
+
+    handle.instance = instance
+    return instance
+
+
+def _bind_lifecycle_handlers(
+    instance: Any, import_path: str, scoped_bus: ScopedEventBus
+) -> None:
+    for md in plugin_registry.get_handlers_by_module_path(import_path):
+        if md.kind != MetadataKind.LIFECYCLE:
+            continue
+        ctx_type = _EVENT_TYPE_MAP.get(md.event_type)  # type: ignore[arg-type]
+        if ctx_type is None:
+            continue
+        scoped_bus.on(ctx_type, functools.partial(md.handler, instance))
+
+
+def _register_tools(instance: Any, handle: PluginHandle, deps: Any) -> None:
+    # 旧行为：宿主未提供 ToolRegistry 时静默跳过工具注册
+    if deps.tool_registry is None:
+        return
+    from agent.tools.base import Tool as AgentTool
+
+    tools_capability = ToolsCapability(
+        deps.tool_registry, handle.effects, handle.contributions, handle.plugin_id
+    )
+    for md in plugin_registry.get_handlers_by_module_path(handle.record.import_path):
+        if md.kind != MetadataKind.TOOL:
+            continue
+        bound = functools.partial(md.handler, instance, None)
+        tool_name = md.tool_name or md.handler_name
+        ToolCls = type(
+            f"PluginTool_{tool_name}",
+            (AgentTool,),
+            {
+                "name": tool_name,
+                "description": (md.handler.__doc__ or "").strip(),
+                "parameters": md.tool_schema
+                or {"type": "object", "properties": {}, "required": []},
+                "execute": _make_execute(bound),
+            },
+        )
+        tools_capability.register(
+            ToolCls(),
+            risk=md.tool_risk or "read-write",
+            always_on=bool(md.tool_always_on),
+            search_hint=md.tool_search_hint,
+        )
+        logger.info("插件工具已注册: %s (来自 %s)", tool_name, handle.plugin_id)
+
+
+def _bind_tool_hooks(instance: Any, handle: PluginHandle, import_path: str) -> None:
+    hooks_capability = ToolHooksCapability(handle.contributions, handle.effects)
+    for md in plugin_registry.get_handlers_by_module_path(import_path):
+        if md.kind != MetadataKind.TOOL_HOOK:
+            continue
+        hook = _PluginToolHook(
+            name=f"plugin:{getattr(instance, 'name', import_path)}:{md.handler_name}",
+            handler=functools.partial(md.handler, instance),
+            tool_name_filter=md.hook_tool_name,
+        )
+        hooks_capability.add(hook)
+        logger.info("插件 tool hook 已注册: %s", hook.name)
+
+
+def _collect_phase_modules(instance: Any, handle: PluginHandle) -> None:
+    lifecycle = LifecycleCapability(handle.contributions, handle.effects)
+    for slot in PHASE_SLOTS:
+        modules = _load_module_list(instance, f"{slot}_modules")
+        if modules:
+            lifecycle.contribute(slot, modules)
+
+
+def _collect_proactive_gates(instance: Any, handle: PluginHandle) -> None:
+    from agent.core.proactive_turn.gates import ProactiveGate
+
+    gates_capability = ProactiveGatesCapability(handle.contributions, handle.effects)
+    for gate in _load_module_list(instance, "proactive_gates"):
+        if not isinstance(gate, ProactiveGate):
+            raise TypeError(
+                f"插件 {type(instance).__name__}.proactive_gates 返回了无效 gate: "
+                f"{type(gate).__name__}"
+            )
+        gates_capability.add(gate)

--- a/apps/backend/agent/plugin_host/manifest.py
+++ b/apps/backend/agent/plugin_host/manifest.py
@@ -1,0 +1,114 @@
+"""插件 manifest：v2 插件必备的声明文件，legacy 插件由适配器合成隐式 manifest。"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# v1 首批 capability 名称；manifest 只能声明这里列出的能力
+KNOWN_CAPABILITIES = frozenset(
+    {
+        "tools",
+        "lifecycle",
+        "tool_hooks",
+        "proactive_gates",
+        "channels",
+        "events",
+        "kv",
+        "config",
+        "background",
+    }
+)
+
+# legacy Plugin ABC 经适配器运行时隐式获得全部能力（旧 PluginContext 语义）
+LEGACY_CAPABILITIES = tuple(sorted(KNOWN_CAPABILITIES))
+
+
+class ManifestError(Exception):
+    """manifest 缺失必填字段或声明了未知 capability。"""
+
+
+@dataclass
+class PluginManifest:
+    """插件包声明：身份、入口与所需 capability。"""
+
+    id: str
+    version: str | None = None
+    desc: str | None = None
+    author: str | None = None
+    entry: str = "plugin.py"
+    capabilities: tuple[str, ...] = ()
+    config_model: str | None = None
+    api: int = 1
+    metadata: dict[str, object] = field(default_factory=dict)
+
+    @property
+    def is_v2(self) -> bool:
+        return self.api >= 2
+
+
+def load_manifest(plugin_dir: Path) -> PluginManifest | None:
+    """读取 manifest.yaml；不存在返回 None，格式非法抛 ManifestError。
+
+    只有显式声明 ``api: 2`` 的 manifest 才按 v2 契约解析；
+    只含 name/version/desc/author 的旧四字段 manifest 保持 legacy 元信息覆盖语义。
+    """
+    manifest_path = plugin_dir / "manifest.yaml"
+    if not manifest_path.exists():
+        return None
+    import yaml
+
+    loaded = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    if not isinstance(loaded, dict):
+        raise ManifestError(f"manifest.yaml 格式错误，期望 dict: {manifest_path}")
+    raw: dict[str, object] = loaded
+    api = int(str(raw.get("api", 1)))
+    plugin_id = str(raw.get("id") or raw.get("name") or plugin_dir.name)
+    capabilities = _parse_capabilities(raw, manifest_path, required=api >= 2)
+    return PluginManifest(
+        id=plugin_id,
+        version=_optional_str(raw.get("version")),
+        desc=_optional_str(raw.get("desc")),
+        author=_optional_str(raw.get("author")),
+        entry=str(raw.get("entry") or "plugin.py"),
+        capabilities=capabilities,
+        config_model=_optional_str(raw.get("config_model")),
+        api=api,
+        metadata={k: v for k, v in raw.items() if isinstance(k, str)},
+    )
+
+
+def synthesize_legacy_manifest(plugin_dir: Path) -> PluginManifest:
+    """为无 manifest（或旧四字段 manifest）的 legacy 插件合成隐式 manifest。"""
+    return PluginManifest(
+        id=plugin_dir.name,
+        entry="plugin.py",
+        capabilities=LEGACY_CAPABILITIES,
+        api=1,
+    )
+
+
+def _parse_capabilities(
+    raw: dict[str, object], manifest_path: Path, *, required: bool
+) -> tuple[str, ...]:
+    value = raw.get("capabilities")
+    if value is None:
+        if required:
+            raise ManifestError(f"v2 manifest 缺少 capabilities 声明: {manifest_path}")
+        return LEGACY_CAPABILITIES
+    if not isinstance(value, list):
+        raise ManifestError(f"capabilities 必须是列表: {manifest_path}")
+    names = tuple(str(item) for item in value)
+    unknown = [name for name in names if name not in KNOWN_CAPABILITIES]
+    if unknown:
+        raise ManifestError(
+            f"manifest 声明了未知 capability {unknown}: {manifest_path}"
+        )
+    return names
+
+
+def _optional_str(value: object) -> str | None:
+    return None if value is None else str(value)

--- a/apps/backend/agent/plugin_host/runtime_context.py
+++ b/apps/backend/agent/plugin_host/runtime_context.py
@@ -1,0 +1,57 @@
+"""插件作用域运行时上下文：只暴露 manifest 声明的 capability，取代旧上帝对象。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+from agent.plugin_host.effects import Dispose, EffectScope
+from agent.plugin_host.manifest import PluginManifest
+
+
+class CapabilityNotGranted(AttributeError):
+    """插件访问了 manifest 未声明的 capability。"""
+
+
+class PluginRuntimeContext:
+    """v2 插件在 setup(ctx) 中拿到的唯一句柄。
+
+    通过属性访问已授予的 capability（ctx.tools / ctx.events / ctx.kv / ...）；
+    未声明的能力访问时抛 CapabilityNotGranted，而不是拿到 None。
+    """
+
+    def __init__(
+        self,
+        *,
+        plugin_id: str,
+        plugin_dir: Path,
+        manifest: PluginManifest,
+        effects: EffectScope,
+        capabilities: dict[str, Any],
+    ) -> None:
+        self.plugin_id = plugin_id
+        self.plugin_dir = plugin_dir
+        self.manifest = manifest
+        self._effects = effects
+        self._capabilities = capabilities
+
+    @property
+    def granted(self) -> tuple[str, ...]:
+        """Returns granted capability names, for diagnostics."""
+        return tuple(sorted(self._capabilities))
+
+    def effect(self, label: str, dispose: Dispose) -> None:
+        """登记插件自定义副作用（连接、文件监听等），卸载时逆序撤销。"""
+        self._effects.add(f"custom:{label}", dispose)
+
+    def __getattr__(self, name: str) -> Any:
+        try:
+            capabilities = object.__getattribute__(self, "_capabilities")
+        except AttributeError as e:  # 构造未完成时保持原始 AttributeError 语义
+            raise AttributeError(name) from e
+        if name in capabilities:
+            return capabilities[name]
+        raise CapabilityNotGranted(
+            f"插件 {self.plugin_id} 未声明 capability {name!r}；"
+            f"已授予: {', '.join(self.granted) or '无'}"
+        )

--- a/apps/backend/bootstrap/tools.py
+++ b/apps/backend/bootstrap/tools.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 from uuid import uuid4
 
 if TYPE_CHECKING:
-    from agent.plugins.manager import PluginManager
+    from agent.plugin_host import PluginKernel
 
 from agent.config_models import Config, WiringConfig
 from agent.context import ContextBuilder
@@ -94,7 +94,7 @@ class CoreRuntime:
     role_runtime_registry: RoleRuntimeRegistry
     image_sync_service: ExternalImageSyncService | None = None
     agent_provider: LLMProvider | None = None
-    plugin_manager: "PluginManager | None" = None
+    plugin_manager: "PluginKernel | None" = None
     memory_optimizer: Any | None = None
     screen_observation: ScreenObservationService | None = None
     additional_providers: list[LLMProvider] = field(default_factory=list)
@@ -503,24 +503,26 @@ def build_core_runtime(
         active_turn_states=loop.active_turn_states,
     )
 
-    from agent.plugins.manager import PluginManager as _PluginManager
+    from agent.plugin_host import HostServices, PluginKernel
     plugin_light_provider, plugin_light_model = _resolve_plugin_llm_dependencies(
         config,
         provider,
         light_provider,
     )
-    plugin_manager = _PluginManager(
+    plugin_manager = PluginKernel(
         plugin_dirs=_resolve_plugin_dirs(workspace),
-        event_bus=event_bus,
-        tool_registry=tools,
-        workspace=workspace,
-        session_manager=session_manager,
-        memory_engine=memory_runtime.engine,
-        app_config=config,
-        light_provider=plugin_light_provider,
-        light_model=plugin_light_model,
-        plugin_configs=config.plugins,
-        relationship_runtime=relationship_runtime,
+        services=HostServices(
+            event_bus=event_bus,
+            tool_registry=tools,
+            workspace=workspace,
+            session_manager=session_manager,
+            memory_engine=memory_runtime.engine,
+            app_config=config,
+            light_provider=plugin_light_provider,
+            light_model=plugin_light_model,
+            plugin_configs=config.plugins,
+            relationship_runtime=relationship_runtime,
+        ),
         namespace=uuid4().hex,
         strict=shared is not None,
     )

--- a/tests/backend/agent/plugin_host/conftest.py
+++ b/tests/backend/agent/plugin_host/conftest.py
@@ -1,0 +1,69 @@
+"""plugin_host 测试共享设施：全局 registry 清理与内核构造助手。"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+
+# 预热 agent.core 导入链，避免 agent.lifecycle.types 触发循环导入
+from agent.core.passive_turn import ContextStore as _  # noqa: F401
+from agent.lifecycle.types import BeforeTurnCtx
+from agent.plugin_host import HostServices, PluginKernel
+from agent.plugins.registry import plugin_registry
+from agent.tools.registry import ToolRegistry
+from bus.event_bus import EventBus
+
+REPOSITORY_ROOT = Path(__file__).resolve().parents[4]
+FIXTURES_DIR = REPOSITORY_ROOT / "tests" / "fixtures" / "plugins"
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    # 每个测试前后清空全局 registry，避免插件状态跨测试污染
+    import sys
+
+    modules_before = set(sys.modules)
+    plugin_registry._handlers._handlers.clear()
+    plugin_registry._classes.clear()
+    plugin_registry._instances.clear()
+    yield
+    plugin_registry._handlers._handlers.clear()
+    plugin_registry._classes.clear()
+    plugin_registry._instances.clear()
+    # 本测试期间导入的插件模块必须移除，避免污染旧 manager 测试的 sys.modules 查找
+    for name in set(sys.modules) - modules_before:
+        if name.startswith("akasic_plugin_"):
+            _ = sys.modules.pop(name, None)
+
+
+def make_kernel(
+    plugin_dirs: list[Path],
+    *,
+    event_bus: EventBus,
+    tools: ToolRegistry | None = None,
+    namespace: str = "",
+    strict: bool = False,
+) -> PluginKernel:
+    return PluginKernel(
+        plugin_dirs,
+        services=HostServices(event_bus=event_bus, tool_registry=tools),
+        namespace=namespace,
+        strict=strict,
+    )
+
+
+def before_turn_ctx(**overrides: object) -> BeforeTurnCtx:
+    defaults: dict = dict(
+        session_key="test:123",
+        channel="cli",
+        chat_id="123",
+        content="hello",
+        timestamp=datetime.now(),
+        retrieved_memory_block="",
+        retrieval_trace_raw=None,
+        history_messages=(),
+    )
+    defaults.update(overrides)
+    return BeforeTurnCtx(**defaults)

--- a/tests/backend/agent/plugin_host/test_capabilities.py
+++ b/tests/backend/agent/plugin_host/test_capabilities.py
@@ -1,0 +1,254 @@
+"""capabilities.py 行为：贡献登记、卸载移除、后台任务取消与槽位校验。"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from agent.plugin_host.capabilities import (
+    BackgroundCapability,
+    ChannelsCapability,
+    LifecycleCapability,
+    PHASE_SLOTS,
+    PluginContributions,
+    ProactiveGatesCapability,
+    ToolHooksCapability,
+    ToolsCapability,
+    contribute_to_list,
+)
+from agent.plugin_host.effects import EffectScope
+
+
+class _FakeRegistry:
+    """记录 register/unregister 调用的最小 ToolRegistry 替身。"""
+
+    def __init__(self) -> None:
+        self.registered: list[str] = []
+        self.register_kwargs: dict[str, object] = {}
+
+    def register(self, tool: object, **kwargs: object) -> None:
+        self.registered.append(str(getattr(tool, "name")))
+        self.register_kwargs = kwargs
+
+    def unregister(self, name: str) -> None:
+        if name in self.registered:
+            self.registered.remove(name)
+
+
+class _FakeTool:
+    name = "demo_tool"
+
+
+class _Named:
+    def __init__(self, name: str) -> None:
+        self.name = name
+
+
+# ── 共享 helper ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_contribute_to_list_adds_then_removes_on_dispose():
+    scope = EffectScope("demo")
+    target: list[str] = ["pre-existing"]
+    contribute_to_list(target, "added", effects=scope, label="x:added")
+
+    assert target == ["pre-existing", "added"]
+    _ = await scope.dispose_all()
+    # 只移除自己贡献的项，既有内容保留
+    assert target == ["pre-existing"]
+
+
+@pytest.mark.asyncio
+async def test_contribute_to_list_discard_is_idempotent():
+    scope = EffectScope("demo")
+    target: list[str] = []
+    contribute_to_list(target, "once", effects=scope, label="x:once")
+    target.remove("once")  # 外部已移除
+
+    # 守卫使处置不抛 ValueError
+    assert await scope.dispose_all() == []
+
+
+# ── ToolsCapability ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tools_capability_registers_with_plugin_source_and_unregisters():
+    registry = _FakeRegistry()
+    contributions = PluginContributions()
+    scope = EffectScope("demo")
+    capability = ToolsCapability(registry, scope, contributions, "demo_plugin")
+
+    capability.register(_FakeTool(), risk="destructive", always_on=True)
+
+    assert registry.registered == ["demo_tool"]
+    assert contributions.tool_names == ["demo_tool"]
+    # 工具来源必须标为插件，否则 ToolRegistry 无法归因
+    assert registry.register_kwargs["source_type"] == "plugin"
+    assert registry.register_kwargs["source_name"] == "demo_plugin"
+    assert registry.register_kwargs["risk"] == "destructive"
+    assert registry.register_kwargs["always_on"] is True
+
+    _ = await scope.dispose_all()
+    assert registry.registered == []
+    assert contributions.tool_names == []
+
+
+def test_tools_capability_without_registry_raises():
+    capability = ToolsCapability(
+        None, EffectScope("demo"), PluginContributions(), "demo_plugin"
+    )
+    with pytest.raises(RuntimeError, match="未提供 ToolRegistry"):
+        capability.register(_FakeTool())
+
+
+# ── LifecycleCapability ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_contribution_removed_on_dispose():
+    contributions = PluginContributions()
+    scope = EffectScope("demo")
+    capability = LifecycleCapability(contributions, scope)
+    first, second = object(), object()
+
+    capability.contribute("before_turn", [first, second])
+    assert contributions.phase_modules["before_turn"] == [first, second]
+
+    _ = await scope.dispose_all()
+    assert contributions.phase_modules["before_turn"] == []
+
+
+def test_lifecycle_unknown_slot_raises():
+    capability = LifecycleCapability(PluginContributions(), EffectScope("demo"))
+    with pytest.raises(ValueError, match="未知 phase 槽位"):
+        capability.contribute("after_everything", [object()])
+
+
+@pytest.mark.asyncio
+async def test_lifecycle_dispose_only_removes_own_modules():
+    contributions = PluginContributions()
+    foreign = object()
+    contributions.phase_modules["after_turn"].append(foreign)
+    scope = EffectScope("demo")
+    mine = object()
+
+    LifecycleCapability(contributions, scope).contribute("after_turn", [mine])
+    _ = await scope.dispose_all()
+
+    # 其他插件贡献的模块不能被本插件卸载带走
+    assert contributions.phase_modules["after_turn"] == [foreign]
+
+
+def test_all_phase_slots_are_contributable():
+    contributions = PluginContributions()
+    capability = LifecycleCapability(contributions, EffectScope("demo"))
+    for slot in PHASE_SLOTS:
+        capability.contribute(slot, [object()])
+    assert all(len(contributions.phase_modules[slot]) == 1 for slot in PHASE_SLOTS)
+
+
+# ── 列表型 capability ──────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_tool_hooks_capability_add_and_dispose():
+    contributions = PluginContributions()
+    scope = EffectScope("demo")
+    hook = _Named("plugin:demo:guard")
+
+    ToolHooksCapability(contributions, scope).add(hook)  # type: ignore[arg-type]
+    assert contributions.tool_hooks == [hook]
+    assert scope.labels == ["tool_hook:plugin:demo:guard"]
+
+    _ = await scope.dispose_all()
+    assert contributions.tool_hooks == []
+
+
+@pytest.mark.asyncio
+async def test_proactive_gates_capability_add_and_dispose():
+    contributions = PluginContributions()
+    scope = EffectScope("demo")
+    gate = _Named("relationship.loneliness")
+
+    ProactiveGatesCapability(contributions, scope).add(gate)  # type: ignore[arg-type]
+    assert contributions.proactive_gates == [gate]
+    assert scope.labels == ["proactive_gate:relationship.loneliness"]
+
+    _ = await scope.dispose_all()
+    assert contributions.proactive_gates == []
+
+
+@pytest.mark.asyncio
+async def test_channels_capability_add_and_dispose():
+    contributions = PluginContributions()
+    scope = EffectScope("demo")
+    channel = _Named("qq")
+
+    ChannelsCapability(contributions, scope).add(channel)  # type: ignore[arg-type]
+    assert contributions.channels == [channel]
+    assert scope.labels == ["channel:qq"]
+
+    _ = await scope.dispose_all()
+    assert contributions.channels == []
+
+
+# ── BackgroundCapability ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_background_task_cancelled_and_awaited_on_dispose():
+    scope = EffectScope("demo")
+    started = asyncio.Event()
+    cleaned: list[str] = []
+
+    async def worker() -> None:
+        started.set()
+        try:
+            await asyncio.sleep(30)
+        except asyncio.CancelledError:
+            cleaned.append("cancelled")
+            raise
+
+    task = BackgroundCapability(scope, "demo_plugin").spawn(worker(), name="worker")
+    await started.wait()
+    assert not task.done()
+    assert task.get_name() == "plugin:demo_plugin:worker"
+
+    _ = await scope.dispose_all()
+    # dispose 必须等到任务真正退出，而不是只发出取消
+    assert task.done()
+    assert cleaned == ["cancelled"]
+
+
+@pytest.mark.asyncio
+async def test_background_dispose_of_finished_task_is_noop():
+    scope = EffectScope("demo")
+
+    async def quick() -> None:
+        return None
+
+    task = BackgroundCapability(scope, "demo_plugin").spawn(quick(), name="quick")
+    await task
+
+    assert await scope.dispose_all() == []
+    assert not task.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_background_task_failure_does_not_break_dispose():
+    scope = EffectScope("demo")
+    failed = asyncio.Event()
+
+    async def boom() -> None:
+        failed.set()
+        raise RuntimeError("worker exploded")
+
+    _ = BackgroundCapability(scope, "demo_plugin").spawn(boom(), name="boom")
+    await failed.wait()
+    await asyncio.sleep(0)
+
+    # 后台任务自身异常不得让插件卸载失败
+    assert await scope.dispose_all() == []

--- a/tests/backend/agent/plugin_host/test_effects.py
+++ b/tests/backend/agent/plugin_host/test_effects.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+import pytest
+
+from agent.plugin_host.effects import EffectScope
+
+
+@pytest.mark.asyncio
+async def test_dispose_all_runs_in_reverse_order():
+    scope = EffectScope("demo")
+    order: list[str] = []
+    scope.add("a", lambda: order.append("a"))
+    scope.add("b", lambda: order.append("b"))
+
+    async def dispose_c():
+        order.append("c")
+
+    scope.add("c", dispose_c)
+
+    errors = await scope.dispose_all()
+    assert errors == []
+    assert order == ["c", "b", "a"]
+
+
+@pytest.mark.asyncio
+async def test_dispose_error_collected_without_blocking_rest():
+    scope = EffectScope("demo")
+    order: list[str] = []
+    scope.add("ok-first", lambda: order.append("first"))
+
+    def broken():
+        raise RuntimeError("cleanup boom")
+
+    scope.add("broken", broken)
+    scope.add("ok-last", lambda: order.append("last"))
+
+    errors = await scope.dispose_all()
+    assert [str(e) for e in errors] == ["cleanup boom"]
+    # 失败不阻断其余清理，逆序继续
+    assert order == ["last", "first"]
+
+
+@pytest.mark.asyncio
+async def test_add_after_dispose_rejected():
+    scope = EffectScope("demo")
+    await scope.dispose_all()
+    with pytest.raises(RuntimeError, match="已处置"):
+        scope.add("late", lambda: None)
+
+
+@pytest.mark.asyncio
+async def test_labels_report_registration_order():
+    scope = EffectScope("demo")
+    scope.add("one", lambda: None)
+    scope.add("two", lambda: None)
+    assert scope.labels == ["one", "two"]

--- a/tests/backend/agent/plugin_host/test_events.py
+++ b/tests/backend/agent/plugin_host/test_events.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+
+from agent.plugin_host.effects import EffectScope
+from agent.plugin_host.events import ScopedEventBus
+from bus.event_bus import EventBus
+
+
+@dataclass
+class _DemoEvent:
+    value: str = ""
+
+
+@pytest.mark.asyncio
+async def test_scoped_on_is_unbound_by_dispose():
+    bus = EventBus()
+    scope = EffectScope("demo")
+    scoped = ScopedEventBus(bus, scope)
+    seen: list[str] = []
+
+    async def handler(event: _DemoEvent) -> None:
+        seen.append(event.value)
+
+    scoped.on(_DemoEvent, handler)
+    await bus.fanout(_DemoEvent(value="before"))
+    assert seen == ["before"]
+
+    await scope.dispose_all()
+    await bus.fanout(_DemoEvent(value="after"))
+    assert seen == ["before"]
+
+
+@pytest.mark.asyncio
+async def test_manual_off_then_dispose_is_safe():
+    bus = EventBus()
+    scope = EffectScope("demo")
+    scoped = ScopedEventBus(bus, scope)
+
+    async def handler(event: _DemoEvent) -> None:
+        raise AssertionError("should not fire")
+
+    scoped.on(_DemoEvent, handler)
+    scoped.off(_DemoEvent, handler)
+    await bus.fanout(_DemoEvent())
+    # 插件自行 off 后，dispose 再次 off 不应报错
+    assert await scope.dispose_all() == []
+
+
+@pytest.mark.asyncio
+async def test_non_subscription_methods_delegate_to_real_bus():
+    bus = EventBus()
+    scoped = ScopedEventBus(bus, EffectScope("demo"))
+    seen: list[str] = []
+
+    bus.on(_DemoEvent, lambda event: seen.append(event.value))
+    # emit 等方法直接委托底层总线
+    _ = await scoped.emit(_DemoEvent(value="delegated"))
+    assert seen == ["delegated"]

--- a/tests/backend/agent/plugin_host/test_handle.py
+++ b/tests/backend/agent/plugin_host/test_handle.py
@@ -1,0 +1,141 @@
+"""handle.py 行为：插件句柄记账与生命周期状态迁移（含失败与禁用路径）。"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from agent.plugin_host.handle import (
+    PluginHandle,
+    PluginRecord,
+    PluginState,
+)
+from agent.plugin_host.manifest import PluginManifest
+from bus.event_bus import EventBus
+
+from tests.backend.agent.plugin_host.conftest import FIXTURES_DIR, make_kernel
+
+
+def _make_handle(plugin_id: str = "demo") -> PluginHandle:
+    record = PluginRecord(
+        name=plugin_id,
+        plugin_dir=Path("plugins") / plugin_id,
+        entry_file=Path("plugins") / plugin_id / "plugin.py",
+        import_path=f"akasic_plugin_plugins_{plugin_id}",
+        manifest=PluginManifest(id=plugin_id),
+    )
+    return PluginHandle(record=record)
+
+
+def test_new_handle_starts_discovered_with_empty_contributions():
+    handle = _make_handle()
+    assert handle.state is PluginState.DISCOVERED
+    assert handle.instance is None
+    assert handle.error is None
+    assert handle.contributions.tool_hooks == []
+    assert handle.contributions.phase_modules["before_turn"] == []
+
+
+def test_plugin_id_comes_from_manifest_not_directory_name():
+    record = PluginRecord(
+        name="dir_name",
+        plugin_dir=Path("plugins/dir_name"),
+        entry_file=Path("plugins/dir_name/plugin.py"),
+        import_path="akasic_plugin_plugins_dir_name",
+        manifest=PluginManifest(id="manifest_id"),
+    )
+    assert PluginHandle(record=record).plugin_id == "manifest_id"
+
+
+def test_describe_reports_state_and_error():
+    handle = _make_handle()
+    handle.state = PluginState.FAILED
+    handle.error = RuntimeError("init boom")
+
+    described = handle.describe()
+    assert described["id"] == "demo"
+    assert described["state"] == "FAILED"
+    assert described["error"] == "init boom"
+
+
+def test_describe_leaves_error_blank_when_healthy():
+    handle = _make_handle()
+    handle.state = PluginState.ACTIVE
+    assert handle.describe()["error"] == ""
+
+
+def test_handles_do_not_share_contribution_state():
+    """default_factory 必须为每个句柄新建贡献容器，否则插件间会互相污染。"""
+    first, second = _make_handle("a"), _make_handle("b")
+    first.contributions.tool_names.append("tool_from_a")
+    assert second.contributions.tool_names == []
+    assert first.effects is not second.effects
+
+
+# ── 经内核观察到的真实状态迁移 ─────────────────────────────────────────────
+
+
+def _state_of(kernel: object, name: str) -> str:
+    states = {item["id"]: item["state"] for item in kernel.states()}  # type: ignore[attr-defined]
+    return states[name]
+
+
+@pytest.mark.asyncio
+async def test_successful_load_reaches_active(tmp_path: Path):
+    shutil.copytree(FIXTURES_DIR / "hello", tmp_path / "hello")
+    kernel = make_kernel([tmp_path], event_bus=EventBus())
+    await kernel.load_all()
+    assert _state_of(kernel, "hello") == PluginState.ACTIVE.name
+
+
+@pytest.mark.asyncio
+async def test_init_failure_reaches_failed_and_records_error(tmp_path: Path):
+    plugin_dir = tmp_path / "broken"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class Broken(Plugin):\n"
+        "    name = 'broken'\n"
+        "    async def initialize(self):\n"
+        "        raise RuntimeError('init boom')\n",
+        encoding="utf-8",
+    )
+    kernel = make_kernel([tmp_path], event_bus=EventBus())
+    await kernel.load_all()
+
+    states = {item["id"]: item for item in kernel.states()}
+    assert states["broken"]["state"] == PluginState.FAILED.name
+    # 失败原因必须落到句柄上，否则诊断只剩日志
+    assert "init boom" in states["broken"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_disabled_marker_reaches_disabled_state(tmp_path: Path):
+    shutil.copytree(FIXTURES_DIR / "hello", tmp_path / "hello")
+    (tmp_path / "hello" / "plugin.disabled").write_text("", encoding="utf-8")
+    kernel = make_kernel([tmp_path], event_bus=EventBus())
+    await kernel.load_all()
+
+    assert _state_of(kernel, "hello") == PluginState.DISABLED.name
+    assert kernel.loaded_count == 0
+
+
+@pytest.mark.asyncio
+async def test_unload_discards_handle_so_plugin_can_reload(tmp_path: Path):
+    shutil.copytree(FIXTURES_DIR / "hello", tmp_path / "hello")
+    kernel = make_kernel([tmp_path], event_bus=EventBus())
+    await kernel.load_all()
+
+    _ = await kernel.unload("hello")
+    assert kernel.states() == []
+
+    assert await kernel.load("hello") is True
+    assert _state_of(kernel, "hello") == PluginState.ACTIVE.name
+
+
+@pytest.mark.asyncio
+async def test_unload_of_unknown_plugin_is_noop(tmp_path: Path):
+    kernel = make_kernel([tmp_path], event_bus=EventBus())
+    assert await kernel.unload("never_loaded") == []

--- a/tests/backend/agent/plugin_host/test_kernel.py
+++ b/tests/backend/agent/plugin_host/test_kernel.py
@@ -1,0 +1,227 @@
+"""内核行为：发现、v2 装配、capability 门控、启停与聚合面。"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from agent.plugin_host import PluginState
+from agent.tools.registry import ToolRegistry
+from bus.event_bus import EventBus
+
+from tests.backend.agent.plugin_host.conftest import (
+    FIXTURES_DIR,
+    before_turn_ctx,
+    make_kernel,
+)
+
+_V2_PLUGIN = """
+from agent.lifecycle.types import BeforeTurnCtx
+
+seen: list[str] = []
+
+
+class StampModule:
+    async def run(self, frame):
+        return frame
+
+
+async def setup(ctx):
+    ctx.events.on(BeforeTurnCtx, _on_turn)
+    ctx.lifecycle.contribute("before_turn", [StampModule()])
+    ctx.kv.set("booted", True)
+
+
+async def _on_turn(event):
+    seen.append(event.session_key)
+    return event
+""".strip()
+
+_V2_MANIFEST = (
+    "api: 2\nid: v2demo\nversion: '0.1'\n"
+    "capabilities:\n  - events\n  - lifecycle\n  - kv\n"
+)
+
+
+def _write_v2_plugin(root: Path) -> Path:
+    plugin_dir = root / "v2demo"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(_V2_PLUGIN, encoding="utf-8")
+    (plugin_dir / "manifest.yaml").write_text(_V2_MANIFEST, encoding="utf-8")
+    return plugin_dir
+
+
+@pytest.mark.asyncio
+async def test_v2_plugin_setup_and_unload(tmp_path: Path):
+    plugin_dir = _write_v2_plugin(tmp_path)
+    bus = EventBus()
+    kernel = make_kernel([tmp_path], event_bus=bus)
+    await kernel.load_all()
+
+    assert kernel.loaded_count == 1
+    assert [m.__class__.__name__ for m in kernel.before_turn_modules] == ["StampModule"]
+    assert (plugin_dir / ".kv.json").exists()
+
+    import sys
+
+    module = next(
+        m for k, m in sys.modules.items()
+        if k.startswith("akasic_plugin_") and k.endswith("_v2demo")
+    )
+    _ = await bus.emit(before_turn_ctx(session_key="test:v2"))
+    assert module.seen == ["test:v2"]
+
+    _ = await kernel.unload("v2demo")
+    assert kernel.before_turn_modules == []
+    _ = await bus.emit(before_turn_ctx(session_key="test:gone"))
+    assert module.seen == ["test:v2"]
+
+
+@pytest.mark.asyncio
+async def test_v2_capability_gating(tmp_path: Path):
+    plugin_dir = tmp_path / "gated"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(
+        """
+captured: dict = {}
+
+
+async def setup(ctx):
+    captured["granted"] = ctx.granted
+    try:
+        _ = ctx.tools
+    except AttributeError as e:
+        captured["denied"] = str(e)
+""".strip(),
+        encoding="utf-8",
+    )
+    (plugin_dir / "manifest.yaml").write_text(
+        "api: 2\nid: gated\ncapabilities:\n  - events\n",
+        encoding="utf-8",
+    )
+    kernel = make_kernel([tmp_path], event_bus=EventBus())
+    await kernel.load_all()
+
+    import sys
+
+    module = next(
+        m for k, m in sys.modules.items()
+        if k.startswith("akasic_plugin_") and k.endswith("_gated")
+    )
+    assert module.captured["granted"] == ("events",)
+    assert "未声明 capability" in module.captured["denied"]
+
+
+@pytest.mark.asyncio
+async def test_v2_setup_failure_rolls_back_effects(tmp_path: Path):
+    plugin_dir = tmp_path / "v2broken"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(
+        """
+from agent.lifecycle.types import BeforeTurnCtx
+
+
+async def setup(ctx):
+    ctx.events.on(BeforeTurnCtx, _on_turn)
+    raise RuntimeError("v2 boom")
+
+
+async def _on_turn(event):
+    event.extra_metadata["v2broken_touched"] = True
+    return event
+""".strip(),
+        encoding="utf-8",
+    )
+    (plugin_dir / "manifest.yaml").write_text(
+        "api: 2\nid: v2broken\ncapabilities:\n  - events\n",
+        encoding="utf-8",
+    )
+    bus = EventBus()
+    kernel = make_kernel([tmp_path], event_bus=bus)
+    await kernel.load_all()
+
+    assert kernel.loaded_count == 0
+    result = await bus.emit(before_turn_ctx())
+    assert "v2broken_touched" not in result.extra_metadata
+
+
+@pytest.mark.asyncio
+async def test_disabled_marker_skips_plugin(tmp_path: Path):
+    shutil.copytree(FIXTURES_DIR / "hello", tmp_path / "hello")
+    (tmp_path / "hello" / "plugin.disabled").write_text("", encoding="utf-8")
+    kernel = make_kernel([tmp_path], event_bus=EventBus())
+    await kernel.load_all()
+
+    assert kernel.loaded_count == 0
+    assert any(item["state"] == PluginState.DISABLED.name for item in kernel.states())
+
+
+@pytest.mark.asyncio
+async def test_duplicate_plugin_name_first_wins(tmp_path: Path):
+    kernel = make_kernel([FIXTURES_DIR, FIXTURES_DIR], event_bus=EventBus())
+    records = kernel.discover()
+    assert len({r.name for r in records}) == len(records)
+
+
+@pytest.mark.asyncio
+async def test_runtime_disable_then_enable(tmp_path: Path):
+    shutil.copytree(FIXTURES_DIR / "hello", tmp_path / "hello")
+    bus = EventBus()
+    kernel = make_kernel([tmp_path], event_bus=bus)
+    await kernel.load_all()
+    assert kernel.loaded_count == 1
+
+    _ = await kernel.unload("hello")
+    assert kernel.loaded_count == 0
+    result = await bus.emit(before_turn_ctx())
+    assert "hello_touched" not in result.extra_metadata
+
+    # 重新启用后行为恢复
+    assert await kernel.load("hello") is True
+    assert kernel.loaded_count == 1
+    result = await bus.emit(before_turn_ctx())
+    assert result.extra_metadata.get("hello_touched") is True
+
+
+@pytest.mark.asyncio
+async def test_load_all_is_idempotent(tmp_path: Path):
+    shutil.copytree(FIXTURES_DIR / "hello", tmp_path / "hello")
+    bus = EventBus()
+    kernel = make_kernel([tmp_path], event_bus=bus)
+    await kernel.load_all()
+    await kernel.load_all()
+
+    assert kernel.loaded_count == 1
+    result = await bus.emit(before_turn_ctx())
+    # 重复 load_all 不得重复绑定 handler（否则 metadata 被写两次也看不出，改用计数）
+    assert result.extra_metadata.get("hello_touched") is True
+
+
+@pytest.mark.asyncio
+async def test_telegram_bot_commands_aggregated(tmp_path: Path):
+    plugin_dir = tmp_path / "cmds"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class Cmds(Plugin):\n"
+        "    name = 'cmds'\n"
+        "    def telegram_bot_commands(self):\n"
+        "        return [('undo', '撤销上一轮')]\n",
+        encoding="utf-8",
+    )
+    kernel = make_kernel([tmp_path], event_bus=EventBus())
+    await kernel.load_all()
+    assert kernel.telegram_bot_commands == [("undo", "撤销上一轮")]
+
+
+@pytest.mark.asyncio
+async def test_weather_tool_via_facade(tmp_path: Path):
+    shutil.copytree(FIXTURES_DIR / "weather", tmp_path / "weather")
+    tools = ToolRegistry()
+    kernel = make_kernel([tmp_path], event_bus=EventBus(), tools=tools)
+    await kernel.load_all()
+    assert tools.get_tool("get_weather") is not None
+    await kernel.terminate_all()
+    assert tools.get_tool("get_weather") is None

--- a/tests/backend/agent/plugin_host/test_legacy.py
+++ b/tests/backend/agent/plugin_host/test_legacy.py
@@ -1,0 +1,194 @@
+"""legacy 适配器行为：旧 Plugin ABC 插件零改动跑在内核上，卸载全量回收。"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from bus.event_bus import EventBus
+from agent.tools.registry import ToolRegistry
+
+from tests.backend.agent.plugin_host.conftest import (
+    FIXTURES_DIR,
+    before_turn_ctx,
+    make_kernel,
+)
+
+
+@pytest.mark.asyncio
+async def test_legacy_decorator_handler_fires_and_unbinds_on_unload(tmp_path: Path):
+    shutil.copytree(FIXTURES_DIR / "hello", tmp_path / "hello")
+    bus = EventBus()
+    kernel = make_kernel([tmp_path], event_bus=bus)
+    await kernel.load_all()
+    assert kernel.loaded_count == 1
+
+    result = await bus.emit(before_turn_ctx())
+    assert result.extra_metadata.get("hello_touched") is True
+
+    _ = await kernel.unload("hello")
+    result_after = await bus.emit(before_turn_ctx())
+    assert "hello_touched" not in result_after.extra_metadata
+
+
+@pytest.mark.asyncio
+async def test_direct_event_bus_subscription_unbound_on_unload(tmp_path: Path):
+    """修复既有缺陷：插件在 initialize 里直接 event_bus.on 且不自行 off。"""
+    plugin_dir = tmp_path / "direct_sub"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(
+        """
+from agent.lifecycle.types import BeforeTurnCtx
+from agent.plugins import Plugin
+
+calls: list[str] = []
+
+
+class DirectSub(Plugin):
+    name = "direct_sub"
+
+    async def initialize(self):
+        # 直接订阅且从不 off —— 旧 PluginManager 卸载后会残留
+        self.context.event_bus.on(BeforeTurnCtx, self._on_turn)
+
+    async def _on_turn(self, event):
+        calls.append(event.session_key)
+        return event
+""".strip(),
+        encoding="utf-8",
+    )
+    bus = EventBus()
+    kernel = make_kernel([tmp_path], event_bus=bus)
+    await kernel.load_all()
+
+    import sys
+
+    module = next(
+        m for k, m in sys.modules.items()
+        if k.startswith("akasic_plugin_") and k.endswith("_direct_sub")
+    )
+    _ = await bus.emit(before_turn_ctx(session_key="test:live"))
+    assert module.calls == ["test:live"]
+
+    _ = await kernel.unload("direct_sub")
+    _ = await bus.emit(before_turn_ctx(session_key="test:stale"))
+    assert module.calls == ["test:live"]
+
+
+@pytest.mark.asyncio
+async def test_legacy_tool_registered_then_unregistered(tmp_path: Path):
+    shutil.copytree(FIXTURES_DIR / "weather", tmp_path / "weather")
+    bus = EventBus()
+    tools = ToolRegistry()
+    kernel = make_kernel([tmp_path], event_bus=bus, tools=tools)
+    await kernel.load_all()
+
+    result = await tools.execute("get_weather", {"city": "巴黎"})
+    assert "巴黎" in str(result)
+
+    _ = await kernel.unload("weather")
+    assert tools.get_tool("get_weather") is None
+
+
+@pytest.mark.asyncio
+async def test_init_failure_rolls_back_only_failed_plugin(tmp_path: Path):
+    shutil.copytree(FIXTURES_DIR / "hello", tmp_path / "hello")
+    broken_dir = tmp_path / "zbroken"
+    broken_dir.mkdir()
+    (broken_dir / "plugin.py").write_text(
+        """
+from agent.lifecycle.types import BeforeTurnCtx
+from agent.plugins import Plugin, tool
+
+
+class Broken(Plugin):
+    name = "zbroken"
+
+    @tool("broken_tool")
+    async def broken_tool(self, event, city: str = ""):
+        return "never"
+
+    async def initialize(self):
+        self.context.event_bus.on(BeforeTurnCtx, self._on_turn)
+        raise RuntimeError("init boom")
+
+    async def _on_turn(self, event):
+        event.extra_metadata["broken_touched"] = True
+        return event
+""".strip(),
+        encoding="utf-8",
+    )
+    bus = EventBus()
+    tools = ToolRegistry()
+    kernel = make_kernel([tmp_path], event_bus=bus, tools=tools)
+    await kernel.load_all()
+
+    # 失败插件的工具与订阅全部回滚，健康插件不受影响
+    assert kernel.loaded_count == 1
+    assert tools.get_tool("broken_tool") is None
+    result = await bus.emit(before_turn_ctx())
+    assert result.extra_metadata.get("hello_touched") is True
+    assert "broken_touched" not in result.extra_metadata
+
+
+@pytest.mark.asyncio
+async def test_strict_mode_raises_on_init_failure(tmp_path: Path):
+    broken_dir = tmp_path / "broken"
+    broken_dir.mkdir()
+    (broken_dir / "plugin.py").write_text(
+        "from agent.plugins import Plugin\n"
+        "class Broken(Plugin):\n"
+        "    name = 'broken'\n"
+        "    async def initialize(self):\n"
+        "        raise RuntimeError('candidate failure')\n",
+        encoding="utf-8",
+    )
+    kernel = make_kernel([tmp_path], event_bus=EventBus(), namespace="candidate", strict=True)
+    with pytest.raises(Exception, match="candidate failure"):
+        await kernel.load_all()
+    assert kernel.loaded_count == 0
+
+
+@pytest.mark.asyncio
+async def test_terminate_runs_before_unbind(tmp_path: Path):
+    """terminate 中插件自行 off 自己的订阅（scene_awareness 模式）不应报错。"""
+    plugin_dir = tmp_path / "self_off"
+    plugin_dir.mkdir()
+    (plugin_dir / "plugin.py").write_text(
+        """
+from agent.lifecycle.types import BeforeTurnCtx
+from agent.plugins import Plugin
+
+terminated: list[bool] = []
+
+
+class SelfOff(Plugin):
+    name = "self_off"
+
+    async def initialize(self):
+        self._handler = self._on_turn
+        self.context.event_bus.on(BeforeTurnCtx, self._handler)
+
+    async def terminate(self):
+        self.context.event_bus.off(BeforeTurnCtx, self._handler)
+        terminated.append(True)
+
+    async def _on_turn(self, event):
+        return event
+""".strip(),
+        encoding="utf-8",
+    )
+    bus = EventBus()
+    kernel = make_kernel([tmp_path], event_bus=bus)
+    await kernel.load_all()
+
+    import sys
+
+    module = next(
+        m for k, m in sys.modules.items()
+        if k.startswith("akasic_plugin_") and k.endswith("_self_off")
+    )
+    await kernel.terminate_all()
+    assert module.terminated == [True]

--- a/tests/backend/agent/plugin_host/test_manifest.py
+++ b/tests/backend/agent/plugin_host/test_manifest.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.plugin_host.manifest import (
+    LEGACY_CAPABILITIES,
+    ManifestError,
+    load_manifest,
+    synthesize_legacy_manifest,
+)
+
+
+def test_missing_manifest_returns_none(tmp_path: Path):
+    assert load_manifest(tmp_path) is None
+
+
+def test_legacy_four_field_manifest_keeps_api_one(tmp_path: Path):
+    (tmp_path / "manifest.yaml").write_text(
+        "name: qq_bot\nversion: '1.0'\ndesc: 渠道\nauthor: tester\n",
+        encoding="utf-8",
+    )
+    manifest = load_manifest(tmp_path)
+    assert manifest is not None
+    assert not manifest.is_v2
+    assert manifest.id == "qq_bot"
+    # 旧 manifest 未声明 capabilities 时保持 legacy 全量能力
+    assert manifest.capabilities == LEGACY_CAPABILITIES
+
+
+def test_v2_manifest_parses_capabilities(tmp_path: Path):
+    (tmp_path / "manifest.yaml").write_text(
+        "api: 2\nid: demo\nversion: '0.1'\nentry: main.py\n"
+        "capabilities:\n  - events\n  - kv\n",
+        encoding="utf-8",
+    )
+    manifest = load_manifest(tmp_path)
+    assert manifest is not None
+    assert manifest.is_v2
+    assert manifest.entry == "main.py"
+    assert manifest.capabilities == ("events", "kv")
+
+
+def test_v2_manifest_requires_capabilities(tmp_path: Path):
+    (tmp_path / "manifest.yaml").write_text("api: 2\nid: demo\n", encoding="utf-8")
+    with pytest.raises(ManifestError, match="capabilities"):
+        _ = load_manifest(tmp_path)
+
+
+def test_unknown_capability_rejected(tmp_path: Path):
+    (tmp_path / "manifest.yaml").write_text(
+        "api: 2\nid: demo\ncapabilities:\n  - warp_drive\n",
+        encoding="utf-8",
+    )
+    with pytest.raises(ManifestError, match="warp_drive"):
+        _ = load_manifest(tmp_path)
+
+
+def test_synthesized_legacy_manifest_grants_all(tmp_path: Path):
+    manifest = synthesize_legacy_manifest(tmp_path / "hello")
+    assert manifest.id == "hello"
+    assert not manifest.is_v2
+    assert manifest.capabilities == LEGACY_CAPABILITIES

--- a/tests/backend/agent/plugin_host/test_runtime_context.py
+++ b/tests/backend/agent/plugin_host/test_runtime_context.py
@@ -1,0 +1,92 @@
+"""runtime_context.py 行为：capability 授予门控与自定义 effect 登记。"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.plugin_host.effects import EffectScope
+from agent.plugin_host.manifest import PluginManifest
+from agent.plugin_host.runtime_context import (
+    CapabilityNotGranted,
+    PluginRuntimeContext,
+)
+
+
+def _make_context(
+    capabilities: dict[str, object], *, effects: EffectScope | None = None
+) -> PluginRuntimeContext:
+    scope = effects or EffectScope("demo")
+    return PluginRuntimeContext(
+        plugin_id="demo",
+        plugin_dir=Path("plugins/demo"),
+        manifest=PluginManifest(id="demo", capabilities=tuple(capabilities)),
+        effects=scope,
+        capabilities=capabilities,
+    )
+
+
+def test_granted_capability_is_accessible():
+    sentinel = object()
+    context = _make_context({"events": sentinel})
+    # 属性访问必须拿到宿主注入的同一实例，而不是替身
+    assert context.events is sentinel
+
+
+def test_ungranted_capability_raises_with_diagnostic():
+    context = _make_context({"events": object()})
+    with pytest.raises(CapabilityNotGranted) as excinfo:
+        _ = context.tools
+    message = str(excinfo.value)
+    assert "tools" in message
+    assert "demo" in message
+    # 诊断信息要列出已授予能力，便于插件作者修 manifest
+    assert "events" in message
+
+
+def test_capability_not_granted_is_attribute_error():
+    """getattr 默认值等惯用法依赖 AttributeError 子类语义。"""
+    context = _make_context({})
+    assert issubclass(CapabilityNotGranted, AttributeError)
+    assert getattr(context, "tools", "fallback") == "fallback"
+
+
+def test_granted_reports_sorted_capability_names():
+    context = _make_context({"kv": object(), "events": object()})
+    assert context.granted == ("events", "kv")
+
+
+def test_identity_fields_exposed():
+    context = _make_context({})
+    assert context.plugin_id == "demo"
+    assert context.plugin_dir == Path("plugins/demo")
+    assert context.manifest.id == "demo"
+
+
+@pytest.mark.asyncio
+async def test_effect_registration_disposed_with_scope():
+    scope = EffectScope("demo")
+    context = _make_context({}, effects=scope)
+    closed: list[str] = []
+
+    context.effect("connection", lambda: closed.append("closed"))
+    assert closed == []
+    assert scope.labels == ["custom:connection"]
+
+    _ = await scope.dispose_all()
+    assert closed == ["closed"]
+
+
+@pytest.mark.asyncio
+async def test_async_effect_is_awaited():
+    scope = EffectScope("demo")
+    context = _make_context({}, effects=scope)
+    closed: list[str] = []
+
+    async def close() -> None:
+        closed.append("async-closed")
+
+    context.effect("async-connection", close)
+    _ = await scope.dispose_all()
+    assert closed == ["async-closed"]


### PR DESCRIPTION
## 概述

Ticket #176（Part of #174）：建立 cordis 风格插件内核 `agent/plugin_host/`，以作用域上下文 + effect 式可回滚副作用 + capability 注入替代 `PluginManager`/`PluginContext` 的装配职责；旧 `Plugin` ABC 经适配器零改动运行。

## 改动

- 新增 `apps/backend/agent/plugin_host/`（9 文件，约 912 行）：
  - `effects.py`：EffectScope，LIFO 处置与错误收集
  - `events.py`：ScopedEventBus 代理——直接 `event_bus.on(...)` 订阅在卸载时全部解绑（修复已知不解绑缺陷）
  - `manifest.py`：manifest v2（`api: 2`，entry/capabilities/config_model）+ 旧插件隐式 manifest 合成
  - `capabilities.py` / `runtime_context.py`：tools / lifecycle / tool_hooks / proactive_gates / channels / background 等 capability；未声明访问抛 `CapabilityNotGranted`（旧插件隐式全量授权）
  - `handle.py`：生命周期状态机 DISCOVERED→LOADING→ACTIVE→UNLOADING→DISPOSED/FAILED/DISABLED；LOADING 失败按逆序回滚仅该插件资源
  - `kernel.py`：PluginKernel，对外 facade 与旧 PluginManager 一致
  - `legacy.py`：旧 ABC/装饰器适配器（过渡期复用旧 manager 私有帮助函数保证行为一致，#184 收尾移除）
- `bootstrap/tools.py`（+16/−14）：构造 PluginKernel 取代 PluginManager；`app.py`/`reload.py`/`inspection.py` 等消费方接线不变
- 新增 `tests/backend/agent/plugin_host/` 28 个内核行为测试

## 验证

- `pytest tests/backend/agent/plugin_host tests/backend/agent/plugins tests/backend/plugins tests/backend/bootstrap -q` → **376 passed**（父会话独立复跑确认）
- 17 个存量插件文件零改动；内核 smoke 对真实 `apps/backend/plugins` 加载 16/17 ACTIVE，novelai 因环境缺共享 HTTP 资源初始化失败并干净回滚——与旧 PluginManager 同 harness 下逐字节一致（16/17），为环境性 parity 非回归
- `--inspect-modules` smoke：phase 拓扑含插件模块正常渲染
- `ruff check` 改动路径干净
- 关键测试：`test_direct_event_bus_subscription_unbound_on_unload`（旧系统下按设计失败）、`test_init_failure_rolls_back_only_failed_plugin`、`test_runtime_disable_then_enable`

## 关联

- Spec：#174
- Closes #176
