### PR TITLE
chore(backend): 删除冗余断言并收敛重复契约检查

### DIFF
--- a/apps/backend/agent/core/proactive_turn/gates.py
+++ b/apps/backend/agent/core/proactive_turn/gates.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 from time import perf_counter
-from typing import Literal, Mapping, Protocol, Sequence, runtime_checkable
+from typing import Literal, Mapping, Protocol, Sequence, cast, runtime_checkable
 
 
 class ProactiveMode(StrEnum):
@@ -192,13 +192,15 @@ class ProactiveGateChain:
                     blocked_gate_name=gate.name,
                 )
             if decision.kind == "activate":
-                assert decision.mode is not None
+                # _validate_decision 已保证 activate 分支下 mode 不为空；
+                # 这里仅做静态类型收窄，不再重复运行期校验。
+                mode = cast(ProactiveMode, decision.mode)
                 return ProactiveGateResult(
                     blocked=False,
                     reason=decision.reason or gate.name,
                     activation=ProactiveGateActivation(
                         gate_name=gate.name,
-                        mode=decision.mode,
+                        mode=mode,
                         reason=decision.reason,
                         metadata=dict(decision.metadata),
                     ),

--- a/apps/backend/agent/mcp/client.py
+++ b/apps/backend/agent/mcp/client.py
@@ -7,7 +7,7 @@ import os
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 logger = logging.getLogger(__name__)
 
@@ -212,17 +212,24 @@ class McpClient:
         self._next_id += 1
         return i
 
+    def _require_process(self) -> asyncio.subprocess.Process:
+        """返回已连接的子进程；未连接时立即失败，而不是让调用方在下游拿到 None。"""
+        if self._process is None:
+            raise RuntimeError(f"MCP 客户端 {self.name!r} 未连接")
+        return self._process
+
     async def _send(self, payload: dict[str, Any]) -> None:
-        assert self._process and self._process.stdin
+        process = self._require_process()
+        # connect() 总是以 stdin=PIPE 创建子进程，因此进程存在时 stdin 必非空；
+        # 这里仅做静态类型收窄。
+        stdin = cast(asyncio.StreamWriter, process.stdin)
         logger.debug(
             "[mcp:%s] -> %s",
             self.name,
             json.dumps(payload, ensure_ascii=False)[:400],
         )
-        self._process.stdin.write(
-            (json.dumps(payload, ensure_ascii=False) + "\n").encode()
-        )
-        await self._process.stdin.drain()
+        stdin.write((json.dumps(payload, ensure_ascii=False) + "\n").encode())
+        await stdin.drain()
 
     async def _recv(
         self,
@@ -230,13 +237,14 @@ class McpClient:
         stage: str = "recv",
         timeout: float | None = None,
     ) -> dict[str, Any]:
-        assert self._process and self._process.stdout
+        process = self._require_process()
+        # connect() 总是以 stdout=PIPE 创建子进程，因此进程存在时 stdout 必非空；
+        # 这里仅做静态类型收窄。
+        stdout = cast(asyncio.StreamReader, process.stdout)
         recv_timeout = _RECV_TIMEOUT if timeout is None else timeout
         while True:
             try:
-                line = await asyncio.wait_for(
-                    self._process.stdout.readline(), timeout=recv_timeout
-                )
+                line = await asyncio.wait_for(stdout.readline(), timeout=recv_timeout)
             except asyncio.TimeoutError as e:
                 raise TimeoutError(
                     self._build_timeout_message(stage, expected_id, recv_timeout)
@@ -270,10 +278,13 @@ class McpClient:
 
     async def _drain_stderr(self) -> None:
         """后台读取 stderr，防止缓冲区阻塞。"""
-        assert self._process and self._process.stderr
+        process = self._require_process()
+        # connect() 总是以 stderr=PIPE 创建子进程，因此进程存在时 stderr 必非空；
+        # 这里仅做静态类型收窄。
+        stderr = cast(asyncio.StreamReader, process.stderr)
         try:
             while True:
-                line = await self._process.stderr.readline()
+                line = await stderr.readline()
                 if not line:
                     break
                 text = line.decode().rstrip()

--- a/apps/backend/agent/mcp/client.py
+++ b/apps/backend/agent/mcp/client.py
@@ -7,7 +7,7 @@ import os
 from collections import deque
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -218,11 +218,34 @@ class McpClient:
             raise RuntimeError(f"MCP 客户端 {self.name!r} 未连接")
         return self._process
 
+    def _require_stdin(self) -> asyncio.StreamWriter:
+        """返回已连接进程的 stdin。
+
+        connect() 总是以 stdin/stdout/stderr=PIPE 创建子进程，因此进程存在时
+        三个流理论上必非空；这里仍做真实的 None 检查并立即失败，而不是让
+        None 流入下游触发一个更晚、更隐晦的错误。
+        """
+        stdin = self._require_process().stdin
+        if stdin is None:
+            raise RuntimeError(f"MCP 客户端 {self.name!r} 的 stdin 不可用")
+        return stdin
+
+    def _require_stdout(self) -> asyncio.StreamReader:
+        """返回已连接进程的 stdout；未连接或流不可用时立即失败。"""
+        stdout = self._require_process().stdout
+        if stdout is None:
+            raise RuntimeError(f"MCP 客户端 {self.name!r} 的 stdout 不可用")
+        return stdout
+
+    def _require_stderr(self) -> asyncio.StreamReader:
+        """返回已连接进程的 stderr；未连接或流不可用时立即失败。"""
+        stderr = self._require_process().stderr
+        if stderr is None:
+            raise RuntimeError(f"MCP 客户端 {self.name!r} 的 stderr 不可用")
+        return stderr
+
     async def _send(self, payload: dict[str, Any]) -> None:
-        process = self._require_process()
-        # connect() 总是以 stdin=PIPE 创建子进程，因此进程存在时 stdin 必非空；
-        # 这里仅做静态类型收窄。
-        stdin = cast(asyncio.StreamWriter, process.stdin)
+        stdin = self._require_stdin()
         logger.debug(
             "[mcp:%s] -> %s",
             self.name,
@@ -237,10 +260,7 @@ class McpClient:
         stage: str = "recv",
         timeout: float | None = None,
     ) -> dict[str, Any]:
-        process = self._require_process()
-        # connect() 总是以 stdout=PIPE 创建子进程，因此进程存在时 stdout 必非空；
-        # 这里仅做静态类型收窄。
-        stdout = cast(asyncio.StreamReader, process.stdout)
+        stdout = self._require_stdout()
         recv_timeout = _RECV_TIMEOUT if timeout is None else timeout
         while True:
             try:
@@ -278,10 +298,7 @@ class McpClient:
 
     async def _drain_stderr(self) -> None:
         """后台读取 stderr，防止缓冲区阻塞。"""
-        process = self._require_process()
-        # connect() 总是以 stderr=PIPE 创建子进程，因此进程存在时 stderr 必非空；
-        # 这里仅做静态类型收窄。
-        stderr = cast(asyncio.StreamReader, process.stderr)
+        stderr = self._require_stderr()
         try:
             while True:
                 line = await stderr.readline()

--- a/apps/backend/agent/plugin_host/kernel.py
+++ b/apps/backend/agent/plugin_host/kernel.py
@@ -18,7 +18,6 @@ from agent.plugin_host.capabilities import (
     BackgroundCapability,
     ChannelsCapability,
     LifecycleCapability,
-    PHASE_SLOTS,
     ProactiveGatesCapability,
     ToolHooksCapability,
     ToolsCapability,
@@ -350,18 +349,6 @@ class PluginKernel:
             for command, description in getter():
                 commands.append((str(command), str(description)))
         return commands
-
-
-# 断言 v2/legacy 使用同一批槽位名，防止两处清单漂移
-assert set(PHASE_SLOTS) == {
-    "before_turn",
-    "before_reasoning",
-    "prompt_render",
-    "before_step",
-    "after_step",
-    "after_reasoning",
-    "after_turn",
-}
 
 
 def _import_module(module_name: str, path: Path) -> None:

--- a/apps/backend/agent/screen_observation/model.py
+++ b/apps/backend/agent/screen_observation/model.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from agent.llm_json import load_json_object_loose
 from agent.provider import LLMProvider
@@ -64,9 +64,11 @@ class ObservationModelAdapter:
                     previous_context=previous_context,
                     recent_bubbles=recent_bubbles,
                 )
-        assert self._provider is not None
+        # 走到这里说明 role_runtime_registry 分支未提前 return；
+        # 方法开头的 raise 已保证此时 provider/model 非空，这里仅做静态类型收窄。
+        provider = cast(LLMProvider, self._provider)
         return await self._analyze_with_provider(
-            provider=self._provider,
+            provider=provider,
             model=self._model,
             frame=frame,
             previous_context=previous_context,

--- a/apps/backend/desktop_bridge/session_task_requests.py
+++ b/apps/backend/desktop_bridge/session_task_requests.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
 from datetime import datetime
-from typing import Any
+from typing import Any, Literal, overload
 
 from core.roles import RoleAggregateService
 from session.manager import Session
@@ -57,7 +57,6 @@ class DesktopSessionTaskRequestHandler:
             )
         if method == "session.messagesPage":
             session_key = self._desktop_session_key(payload, required=True)
-            assert session_key is not None
             meta = self._app_service.session_manager._store.get_session_meta(session_key)
             if meta is None:
                 session = Session(key=session_key)
@@ -114,7 +113,6 @@ class DesktopSessionTaskRequestHandler:
             )
         if method == "session.imageHistory":
             session_key = self._desktop_session_key(payload, required=True)
-            assert session_key is not None
             return self._session_presenter.serialize_image_history(session_key)
         if method == "session.updateDisplayState":
             active_illustration = payload.get("active_illustration")
@@ -200,6 +198,16 @@ class DesktopSessionTaskRequestHandler:
     @staticmethod
     def _role_id(payload: dict[str, Any]) -> str:
         return str(payload.get("role_id") or "").strip()
+
+    @overload
+    def _desktop_session_key(
+        self, payload: dict[str, Any], *, required: Literal[True]
+    ) -> str: ...
+
+    @overload
+    def _desktop_session_key(
+        self, payload: dict[str, Any], *, required: Literal[False]
+    ) -> str | None: ...
 
     def _desktop_session_key(
         self,

--- a/apps/backend/proactive_v2/agent_tick_factory.py
+++ b/apps/backend/proactive_v2/agent_tick_factory.py
@@ -69,14 +69,17 @@ class AgentTickFactory:
     def build(self) -> ProactiveTurnPipeline:
         if self._deps.pool is None:
             raise RuntimeError("proactive_v2 依赖 MCP 连接池，pool 不能为空")
+        # 上面的 raise 已经保证 pool 非空；此处收窄一次类型，
+        # 后续构建方法直接接收非空 pool，不必再逐处断言。
+        pool = self._deps.pool
 
         # 1. 先确定本轮 proactive 要服务哪个 session。
         session_key = self._get_session_key()
         # 2. 再把 tick 运行期依赖逐项组装好：
         #    最近用户时间 / 工具依赖 / gateway 数据依赖 / 近期主动消息读取函数。
         last_user_at_fn = self._build_last_user_at_fn(session_key)
-        tool_deps = self._build_tool_deps()
-        gateway_deps = self._build_gateway_deps(tool_deps)
+        tool_deps = self._build_tool_deps(pool)
+        gateway_deps = self._build_gateway_deps(tool_deps, pool)
         recent_proactive_fn = self._build_recent_proactive_fn()
         drift_pipeline = self._build_drift_pipeline(tool_deps)
         target_transports_fn = getattr(self._deps.sense, "target_transports", None)
@@ -156,29 +159,20 @@ class AgentTickFactory:
 
         return llm_fn
 
-    def _build_alert_fn(self) -> AlertFn:
-        pool = self._deps.pool
-        assert pool is not None
-
+    def _build_alert_fn(self, pool: McpClientPool) -> AlertFn:
         async def alert_fn() -> list[dict]:
             return await mcp_sources.fetch_alert_events_async(pool)
 
         return alert_fn
 
-    def _build_feed_fn(self) -> FeedFn:
-        pool = self._deps.pool
-        assert pool is not None
-
+    def _build_feed_fn(self, pool: McpClientPool) -> FeedFn:
         async def feed_fn(limit: int = 5) -> list[dict]:
             events = await mcp_sources.fetch_content_events_async(pool)
             return events[:limit]
 
         return feed_fn
 
-    def _build_context_fn(self) -> ContextFn:
-        pool = self._deps.pool
-        assert pool is not None
-
+    def _build_context_fn(self, pool: McpClientPool) -> ContextFn:
         async def context_fn() -> list[dict]:
             rows = await mcp_sources.fetch_context_data_async(pool)
             if not isinstance(rows, list):
@@ -198,10 +192,7 @@ class AgentTickFactory:
 
         return recent_chat_fn
 
-    def _build_ack_fn(self) -> AckFn:
-        pool = self._deps.pool
-        assert pool is not None
-
+    def _build_ack_fn(self, pool: McpClientPool) -> AckFn:
         async def ack_fn(compound_key: str, ttl_hours: int) -> None:
             """compound_key 格式："{ack_server}:{id}"，如 "feed-mcp:c1"."""
             parts = compound_key.split(":", 1)
@@ -215,10 +206,7 @@ class AgentTickFactory:
 
         return ack_fn
 
-    def _build_alert_ack_fn(self) -> AlertAckFn:
-        pool = self._deps.pool
-        assert pool is not None
-
+    def _build_alert_ack_fn(self, pool: McpClientPool) -> AlertAckFn:
         async def alert_ack_fn(compound_key: str) -> None:
             """Alert 专用通道，走 acknowledge_events（非 content entries）。"""
             import types as _types
@@ -231,7 +219,7 @@ class AgentTickFactory:
 
         return alert_ack_fn
 
-    def _build_tool_deps(self) -> ToolDeps:
+    def _build_tool_deps(self, pool: McpClientPool) -> ToolDeps:
         web_fetch_tool = None
         try:
             web_fetch_tool = WebFetchTool()
@@ -241,16 +229,18 @@ class AgentTickFactory:
             web_fetch_tool=web_fetch_tool,
             memory=self._deps.memory,
             recent_chat_fn=self._build_recent_chat_fn(),
-            ack_fn=self._build_ack_fn(),
-            alert_ack_fn=self._build_alert_ack_fn(),
+            ack_fn=self._build_ack_fn(pool),
+            alert_ack_fn=self._build_alert_ack_fn(pool),
             max_chars=self._deps.cfg.agent_tick_web_fetch_max_chars,
         )
 
-    def _build_gateway_deps(self, tool_deps: ToolDeps) -> GatewayDeps:
+    def _build_gateway_deps(
+        self, tool_deps: ToolDeps, pool: McpClientPool
+    ) -> GatewayDeps:
         return GatewayDeps(
-            alert_fn=self._build_alert_fn(),
-            feed_fn=self._build_feed_fn(),
-            context_fn=self._build_context_fn(),
+            alert_fn=self._build_alert_fn(pool),
+            feed_fn=self._build_feed_fn(pool),
+            context_fn=self._build_context_fn(pool),
             web_fetch_tool=tool_deps.web_fetch_tool,
             max_chars=tool_deps.max_chars,
             content_limit=getattr(self._deps.cfg, "agent_tick_content_limit", 5),

--- a/tests/backend/agent/plugin_host/test_capabilities.py
+++ b/tests/backend/agent/plugin_host/test_capabilities.py
@@ -150,6 +150,23 @@ def test_all_phase_slots_are_contributable():
     assert all(len(contributions.phase_modules[slot]) == 1 for slot in PHASE_SLOTS)
 
 
+def test_phase_slots_matches_the_seven_documented_slot_names():
+    """v2 PHASE_SLOTS 与 legacy 清单共用同一批槽位名，防止两处清单漂移。
+
+    原先这条检查是 kernel.py 模块顶层的 assert（会在每次导入时执行）；
+    迁移为普通测试，避免生产导入路径承担单元测试职责。
+    """
+    assert set(PHASE_SLOTS) == {
+        "before_turn",
+        "before_reasoning",
+        "prompt_render",
+        "before_step",
+        "after_step",
+        "after_reasoning",
+        "after_turn",
+    }
+
+
 # ── 列表型 capability ──────────────────────────────────────────────────────
 
 

--- a/tests/backend/test_core_decoupling_baseline.py
+++ b/tests/backend/test_core_decoupling_baseline.py
@@ -23,7 +23,6 @@ Covers:
 
 from __future__ import annotations
 
-import inspect
 import json
 import pytest
 from types import SimpleNamespace
@@ -248,19 +247,3 @@ def test_history_message_fields():
     assert msg.content == "hello"
     assert msg.tools_used == ["shell"]
     assert msg.tool_chain == []
-
-
-def test_turn_types_shim_is_removed():
-    """looping.turn_types 已移除，核心类型统一从 agent.core.types 导入。"""
-    import importlib.util
-
-    assert importlib.util.find_spec("agent.looping.turn_types") is None
-
-
-def test_core_boundary_modules_do_not_import_looping_turn_types():
-    """Canonical core/retrieval contracts must not depend on looping.turn_types."""
-    from agent.core import passive_turn
-    from agent.retrieval import protocol as retrieval_protocol
-
-    assert "agent.looping.turn_types" not in inspect.getsource(passive_turn)
-    assert "agent.looping.turn_types" not in inspect.getsource(retrieval_protocol)


### PR DESCRIPTION
Closes #192 · Parent #191

## 变更摘要

清理 `apps/backend` 下 13 处裸 `assert`，行首 `assert` 语句归零。这些断言的不变式在上游已由显式 `raise` 保证；且 Python 在 `-O` 下会整体剥离 `assert`，用它做运行时校验本就不可靠。

| 模块 | 处理 |
|---|---|
| `agent/core/proactive_turn/gates.py` | 删除 `activate` 分支的 mode 非空断言。同一循环体上一行的 `_validate_decision` 已对相同不变式 `raise ValueError`，断言是可证明的死代码。改用 `cast` 做静态收窄并注明运行期校验在上游。 |
| `proactive_v2/agent_tick_factory.py` | 五处重复的 `assert pool is not None` 收敛为 `build()` 入口一次收窄，`pool` 作为显式参数下发给各构建方法。入口处原有的 `raise RuntimeError` 是唯一的真实校验点。 |
| `desktop_bridge/session_task_requests.py` | 给 `_desktop_session_key` 补 `@overload`（`Literal[True] -> str` / `Literal[False] -> str \| None`），从类型层面消除两处永不为假的断言。 |
| `agent/mcp/client.py` | 三份重复的进程非空样板收敛为 `_require_process()`，未连接时抛出说明性 `RuntimeError`。三个流的非空性由 `connect()` 恒以 `PIPE` 创建子进程保证。 |
| `agent/screen_observation/model.py` | 删除可证明冗余的 provider 非空断言（方法开头的 guard 加上 `role_runtime_registry` 分支提前 return 已保证非空）。 |
| `agent/plugin_host/kernel.py` | 模块级 `PHASE_SLOTS` 漂移断言迁出生产导入路径，落为 `tests/backend/agent/plugin_host/test_capabilities.py` 里的普通测试，保留防漂移能力。 |

另删除 `tests/backend/test_core_decoupling_baseline.py` 中两个迁移期一次性用例：`test_turn_types_shim_is_removed` 与 `test_core_boundary_modules_do_not_import_looping_turn_types`。后者用 `inspect.getsource()` 做源码字符串搜索，其不变式在自身 import 语句执行时已被间接保证。

## 唯一的行为变化

**MCP 客户端未连接时的异常类型由 `AssertionError` 变为 `RuntimeError`**（错误信息带上客户端名）。这是有意改进：`AssertionError` 在 `-O` 下根本不会抛出。

`_drain_stderr` 中 `_require_process()` 刻意放在 `try` **之外**，与原 `assert` 位置一致，保证"未连接"的失败仍然冒泡，不被该函数的 `except Exception: pass` 吞掉。

## 实际验证结果

在 `.venv`（Python 3.12.9）本地执行：

- `pytest -q` → **2222 passed / 0 failed / 0 skipped**（基线 2223，−2 删除用例 +1 迁移新增，逐项对得上）
- `pyright --level error` → **0 errors, 0 warnings**
- `pyright --project pyrightconfig.tests.json --level error` → **0 errors, 0 warnings**
- `ruff check apps/backend tests/backend` → All checks passed
- `grep -rn "^\s*assert " --include=*.py apps/backend` → 空

第 6 项的迁移测试做了红/绿验证：临时把 `capabilities.py` 里的 `after_turn` 改坏，新测试如期失败并给出清晰 diff；还原后通过。`capabilities.py` 最终 diff 为空。

## 已知阻塞项

无。

## 顺带发现（不在本 PR 处理）

`pyproject.toml` 的 `[tool.black] target-version = ["py314"]` 与 `requires-python = ">=3.12"` 及 `.venv` 的 Python 3.12.9 不一致，导致 `black --check` 在约 395 个文件（含本 PR 未触碰的文件）上报错，且其建议的"修复"会产出 3.12 无法解析的 PEP 758 语法。这是既存的仓库级配置问题，与本 PR 无关，CI 也不跑 black。需要人来决定是升 venv 的 Python 还是改 target-version 固定值，故未在此处理。


---

## 评审后的修复（head 88340ce9）

独立 Spec 评审发现原实现有一处真实缺陷：`typing.cast` 在运行期是纯空操作，它把失败点从 `try` **之外**推迟到了 `try` **内部**。`_drain_stderr` 中若 stderr 为 None，`None.readline()` 会落进该函数的 `except Exception: pass` 被**静默吞掉**——而原来的 `assert` 在 `try` 之外，是会逸出协程的。这违反 AGENTS.md「业务层不要吞错、让异常尽早冒泡」。

修法：在 `_require_process()` 之上补三个精确的流访问器 `_require_stdin` / `_require_stdout` / `_require_stderr`，各自做**真实的 None 检查**并抛 `RuntimeError`，取代三处 `cast`。三个调用点各自一行，且**均在 `try` 之外**，恢复失败即停语义。同时消掉了三段逐字重复的注释（Standards 评审的 Duplicated Code）以及调用方对 `Process` 本身的无谓依赖（Middle Man）——它们本就只需要流。

修复后「唯一可观察的行为变化是 `AssertionError` → `RuntimeError`」这一说法重新成立。

### 明确不采纳的评审意见

- **恢复 `test_core_decoupling_baseline.py` 里被删的两个用例**：不采纳。评审称它们"不在本 PR 范围内"与事实不符——#192 正文第 7 项明确列出了它们。评审自己提供的证据（`turn_types` 全仓零命中）反而支持删除：迁移已彻底完成，不存在可以漂移回去的源头；`test_turn_types_shim_is_removed` 防的是"有人重新创建一个已删除的模块"，那不是会意外发生的回归。
- **把 `gates.py` / `model.py` 的 `cast` 也改成显式 `raise`**：不采纳。#191 明确约定「用类型系统或一次性收窄来满足 pyright，而不是把断言换成另一种等价的运行期检查」，且上游 guard 已存在，再加一层属于 AGENTS.md 说的"不必要的 fallback"。与 `client.py` 的区别在于：那里的 `cast` 会导致实际的吞错 bug，这两处不会（值流向有类型标注的参数，真为 None 会在下游响亮失败）。

### 记录（非缺陷）

#191 的 Testing Decisions 写「这是本次唯一新增的测试文件」，实际是追加到既有的 `tests/backend/agent/plugin_host/test_capabilities.py`。镜像位置正确且该文件本就覆盖 `capabilities.py`，结果优于新建文件，仅措辞不符。


### 复核后的一处如实修正

Standards 轴复核确认了 try 边界修复成立，但指出我上面的措辞过于乐观：`_drain_stderr` 由 `asyncio.create_task(self._drain_stderr())` 以 fire-and-forget 方式启动且**丢弃了 task 句柄**（`client.py:103`）。因此 `_require_stderr()` 抛出的 `RuntimeError` 不会到达任何调用方，只会在 GC 时以 "Task exception was never retrieved" 浮现。

准确的说法是：本 PR 让该错误**不再被 `except Exception: pass` 静默吞掉**，但对这条特定路径尚未做到真正的失败即停。造成这一点的是 base 已有的 fire-and-forget 结构（`except Exception: pass` 在 base 中逐字相同），本 PR 未引入也未加剧，修正它需要改动 task 生命周期管理，超出 #192 范围。

另有一处非阻塞小瑕疵：`_require_stdin` 的 docstring 讲的是三个流的共同前提，挂在单个方法上略有错位。为避免为一处文档措辞再走一轮完整 CI，未在本 PR 调整。
