### PR TITLE
fix(desktop): 修复 Select 焦点边框与光圈颜色

### DIFF
--- a/apps/desktop/renderer/src/shared/ui/Select.tsx
+++ b/apps/desktop/renderer/src/shared/ui/Select.tsx
@@ -42,7 +42,7 @@ export function Select({ value, options, onValueChange, disabled, id, name, clas
         {...aria}
         className={cx(
           className ?? inputClass,
-          "flex min-w-0 items-center justify-between gap-2 text-left transition focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary disabled:cursor-default disabled:opacity-50",
+          "flex min-w-0 items-center justify-between gap-2 text-left transition disabled:cursor-default disabled:opacity-50",
         )}
       >
         <SelectPrimitive.Value className="min-h-[1lh] min-w-0 truncate" />

--- a/apps/desktop/renderer/src/styles.css
+++ b/apps/desktop/renderer/src/styles.css
@@ -203,7 +203,8 @@
      (e.g. the chat composer's ring-0) can still opt out via utilities. */
   input:where(:focus),
   textarea:where(:focus),
-  select:where(:focus) {
+  select:where(:focus),
+  button:where([role="combobox"]:focus) {
     outline: none;
     border-color: var(--color-border-accent);
     box-shadow: 0 0 0 1px var(--color-ring-soft);

--- a/docs/_handbook/design-system.md
+++ b/docs/_handbook/design-system.md
@@ -153,7 +153,7 @@ restyle 之前的一批变量名仍然存在，它们都已指回语义层，渲
 
 焦点样式有**单一来源**，组件里不要重复实现：
 
-1. `styles.css:204` —— `input / textarea / select` 的 `:focus` 统一给"强调色边框 + 一层柔光晕"。
+1. `styles.css:204` —— `input / textarea / select / button[role="combobox"]` 的 `:focus` 统一给"强调色边框 + 一层柔光晕"。
    用 `:where()` 包住让特异性归零，所以刻意无边框的控件（如聊天输入区的 `ring-0`）能用工具类覆盖掉。
 2. `styles.css:343` —— 全局 `:focus-visible` 给 2px 的 `--color-ring` 描边，键盘焦点始终可见；
    指针点击不显示描边。


### PR DESCRIPTION
共享 Select 聚焦时使用独立的 legacy primary 边框和 ring 类，实际渲染为深粉边框与蓝色 2px 光圈。本次移除组件内覆盖，将 combobox 按钮接入已有全局字段焦点规则，使其与普通 input 一致；同步设计手册的适用控件说明。

Closes #187

## 验证

- Select 定向交互测试 4/4 通过。
- pnpm typecheck、pnpm lint、renderer 构建通过；仅有原有 RoleAssetCategoryGroups Hooks 警告及构建 chunk 体积提示。
- Playwright + Edge，1320px 与 390px：Select 和普通 input 的 computed border/shadow 一致，使用 1px 语义柔光 token，不再出现蓝色 ring 或双描边。
- 展开面板保持 border-line-soft；鼠标与键盘选值正常；浏览器无运行时错误。
- git diff --check 通过。

## CI / 审查

[CI #34350076175](https://github.com/YinFengWindy/Shiori-Agent/actions/runs/34350076175) 两项检查均通过：desktop-check-and-test、check-and-test，验证提交 1f46d10899585c682aacf7eba20da20e1f4c21ff。

自动审查 skipped: UI-only，基线 50a3a30c、提交 1f46d108，变更仅涉及焦点样式接入和说明。

## 阻塞项

无已知实现或验证阻塞项。合并需用户确认。
