### PR TITLE
fix(mcp): 让 _drain_stderr 的异常有确定归属，disconnect 后不残留悬挂 task

### DIFF
--- a/apps/backend/agent/mcp/client.py
+++ b/apps/backend/agent/mcp/client.py
@@ -5,6 +5,7 @@ import json
 import logging
 import os
 from collections import deque
+from contextlib import suppress
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
@@ -68,6 +69,7 @@ class McpClient:
         # cwd 未指定时从 command 中推断，避免子进程继承 agent 工作目录
         self.cwd = cwd or _infer_cwd(command)
         self._process: asyncio.subprocess.Process | None = None
+        self._stderr_task: asyncio.Task[None] | None = None
         self._next_id = 1
         self._tool_infos: list[McpToolInfo] = []
         self._recent_stdout: deque[str] = deque(maxlen=8)
@@ -100,7 +102,11 @@ class McpClient:
             cwd=self.cwd,
             limit=_STREAM_LIMIT,
         )
-        _ = asyncio.create_task(self._drain_stderr())
+        # 在连接路径上取流：流不可用时 RuntimeError 由 connect() 冒泡，
+        # 而不是丢进一个无人接管的后台任务里。
+        self._stderr_task = asyncio.create_task(
+            self._drain_stderr(self._require_stderr())
+        )
 
         # initialize 握手
         init_id = self._new_id()
@@ -193,19 +199,31 @@ class McpClient:
         return str(resp.get("result", ""))
 
     async def disconnect(self) -> None:
