### PR TITLE
fix(repo): 修正 black target-version 与分诊标签文档中的失效映射

### DIFF
--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -4,12 +4,11 @@ Skills 使用五种标准分诊角色。本文件将这些角色映射到仓库 
 
 | mattpocock/skills 中的角色 | 本仓库标签           | 含义                         |
 | ------------------------- | -------------------- | ---------------------------- |
-| `needs-triage`            | `needs-triage`       | 维护者需要评估此 Issue        |
-| `needs-info`              | `needs-info`         | 等待报告者补充信息             |
 | `ready-for-agent`         | `ready-for-agent`    | 信息完整，可交由 AFK Agent 处理 |
-| `ready-for-human`         | `ready-for-human`    | 需要人工实现                   |
 | `wontfix`                 | `wontfix`            | 不会处理                       |
 
 当 skill 提到某个角色时（例如“应用 AFK-ready 分诊标签”），使用表中对应的标签字符串。
+
+`needs-triage`、`needs-info`、`ready-for-human` 三个角色在本仓库**没有对应标签**。skill 遇到它们时不要新建标签，改用 issue 正文或评论说明状态。
 
 如果仓库实际使用其他标签词汇，修改中间一列即可。

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ requires-python = ">=3.12"
 
 [tool.black]
 line-length = 88
-target-version = ["py314"]
+target-version = ["py312"]
 include = '\.pyi?$'
 
 [tool.ruff.lint]


### PR DESCRIPTION
Closes #202

## 变更摘要

两处仓库自身配置/文档与现实不符的修正，**不改任何 Python 源码**。

### 1. `pyproject.toml`：black 的 `target-version` 由 `py314` 改为 `py312`

原配置写着 `target-version = ["py314"]`，但 `requires-python = ">=3.12"`，仓库 `.venv` 的解释器是 Python 3.12.9。

这不只是"报个错"，而是**危险**：black 会按 3.14 语法重排代码，随后自身的 AST 等价性校验失败，直接拒绝格式化 28 个文件；对能格式化的部分，它建议的改法包含 PEP 758 语法（例如 `except asyncio.CancelledError, Exception:`）——当前运行时**根本无法解析**。任何人按 `AGENTS.md` 的要求老实跑 `black -w`，都有把仓库写成跑不起来的状态的风险。CI 不跑 black，一直掩盖着这一点。

`py312` 正是 black 自己在警告里给出的修法。

### 2. `docs/agents/triage-labels.md`：移除三个不存在的标签映射

该文件把 mattpocock/skills 的五个分诊角色映射到本仓库标签，但 `needs-triage`、`needs-info`、`ready-for-human` 三个在 `gh label list` 中并不存在（仓库实际只有 `ready-for-agent` 与 GitHub 默认标签）。

移除这三行失效映射，并补一句说明：这三个角色在本仓库无对应标签，skill 遇到时**不要新建标签**，改用 issue 正文或评论说明状态。之所以不是裸删，是因为裸删会让 skill 遇到这些角色时无所适从，而阻止它凭空创建标签正是本次修改的目的。

## 实际验证结果

- `black --check apps/backend tests/backend benchmarks scripts` → 修改前含 `Python 3.12 cannot parse code formatted for Python 3.14` 警告且 `28 files would fail to reformat`；修改后这两类信息**归零**（`grep -ci "cannot parse\|fail to reformat"` = 0）
- 文档中保留的 `ready-for-agent`、`wontfix` 均已在 `gh label list` 中确认存在
- `pytest -q` → **2222 passed**，与合并后 `main` 的基线一致

## 已知阻塞项

无。

## 明确不在本 PR 范围

降低 `target-version` 后，`black --check` 会诚实地报出 **427 个文件待格式化**（352 个不变）——说明本仓库基本从未被 black 格式化过。本 PR 修掉的是"危险"，不是"红"。

该缺口已单独登记为 **#204**，并**刻意不在此处顺手做全仓重排**：427 个文件的改动会与当前在飞的插件重构 PR（#196、#199、#200、#201，各自带独立 worktree）全面冲突。#204 里列出了三个可选方向供决策。