-        """终止子进程。"""
-        if self._process is None:
+        """终止子进程，并回收 stderr 排空任务。"""
+        if self._process is not None:
+            try:
+                self._process.terminate()
+                _ = await asyncio.wait_for(self._process.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                self._process.kill()
+                _ = await self._process.wait()
+            except Exception as e:
+                logger.warning("[mcp] 断开 %r 时出错: %s", self.name, e)
+            finally:
+                self._process = None
+        # 先结束子进程再收任务：子进程还活着时停止排空 stderr，可能让它写满
+        # 管道缓冲区而卡在退出路径上。
+        await self._close_stderr_task()
+
+    async def _close_stderr_task(self) -> None:
+        """取消并等待 stderr 排空任务，确保 disconnect() 后不残留悬挂 task。"""
+        task = self._stderr_task
+        if task is None:
             return
-        try:
-            self._process.terminate()
-            _ = await asyncio.wait_for(self._process.wait(), timeout=5.0)
-        except asyncio.TimeoutError:
-            self._process.kill()
-            _ = await self._process.wait()
-        except Exception as e:
-            logger.warning("[mcp] 断开 %r 时出错: %s", self.name, e)
-        finally:
-            self._process = None
+        self._stderr_task = None
+        _ = task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
 
     def _new_id(self) -> int:
         i = self._next_id
@@ -296,19 +314,25 @@ class McpClient:
             logger.debug("[mcp:%s] <- %s", self.name, text[:400])
             return msg
 
-    async def _drain_stderr(self) -> None:
-        """后台读取 stderr，防止缓冲区阻塞。"""
-        stderr = self._require_stderr()
+    async def _drain_stderr(self, stderr: asyncio.StreamReader) -> None:
+        """后台读取 stderr，防止缓冲区阻塞。
+
+        流由 `_connect_impl` 取好后传入，因此"流不可用"在连接时就已失败。
+        子进程的 stderr 未必是合法 UTF-8，解码用 replace 兜底：这个协程的
+        全部职责就是持续排空，不能因为一个坏字节停下来让管道写满。
+        """
         try:
             while True:
                 line = await stderr.readline()
                 if not line:
                     break
-                text = line.decode().rstrip()
+                text = line.decode(errors="replace").rstrip()
                 self._recent_stderr.append(text[:500])
                 logger.debug("[mcp:%s] stderr: %s", self.name, text)
-        except Exception:
-            pass
+        except Exception as e:
+            # 排空失败不影响 stdio 主协议通道，因此在这里就地记录并结束，
+            # 而不是把异常留给一个无人 await 的 task 在 GC 时才暴露。
+            logger.warning("[mcp:%s] stderr 排空中止: %s", self.name, e)
 
     def _build_timeout_message(
         self,

--- a/tests/backend/test_io_modules.py
+++ b/tests/backend/test_io_modules.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock
 
@@ -24,8 +25,12 @@ from agent.tools.filesystem import (
 
 
 class _Pipe:
-    def __init__(self, lines: list[bytes] | None = None) -> None:
+    def __init__(
+        self, lines: list[bytes] | None = None, *, block_on_eof: bool = False
+    ) -> None:
         self._lines = list(lines or [])
+        # 行读完后是否一直挂起（模拟仍然存活、暂时没有输出的真实流）
+        self._block_on_eof = block_on_eof
         self.writes: list[bytes] = []
 
     def write(self, data: bytes) -> None:
@@ -37,16 +42,25 @@ class _Pipe:
     async def readline(self) -> bytes:
         if self._lines:
             return self._lines.pop(0)
+        if self._block_on_eof:
+            await asyncio.Event().wait()
         return b""
 
 
 class _Proc:
     def __init__(
-        self, stdout_lines: list[bytes], stderr_lines: list[bytes] | None = None
+        self,
+        stdout_lines: list[bytes],
+        stderr_lines: list[bytes] | None = None,
+        *,
+        with_stderr: bool = True,
+        stderr_blocks: bool = False,
     ) -> None:
         self.stdin = _Pipe()
         self.stdout = _Pipe(stdout_lines)
-        self.stderr = _Pipe(stderr_lines)
+        self.stderr: _Pipe | None = (
+            _Pipe(stderr_lines, block_on_eof=stderr_blocks) if with_stderr else None
+        )
         self.terminated = False
 
     def terminate(self) -> None:
@@ -386,3 +400,73 @@ async def test_mcp_recv_timeout_includes_stage_and_recent_output(
     assert "12s" in text
     assert "expected_id=1" in text
     assert "recent_stderr=GitHub MCP Server running on stdio" in text
+
+
+_HANDSHAKE_LINES = [
+    b'{"jsonrpc":"2.0","id":1,"result":{}}\n',
+    b'{"jsonrpc":"2.0","id":2,"result":{"tools":[]}}\n',
+]
+
+
+@pytest.mark.asyncio
+async def test_mcp_connect_fails_when_stderr_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """stderr 不可用时 connect() 必须报错，而不是把异常留给后台任务。"""
+    proc = _Proc(_HANDSHAKE_LINES, with_stderr=False)
+    monkeypatch.setattr(
+        "agent.mcp.client.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)
+    )
+    client = McpClient("docs", ["python", "srv.py"])
+    with pytest.raises(RuntimeError, match="stderr"):
+        await client.connect()
+    assert client._stderr_task is None
+
+
+@pytest.mark.asyncio
+async def test_mcp_disconnect_leaves_no_pending_stderr_task(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """disconnect() 返回后 stderr 排空任务必须已经结束且不再被持有。"""
+    # stderr 读完后继续挂起，排空协程只能靠 disconnect() 收掉。
+    proc = _Proc(_HANDSHAKE_LINES, [b"warn\n"], stderr_blocks=True)
+    monkeypatch.setattr(
+        "agent.mcp.client.asyncio.create_subprocess_exec", AsyncMock(return_value=proc)
+    )
+    client = McpClient("docs", ["python", "srv.py"])
+    _ = await client.connect()
+    task = client._stderr_task
+    assert task is not None
+    assert not task.done()
+
+    await client.disconnect()
+    assert client._stderr_task is None
+    assert task.done()
+
+
+@pytest.mark.asyncio
+async def test_mcp_stderr_drain_logs_failure_instead_of_swallowing(
+    caplog: pytest.LogCaptureFixture,
+):
+    """排空过程中的异常必须留下 warning，不能被静默吞掉。"""
+
+    class _BrokenStream:
+        async def readline(self) -> bytes:
+            raise OSError("stream closed")
+
+    client = McpClient("docs", ["python", "srv.py"])
+    with caplog.at_level(logging.WARNING, logger="agent.mcp.client"):
+        await client._drain_stderr(_BrokenStream())
+
+    assert "stream closed" in caplog.text
+
+
+@pytest.mark.asyncio
+async def test_mcp_stderr_drain_survives_undecodable_output():
+    """非 UTF-8 的 stderr 不能中断排空循环，否则子进程会被写满的管道卡住。"""
+    stream = _Pipe([b"\xff\xfe bad\n", b"after\n", b""])
+    client = McpClient("docs", ["python", "srv.py"])
+
+    await client._drain_stderr(stream)
+
+    assert list(client._recent_stderr)[-1] == "after"


### PR DESCRIPTION
Closes #203

## 变更摘要

`_drain_stderr` 此前以 fire-and-forget 方式启动且丢弃 task 句柄，协程内 `_require_stderr()` 抛出的 `RuntimeError` 没有任何调用方能接到，只会在 GC 时以 "Task exception was never retrieved" 出现在日志里。

对应 issue 里的四个待决问题，本 PR 的选择：

1. **流在连接路径上取。** `_require_stderr()` 提到 `_connect_impl`，流作为参数传给协程。"stderr 不可用"因此在 `connect()` 处同步失败——真正的失败即停，且不需要引入客户端失效标记这类额外机制。
2. **句柄挂实例。** 新增 `self._stderr_task`，纳入现有连接生命周期。
3. **`disconnect()` 取消并等待。** 新增 `_close_stderr_task()`：`cancel()` + `await` + suppress `CancelledError`。顺序上先终止子进程再收任务——子进程还活着时停止排空 stderr，可能让它写满管道缓冲区卡在退出路径上。原先 `if self._process is None: return` 的提前返回会跳过任务回收，已改为条件块。
4. **协程内异常记 warning 后结束。** 不标记客户端失效：stderr 排空失败不影响 stdio 主协议通道，按失效处理会让正常的进程退出被误判。

额外修了同一函数里 issue 点名的一个真实缺陷：`line.decode()` 遇到非 UTF-8 的 stderr 会抛 `UnicodeDecodeError`，在旧代码里被 `except Exception: pass` 吞掉并**终止排空循环**——而这个协程存在的唯一理由就是持续排空，循环一停管道就可能写满并卡住子进程。改为 `decode(errors="replace")`。

## 新增测试

4 个，均已确认在改动前的实现上失败：

| 测试 | 旧实现下的表现 |
| --- | --- |
| `test_mcp_connect_fails_when_stderr_unavailable` | 旧代码 `connect()` 成功返回，异常留在无人接管的 task 里 |
| `test_mcp_disconnect_leaves_no_pending_stderr_task` | `_stderr_task` 不存在 |
| `test_mcp_stderr_drain_logs_failure_instead_of_swallowing` | `except Exception: pass`，无任何日志 |
| `test_mcp_stderr_drain_survives_undecodable_output` | 坏字节使循环中止，`_recent_stderr` 为空 |

测试暂留在 `tests/backend/test_io_modules.py`（MCP client 现有测试所在处）。该文件的归位属于 #194 范围，不在本 PR 混做。

## 验证结果

- `pytest tests/backend/test_io_modules.py` — 9 passed
- `pytest tests/backend/proactive_v2/test_mcp_sources_async.py tests/backend/test_more_support_modules.py tests/backend/bootstrap/test_toolsets.py` — 31 passed（MCP 下游使用方）
- `ruff check` / `black --check` — 通过
- `pyright apps/backend/agent/mcp/client.py` — 0 errors（11 个 warning 均在未改动的 195-197 行，改前既有）

## 已知阻塞项

无。

## 合并顺序

本 PR 与 #194 的分支在 `tests/backend/test_io_modules.py` 上冲突。建议本 PR 先合，#194 再 rebase（解法是把这里的 4 个测试放进 #194 新建的 `tests/backend/agent/mcp/test_client.py`）。
