### PR TITLE
refactor(plugin): 存量插件迁移批 B——渠道、事件与记忆壳 (#183)

### DIFF
--- a/apps/backend/agent/plugin_host/kernel.py
+++ b/apps/backend/agent/plugin_host/kernel.py
@@ -309,6 +309,14 @@ class PluginKernel:
                 handle.contributions, handle.effects
             ),
             "rpc": lambda: RpcCapability(self.rpc, handle.effects, handle.plugin_id),
+            # 直传引用，无需 effect 包装：宿主拥有这些服务的生命周期，插件只读，
+            # 卸载时无需撤销任何登记（对齐 legacy PluginContext 的同名字段）。
+            "workspace": lambda: services.workspace,
+            "memory_engine": lambda: services.memory_engine,
+            "session_manager": lambda: services.session_manager,
+            "light_provider": lambda: services.light_provider,
+            "light_model": lambda: services.light_model,
+            "relationship_runtime": lambda: services.relationship_runtime,
         }
         return {
             name: builders[name]()

--- a/apps/backend/agent/plugin_host/manifest.py
+++ b/apps/backend/agent/plugin_host/manifest.py
@@ -22,6 +22,16 @@ KNOWN_CAPABILITIES = frozenset(
         "background",
         "bot_commands",
         "rpc",
+        # 批 B（#183）新增：直传宿主服务引用，供渠道/事件/记忆壳插件读取。这些
+        # 字段本身没有装配/回滚语义（不像 tools/kv 等需要 effect 包装），
+        # 因此不各建一个 Capability 类，直接在 kernel._build_capabilities 里
+        # 透传 HostServices 的同名字段。
+        "workspace",
+        "memory_engine",
+        "session_manager",
+        "light_provider",
+        "light_model",
+        "relationship_runtime",
     }
 )
 

--- a/apps/desktop/renderer/src/settings/ChannelsSettingsSection.tsx
+++ b/apps/desktop/renderer/src/settings/ChannelsSettingsSection.tsx
@@ -25,30 +25,6 @@ export function ChannelsSettingsSection({
           </Field>
         </SettingsSectionCard>
       );
-    case "qqbot":
-      return (
-        <SettingsSectionCard>
-          <Field label="App ID">
-            <input
-              className={settingsInputClass}
-              value={draft.channels.qqBotAppId}
-              onChange={(event) => updateDraft((current) => ({
-                ...current,
-                channels: { ...current.channels, qqBotAppId: event.target.value },
-              }))}
-            />
-          </Field>
-          <Field label="Client Secret">
-            <SettingsSecretInput
-              value={draft.channels.qqBotClientSecret}
-              onChange={(value) => updateDraft((current) => ({
-                ...current,
-                channels: { ...current.channels, qqBotClientSecret: value },
-              }))}
-            />
-          </Field>
-        </SettingsSectionCard>
-      );
     default:
       return null;
   }

--- a/apps/desktop/renderer/src/settings/SettingsSectionContent.test.tsx
+++ b/apps/desktop/renderer/src/settings/SettingsSectionContent.test.tsx
@@ -14,8 +14,6 @@ function createSettingsFormData(): SettingsFormData {
     channels: {
       telegramToken: "telegram-token",
       qqBotUin: "10001",
-      qqBotAppId: "qq-app",
-      qqBotClientSecret: "qq-secret",
     },
     memory: {
       enabled: true,
@@ -69,7 +67,7 @@ describe("SettingsSectionContent", () => {
   it("routes every settings domain to its editor", () => {
     const cases = [
       { sectionId: "models", subsectionId: "catalog", expected: "gpt-agent" },
-      { sectionId: "channels", subsectionId: "qqbot", expected: "qq-app" },
+      { sectionId: "channels", subsectionId: "qq", expected: "10001" },
       { sectionId: "memory", subsectionId: "embedding", expected: "embed-model" },
       { sectionId: "integrations", subsectionId: "novelai", expected: "novel-token" },
       { sectionId: "voice", subsectionId: "provider", expected: "secret-id" },

--- a/apps/desktop/renderer/src/settings/registerBuiltinSettingsSections.tsx
+++ b/apps/desktop/renderer/src/settings/registerBuiltinSettingsSections.tsx
@@ -37,7 +37,6 @@ export function registerBuiltinSettingsSections(): void {
     subsections: [
       { id: "telegram", label: "Telegram" },
       { id: "qq", label: "QQ" },
-      { id: "qqbot", label: "QQBot" },
     ],
     Component: ChannelsSettingsSection,
   }, "builtin");

--- a/apps/desktop/renderer/src/settings/settingsPersistence.test.ts
+++ b/apps/desktop/renderer/src/settings/settingsPersistence.test.ts
@@ -19,8 +19,6 @@ function createSettingsFormData(
     channels: {
       telegramToken: "",
       qqBotUin: "",
-      qqBotAppId: "",
-      qqBotClientSecret: "",
     },
     memory: {
       enabled: true,

--- a/apps/desktop/renderer/src/settings/settingsSectionMetadata.test.ts
+++ b/apps/desktop/renderer/src/settings/settingsSectionMetadata.test.ts
@@ -11,7 +11,7 @@ import {
 describe("settingsSectionMetadata", () => {
   it("keeps every configured subsection attached to its owning domain", () => {
     assert.deepEqual(getSettingsSubsections("models").map((item) => item.id), ["catalog"]);
-    assert.deepEqual(getSettingsSubsections("channels").map((item) => item.id), ["telegram", "qq", "qqbot"]);
+    assert.deepEqual(getSettingsSubsections("channels").map((item) => item.id), ["telegram", "qq"]);
   });
 
   it("falls back to the first subsection when persisted selection is invalid", () => {

--- a/apps/desktop/renderer/src/settings/testFixtures.ts
+++ b/apps/desktop/renderer/src/settings/testFixtures.ts
@@ -4,7 +4,7 @@ import type { SettingsFormData } from "../../../src/bridge/shared.js";
 export function createSettingsDraft(): SettingsFormData {
   return {
     models: { registrations: [] },
-    channels: { telegramToken: "", qqBotUin: "", qqBotAppId: "", qqBotClientSecret: "" },
+    channels: { telegramToken: "", qqBotUin: "" },
     memory: { enabled: false, engine: "default", embeddingModel: "", embeddingApiKey: "", embeddingBaseUrl: "", outputDimensionality: "" },
     integrations: { novelaiEnabled: false, novelaiToken: "", novelaiNsfwEnabled: false, novelaiAddQualityTags: false, novelaiUndesiredContentPreset: 0, novelaiAutoWritebackRoleAssets: false },
     voice: { enabled: false, hotkey: "Ctrl+Space", microphoneDeviceId: "", asrProvider: "tencent", asrBaseUrl: "", asrSecretId: "", asrSecretKey: "", ttsProvider: "minimax", ttsBaseUrl: "", ttsModel: "", ttsApiKey: "", ttsVolume: 2 },

--- a/apps/desktop/src/bridge/shared.ts
+++ b/apps/desktop/src/bridge/shared.ts
@@ -153,8 +153,6 @@ export type SettingsFormData = {
   channels: {
     telegramToken: string;
     qqBotUin: string;
-    qqBotAppId: string;
-    qqBotClientSecret: string;
   };
   memory: {
     enabled: boolean;

--- a/apps/desktop/src/settings.ts
+++ b/apps/desktop/src/settings.ts
@@ -169,7 +169,6 @@ export function loadSettingsData(contentOverride?: string): SettingsSnapshot {
   const voiceAsr = asRecord(voice.asr);
   const voiceTts = asRecord(voice.tts);
   const plugins = asRecord(parsed.plugins);
-  const qqbot = asRecord(plugins.qqbot);
   return {
     configPath: configuredPath,
     formData: {
@@ -179,8 +178,6 @@ export function loadSettingsData(contentOverride?: string): SettingsSnapshot {
       channels: {
         telegramToken: String(telegram.token ?? ""),
         qqBotUin: String(qq.bot_uin ?? ""),
-        qqBotAppId: String(qqbot.app_id ?? qqbot.appId ?? ""),
-        qqBotClientSecret: String(qqbot.client_secret ?? qqbot.clientSecret ?? ""),
       },
       memory: {
         enabled: Boolean(memory.enabled),
@@ -235,9 +232,18 @@ export function loadSettingsData(contentOverride?: string): SettingsSnapshot {
         memoryOptimizerIntervalSeconds: Number(
           agentMaintenance.memory_optimizer_interval_seconds ?? 64800,
         ),
+        // feishu is excluded because that surface was retired from the runtime
+        // (the backend rejects [plugins.feishu] outright). qqbot used to be
+        // excluded too, back when its app_id/client_secret had a bespoke
+        // round-trip through channels.qqBot*; now that it owns a schema-driven
+        // settings.section (plugins/qqbot/ui/index.tsx) instead, it flows
+        // through this generic catch-all like any other plugin without
+        // dedicated UI (#183) — dropping it here would silently lose
+        // [plugins.qqbot] on the next unrelated settings save, since this
+        // whole document is rebuilt from formData on every save.
         pluginsRawToml: renderPluginBlocks(
           Object.entries(plugins)
-            .filter(([name]) => name !== "qqbot" && name !== "feishu")
+            .filter(([name]) => name !== "feishu")
             .map(([name, value]) => renderPluginSection(name, asRecord(value)))
             .join("\n"),
         ).trimEnd(),
@@ -296,10 +302,6 @@ function renderSettingsToml(formData: SettingsFormData): string {
     "[channels.qq]",
     `bot_uin = ${quote(formData.channels.qqBotUin)}`,
     "websocket_open_timeout_seconds = 5",
-    "",
-    "[plugins.qqbot]",
-    `app_id = ${quote(formData.channels.qqBotAppId)}`,
-    `client_secret = ${quote(formData.channels.qqBotClientSecret)}`,
     "",
     "[memory]",
     `enabled = ${formData.memory.enabled ? "true" : "false"}`,

--- a/plugins/akasha/backend/plugin.py
+++ b/plugins/akasha/backend/plugin.py
@@ -3,13 +3,15 @@ from __future__ import annotations
 import json
 from datetime import datetime
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 from zoneinfo import ZoneInfo
 
 from agent.lifecycle.types import BeforeTurnCtx, TurnState
-from agent.plugins import Plugin
 from plugins.akasha.backend.config import load_akasha_config, resolve_akasha_db_path
 from plugins.akasha.backend.store import AkashaStore
+
+if TYPE_CHECKING:
+    from agent.plugin_host.runtime_context import PluginRuntimeContext
 
 _CTX_SLOT = "session:ctx"
 _BEIJING_TZ = ZoneInfo("Asia/Shanghai")
@@ -20,8 +22,8 @@ class AkashaLastCommandModule:
     requires = ("before_turn.acquire_session", "session:session")
     produces = (_CTX_SLOT,)
 
-    def __init__(self, plugin: "AkashaPlugin") -> None:
-        self._plugin = plugin
+    def __init__(self, workspace: Path | None) -> None:
+        self._workspace = workspace
 
     async def run(self, frame: Any) -> Any:
         if _CTX_SLOT in frame.slots:
@@ -30,56 +32,56 @@ class AkashaLastCommandModule:
         command = _normalize_command(state.msg.content)
         if command not in {"/akashalast", "/akasha_last"}:
             return frame
-        if not self._plugin.is_active():
-            return frame
         frame.slots[_CTX_SLOT] = _abort_ctx(
             state,
-            self._plugin.render_last_query(state.session_key),
+            render_last_query(self._workspace, state.session_key),
         )
         return frame
 
 
-class AkashaPlugin(Plugin):
-    name = "akasha"
+async def setup(ctx: "PluginRuntimeContext") -> None:
+    """装配 akasha 插件壳：仅当当前记忆引擎是 akasha 时贡献 /akashalast 命令与查询模块。
 
-    def telegram_bot_commands(self) -> list[tuple[str, str]]:
-        if not self.is_active():
-            return []
-        return [("akashalast", "查看上一轮 Akasha 检索诊断")]
+    记忆引擎本体（``AkashaMemoryEngine`` / ``MemoryPlugin``）不在此文件，由
+    ``core.memory.plugin`` 的独立契约装配（见同目录 ``memory_plugin.py``），
+    经 ``bootstrap/wiring.py`` 的 ``resolve_memory_plugin`` 接线，不受本次插件
+    系统迁移影响；这里只是给它接一个 v2 生命周期壳。
 
-    def before_turn_modules(self) -> list[object]:
-        if not self.is_active():
-            return []
-        return [AkashaLastCommandModule(self)]
+    是否激活只在装配时判定一次：``ctx.memory_engine`` 在同一次 kernel
+    generation 内固定不变（由 bootstrap 在构造 ``HostServices`` 时一次性注入），
+    与旧 ``is_active()`` 每次调用时动态判定的效果等价，因此不再需要
+    ``AkashaLastCommandModule.run()`` 内部重复判定。
+    """
+    if not _is_memory_engine(ctx.memory_engine, "akasha"):
+        return
+    ctx.bot_commands.add("akashalast", "查看上一轮 Akasha 检索诊断")
+    ctx.lifecycle.contribute("before_turn", [AkashaLastCommandModule(ctx.workspace)])
 
-    def is_active(self) -> bool:
-        return _is_memory_engine(getattr(self.context, "memory_engine", None), "akasha")
 
-    def render_last_query(self, session_key: str) -> str:
-        workspace = self.context.workspace
-        if workspace is None:
-            return "Akasha 诊断不可用：workspace 不存在。"
-        store = AkashaStore(
-            resolve_akasha_db_path(
-                workspace=workspace,
-                akasha_config=load_akasha_config(plugin_dir=Path(__file__).resolve().parent),
-            )
+def render_last_query(workspace: Path | None, session_key: str) -> str:
+    if workspace is None:
+        return "Akasha 诊断不可用：workspace 不存在。"
+    store = AkashaStore(
+        resolve_akasha_db_path(
+            workspace=workspace,
+            akasha_config=load_akasha_config(plugin_dir=Path(__file__).resolve().parent),
         )
-        try:
-            rows, _ = store.list_query_logs(
-                session_key=session_key,
-                page=1,
-                page_size=1,
-            )
-            if not rows:
-                return "暂无 Akasha 检索诊断记录。"
-            query_id = str(rows[0]["query_id"])
-            raw = store.get_query_log(query_id)
-        finally:
-            store.close()
-        if raw is None:
+    )
+    try:
+        rows, _ = store.list_query_logs(
+            session_key=session_key,
+            page=1,
+            page_size=1,
+        )
+        if not rows:
             return "暂无 Akasha 检索诊断记录。"
-        return _render_query_detail(raw)
+        query_id = str(rows[0]["query_id"])
+        raw = store.get_query_log(query_id)
+    finally:
+        store.close()
+    if raw is None:
+        return "暂无 Akasha 检索诊断记录。"
+    return _render_query_detail(raw)
 
 
 def _render_query_detail(raw: dict[str, object]) -> str:

--- a/plugins/akasha/manifest.yaml
+++ b/plugins/akasha/manifest.yaml
@@ -1,0 +1,8 @@
+api: 2
+id: akasha
+desc: Akasha 记忆引擎的插件壳（/akashalast 诊断命令）；引擎本体由 core.memory.plugin 独立接线
+capabilities:
+  - memory_engine
+  - workspace
+  - bot_commands
+  - lifecycle

--- a/plugins/akasha/tests/test_plugin.py
+++ b/plugins/akasha/tests/test_plugin.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
+import asyncio
 import json
+import shutil
 import sqlite3
+import tempfile
 import threading
 from contextlib import closing
 from datetime import datetime, timezone
@@ -13,10 +16,10 @@ from unittest.mock import AsyncMock
 import pytest
 import numpy as np
 
+from agent.plugin_host import HostServices, PluginKernel
 from bus.event_bus import EventBus
 from bus.events_lifecycle import RoleDeleted, TurnCommitted
 from core.memory.engine import MemoryQuery, MemoryQueryIntent, MemoryScope
-from agent.plugins.context import PluginContext, PluginKVStore
 from agent.config_models import Config, MemoryConfig, MemoryEmbeddingConfig
 from plugins.akasha.backend.config import AkashaConfig
 from plugins.akasha.backend.engine import (
@@ -35,7 +38,7 @@ from plugins.akasha.backend.core import (
     dense_message_candidates,
     reinforce_boost_from_payload,
 )
-from plugins.akasha.backend.plugin import AkashaPlugin
+from plugins.akasha.backend.plugin import render_last_query
 from plugins.akasha.backend.replay import AkashaReplayRuntime, ReplayMessage, _turn_messages
 from plugins.akasha.backend.store import (
     ActivationEventRow,
@@ -47,6 +50,7 @@ from scripts.build_akasha_db import _iter_replay_turns, _load_embeddings_from_ca
 
 
 QUERY_TS = datetime.fromtimestamp(1_700_000_000.0, timezone.utc)
+_AKASHA_PLUGIN_ROOT = Path(__file__).resolve().parents[1]
 
 
 def _init_sessions_db(path: Path) -> None:
@@ -1263,32 +1267,35 @@ def test_undo_removes_akasha_turn_state_after_session_delete(tmp_path: Path) -> 
         store.close()
 
 
+def _load_akasha_kernel(*, memory_engine: object, workspace: Path) -> Any:
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "akasha"
+        shutil.copytree(_AKASHA_PLUGIN_ROOT, plugin_dir)
+        kernel = PluginKernel(
+            [Path(tmp)],
+            services=HostServices(
+                event_bus=EventBus(), workspace=workspace, memory_engine=memory_engine,
+            ),
+        )
+        asyncio.run(kernel.load_all())
+        assert kernel.loaded_count == 1
+        return kernel.telegram_bot_commands, kernel.before_turn_modules
+
+
 def test_akashalast_command_only_registers_for_akasha_engine(tmp_path: Path) -> None:
-    akasha = AkashaPlugin()
-    akasha.context = PluginContext(
-        event_bus=None,
-        tool_registry=None,
-        plugin_id="akasha",
-        plugin_dir=tmp_path,
-        kv_store=PluginKVStore(tmp_path / ".akasha-kv.json"),
-        workspace=tmp_path,
+    akasha_commands, akasha_modules = _load_akasha_kernel(
         memory_engine=SimpleNamespace(describe=lambda: SimpleNamespace(name="akasha")),
-    )
-    default = AkashaPlugin()
-    default.context = PluginContext(
-        event_bus=None,
-        tool_registry=None,
-        plugin_id="akasha",
-        plugin_dir=tmp_path,
-        kv_store=PluginKVStore(tmp_path / ".default-kv.json"),
         workspace=tmp_path,
+    )
+    default_commands, default_modules = _load_akasha_kernel(
         memory_engine=SimpleNamespace(describe=lambda: SimpleNamespace(name="default")),
+        workspace=tmp_path,
     )
 
-    assert akasha.telegram_bot_commands() == [("akashalast", "查看上一轮 Akasha 检索诊断")]
-    assert len(akasha.before_turn_modules()) == 1
-    assert default.telegram_bot_commands() == []
-    assert default.before_turn_modules() == []
+    assert akasha_commands == [("akashalast", "查看上一轮 Akasha 检索诊断")]
+    assert len(akasha_modules) == 1
+    assert default_commands == []
+    assert default_modules == []
 
 
 def test_akashalast_renders_latest_query_log(tmp_path: Path) -> None:
@@ -1348,18 +1355,7 @@ def test_akashalast_renders_latest_query_log(tmp_path: Path) -> None:
     finally:
         store.close()
 
-    plugin = AkashaPlugin()
-    plugin.context = PluginContext(
-        event_bus=None,
-        tool_registry=None,
-        plugin_id="akasha",
-        plugin_dir=tmp_path,
-        kv_store=PluginKVStore(tmp_path / ".kv.json"),
-        workspace=tmp_path,
-        memory_engine=SimpleNamespace(describe=lambda: SimpleNamespace(name="akasha")),
-    )
-
-    reply = plugin.render_last_query("s")
+    reply = render_last_query(tmp_path, "s")
 
     assert "🧠 Akasha 记忆检索诊断" in reply
     assert "📍 会话: `s` | seq `2`" in reply

--- a/plugins/default_memory/backend/plugin.py
+++ b/plugins/default_memory/backend/plugin.py
@@ -6,10 +6,12 @@ import re
 import threading
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from agent.lifecycle.types import AfterToolResultCtx, BeforeTurnCtx
-from agent.plugins import Plugin, on_tool_result
+
+if TYPE_CHECKING:
+    from agent.plugin_host.runtime_context import PluginRuntimeContext
 
 _CTX_SLOT = "session:ctx"
 _ITEM_LINE_RE = re.compile(r"^-\s+\[([^\]]+)\]\s*(.*)$")
@@ -20,34 +22,33 @@ class ContextPrepareRecordModule:
     slot = "default_memory.inspector"
     requires = ("before_turn.emit", _CTX_SLOT)
 
-    def __init__(self, plugin: "DefaultMemoryInspector") -> None:
-        self._plugin = plugin
+    def __init__(self, recorder: "_DefaultMemoryRecorder") -> None:
+        self._recorder = recorder
 
     async def run(self, frame: Any) -> Any:
         ctx = frame.slots.get(_CTX_SLOT)
         if isinstance(ctx, BeforeTurnCtx):
-            self._plugin.record_context_prepare(ctx)
+            self._recorder.record_context_prepare(ctx)
         return frame
 
 
-class DefaultMemoryInspector(Plugin):
-    name = "default_memory"
+class _DefaultMemoryRecorder:
+    """记录 default 记忆引擎的检索/召回轨迹到 workspace 下的 jsonl 文件。
 
-    async def initialize(self) -> None:
-        self._active = _is_memory_engine(self.context.memory_engine, "default")
+    是否激活只在装配时判定一次（与旧 initialize() 里的一次性判定等价，见
+    setup() 文档）；两个记录入口（before_turn 模块、AFTER_TOOL_RESULT 事件）
+    共享同一份状态，因此收进一个小类而不是两处散落的闭包。
+    """
+
+    def __init__(self, *, active: bool, data_path: Path) -> None:
+        self._active = active
         self._lock = threading.RLock()
         self._active_turns: dict[str, str] = {}
-        self._data_path = _data_path(
-            plugin_dir=self.context.plugin_dir,
-            workspace=self.context.workspace,
-        )
+        self._data_path = data_path
         self._data_path.parent.mkdir(parents=True, exist_ok=True)
 
-    def before_turn_modules(self) -> list[object]:
-        return [ContextPrepareRecordModule(self)]
-
     def record_context_prepare(self, event: BeforeTurnCtx) -> None:
-        if not getattr(self, "_active", False):
+        if not self._active:
             return
         turn_id = _turn_id(event.session_key, event.timestamp.isoformat(), event.content)
         self._active_turns[event.session_key] = turn_id
@@ -75,9 +76,8 @@ class DefaultMemoryInspector(Plugin):
             }
         )
 
-    @on_tool_result()
     async def record_recall_memory(self, event: AfterToolResultCtx) -> None:
-        if not getattr(self, "_active", False) or event.tool_name != "recall_memory":
+        if not self._active or event.tool_name != "recall_memory":
             return
         turn_id = self._active_turns.get(event.session_key)
         if not turn_id:
@@ -116,6 +116,24 @@ class DefaultMemoryInspector(Plugin):
         with self._lock:
             with self._data_path.open("a", encoding="utf-8") as fh:
                 _ = fh.write(line + "\n")
+
+
+async def setup(ctx: "PluginRuntimeContext") -> None:
+    """装配 default_memory 插件壳：贡献 before_turn 检索记录模块与 recall_memory 工具结果记录。
+
+    记忆引擎本体（``DefaultMemoryEngine`` / ``MemoryPlugin``）不在此文件，由
+    ``core.memory.plugin`` 的独立契约装配（见同目录 ``memory_plugin.py``），
+    不受本次插件系统迁移影响；这里只是给它接一个 v2 生命周期壳。
+
+    是否激活只在装配时判定一次：``ctx.memory_engine`` 在同一次 kernel
+    generation 内固定不变，与旧 ``initialize()`` 里的一次性判定效果等价。
+    """
+    recorder = _DefaultMemoryRecorder(
+        active=_is_memory_engine(ctx.memory_engine, "default"),
+        data_path=_data_path(plugin_dir=ctx.plugin_dir, workspace=ctx.workspace),
+    )
+    ctx.lifecycle.contribute("before_turn", [ContextPrepareRecordModule(recorder)])
+    ctx.events.on(AfterToolResultCtx, recorder.record_recall_memory)
 
 
 def _turn_id(session_key: str, timestamp: str, content: str) -> str:

--- a/plugins/default_memory/manifest.yaml
+++ b/plugins/default_memory/manifest.yaml
@@ -1,0 +1,8 @@
+api: 2
+id: default_memory
+desc: default 记忆引擎的插件壳（检索/召回轨迹记录）；引擎本体由 core.memory.plugin 独立接线
+capabilities:
+  - memory_engine
+  - workspace
+  - lifecycle
+  - events

--- a/plugins/default_memory/tests/test_plugin.py
+++ b/plugins/default_memory/tests/test_plugin.py
@@ -1,0 +1,218 @@
+from __future__ import annotations
+
+import json
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from agent.lifecycle.types import AfterToolResultCtx, BeforeTurnCtx
+from agent.plugin_host import HostServices, PluginKernel
+from bus.event_bus import EventBus
+from plugins.default_memory.backend.plugin import (
+    ContextPrepareRecordModule,
+    _DefaultMemoryRecorder,
+)
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _before_turn_ctx(**overrides: object) -> BeforeTurnCtx:
+    defaults: dict[str, object] = dict(
+        session_key="cli:1",
+        channel="cli",
+        chat_id="1",
+        content="hello",
+        timestamp=datetime.now(timezone.utc),
+        retrieved_memory_block="",
+        retrieval_trace_raw=None,
+        history_messages=(),
+    )
+    defaults.update(overrides)
+    return BeforeTurnCtx(**defaults)
+
+
+def _read_jsonl(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines() if line]
+
+
+# ── _DefaultMemoryRecorder / ContextPrepareRecordModule 单元行为 ──────────────
+
+
+def test_recorder_skips_when_inactive(tmp_path: Path) -> None:
+    recorder = _DefaultMemoryRecorder(active=False, data_path=tmp_path / "trace.jsonl")
+
+    recorder.record_context_prepare(_before_turn_ctx())
+
+    assert not (tmp_path / "trace.jsonl").exists()
+
+
+def test_recorder_records_context_prepare_when_active(tmp_path: Path) -> None:
+    data_path = tmp_path / "trace.jsonl"
+    recorder = _DefaultMemoryRecorder(active=True, data_path=data_path)
+
+    recorder.record_context_prepare(
+        _before_turn_ctx(retrieved_memory_block="## profile\n- [id1] 摘要文本")
+    )
+
+    rows = _read_jsonl(data_path)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "context_prepare"
+    assert rows[0]["session_key"] == "cli:1"
+    assert rows[0]["context_prepare"]["injected_items"][0]["id"] == "id1"
+
+
+@pytest.mark.asyncio
+async def test_context_prepare_module_delegates_to_recorder(tmp_path: Path) -> None:
+    data_path = tmp_path / "trace.jsonl"
+    recorder = _DefaultMemoryRecorder(active=True, data_path=data_path)
+    module = ContextPrepareRecordModule(recorder)
+    frame = SimpleNamespace(slots={"session:ctx": _before_turn_ctx()})
+
+    result = await module.run(frame)
+
+    assert result is frame
+    assert len(_read_jsonl(data_path)) == 1
+
+
+@pytest.mark.asyncio
+async def test_recall_memory_recorded_only_for_matching_tool_when_active(tmp_path: Path) -> None:
+    data_path = tmp_path / "trace.jsonl"
+    recorder = _DefaultMemoryRecorder(active=True, data_path=data_path)
+
+    await recorder.record_recall_memory(
+        AfterToolResultCtx(
+            session_key="cli:1",
+            channel="cli",
+            chat_id="1",
+            tool_name="other_tool",
+            arguments={},
+            result="{}",
+            status="ok",
+        )
+    )
+    assert _read_jsonl(data_path) == []
+
+    await recorder.record_recall_memory(
+        AfterToolResultCtx(
+            session_key="cli:1",
+            channel="cli",
+            chat_id="1",
+            tool_name="recall_memory",
+            arguments={"query": "q"},
+            result=json.dumps({"items": [{"id": "m1"}]}),
+            status="ok",
+        )
+    )
+    rows = _read_jsonl(data_path)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "recall_memory"
+    assert rows[0]["recall_memory"]["count"] == 1
+
+
+# ── setup(ctx) 通过真实内核装配的端到端验证 ────────────────────────────────
+
+
+def _load_default_memory_kernel(
+    *, tmp_path: Path, memory_engine: object, workspace: Path
+) -> tuple[PluginKernel, EventBus]:
+    root = tmp_path / "plugins"
+    root.mkdir()
+    shutil.copytree(
+        _REPO_ROOT / "plugins" / "default_memory", root / "default_memory"
+    )
+    bus = EventBus()
+    kernel = PluginKernel(
+        [root],
+        services=HostServices(
+            event_bus=bus, workspace=workspace, memory_engine=memory_engine
+        ),
+    )
+    return kernel, bus
+
+
+@pytest.mark.asyncio
+async def test_setup_wires_before_turn_module_and_tool_result_event(tmp_path: Path) -> None:
+    """setup(ctx) 必须与旧 DefaultMemoryInspector 等价：贡献 before_turn 模块，
+    并把 recall_memory 工具结果记录经 AFTER_TOOL_RESULT 事件接线。"""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kernel, bus = _load_default_memory_kernel(
+        tmp_path=tmp_path,
+        memory_engine=SimpleNamespace(describe=lambda: SimpleNamespace(name="default")),
+        workspace=workspace,
+    )
+    await kernel.load_all()
+
+    assert [type(m).__name__ for m in kernel.before_turn_modules] == [
+        "ContextPrepareRecordModule"
+    ]
+
+    data_path = workspace / "observe" / "recall_inspector.jsonl"
+    _ = await bus.emit(
+        AfterToolResultCtx(
+            session_key="cli:1",
+            channel="cli",
+            chat_id="1",
+            tool_name="recall_memory",
+            arguments={"query": "q"},
+            result=json.dumps({"items": []}),
+            status="ok",
+        )
+    )
+    rows = _read_jsonl(data_path)
+    assert len(rows) == 1
+    assert rows[0]["kind"] == "recall_memory"
+
+    # 卸载后贡献必须整体撤回，证明 phase 槽位与事件订阅都挂在插件作用域上
+    _ = await kernel.unload("default_memory")
+    assert kernel.before_turn_modules == []
+    _ = await bus.emit(
+        AfterToolResultCtx(
+            session_key="cli:1",
+            channel="cli",
+            chat_id="1",
+            tool_name="recall_memory",
+            arguments={},
+            result="{}",
+            status="ok",
+        )
+    )
+    assert len(_read_jsonl(data_path)) == 1
+
+
+@pytest.mark.asyncio
+async def test_setup_still_wires_module_but_recorder_is_inactive_for_other_engine(
+    tmp_path: Path,
+) -> None:
+    """引擎不是 default 时模块仍会贡献（对齐旧行为），但记录内部被抑制。"""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kernel, bus = _load_default_memory_kernel(
+        tmp_path=tmp_path,
+        memory_engine=SimpleNamespace(describe=lambda: SimpleNamespace(name="akasha")),
+        workspace=workspace,
+    )
+    await kernel.load_all()
+
+    assert [type(m).__name__ for m in kernel.before_turn_modules] == [
+        "ContextPrepareRecordModule"
+    ]
+
+    _ = await bus.emit(
+        AfterToolResultCtx(
+            session_key="cli:1",
+            channel="cli",
+            chat_id="1",
+            tool_name="recall_memory",
+            arguments={},
+            result="{}",
+            status="ok",
+        )
+    )
+    assert not (workspace / "observe" / "recall_inspector.jsonl").exists()

--- a/plugins/observe/backend/plugin.py
+++ b/plugins/observe/backend/plugin.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from collections.abc import Mapping
-from contextlib import suppress
-from typing import Protocol, cast, runtime_checkable
+from typing import TYPE_CHECKING, cast
 
-from agent.plugins import Plugin
 from bus.events_lifecycle import TurnCommitted
 from core.memory.events import MemoryWritten, RetrievalCompleted
 
@@ -15,72 +12,55 @@ from .collector import GlobalErrorCollector
 from .retention import run_retention_if_needed
 from .writer import TraceWriter
 
+if TYPE_CHECKING:
+    from agent.plugin_host.runtime_context import PluginRuntimeContext
+
 logger = logging.getLogger("plugin.observe")
 
 
-@runtime_checkable
-class _ObserveWriter(Protocol):
-    def emit(self, event: object) -> None: ...
+async def setup(ctx: "PluginRuntimeContext") -> None:
+    """装配 observe：workspace 存在时启动 writer/retention 后台任务并订阅遥测事件。
+
+    登记顺序刻意保持 [writer 后台任务, retention 后台任务, 全局错误采集器,
+    三个事件订阅]：卸载按 LIFO 逆序处置，因此实际清理顺序是
+    事件订阅 -> 采集器 uninstall（把内存中缓冲的错误 flush 进队列）->
+    retention 任务取消 -> writer 任务最后取消，writer 任务的取消时机晚于
+    采集器 flush，保证 flush 出的最后一批错误仍有机会被 writer 写盘——
+    与旧 terminate() 里"先 uninstall 采集器、再依次取消 retention/writer"的
+    手写顺序等价（#183）。
+    """
+    workspace = ctx.workspace
+    if workspace is None:
+        logger.warning("observe 插件缺少 workspace，跳过加载")
+        return
+
+    db_path = workspace / "observe" / "observe.db"
+    writer = TraceWriter(db_path)
+    _ = ctx.background.spawn(writer.run(), name="writer")
+    _ = ctx.background.spawn(run_retention_if_needed(db_path), name="retention")
+
+    collector = GlobalErrorCollector(writer)
+    collector.install()
+    ctx.effect("collector", collector.uninstall)
+
+    ctx.events.on(TurnCommitted, lambda event: _observe_turn_committed(writer, event))
+    ctx.events.on(RetrievalCompleted, lambda event: _observe_retrieval(writer, event))
+    ctx.events.on(MemoryWritten, lambda event: _observe_memory_written(writer, event))
 
 
-class ObservePlugin(Plugin):
-    name = "observe"
-
-    async def initialize(self) -> None:
-        workspace = self.context.workspace
-        if workspace is None:
-            logger.warning("observe 插件缺少 workspace，跳过加载")
-            return
-
-        self._writer = TraceWriter(workspace / "observe" / "observe.db")
-        self._writer_task = asyncio.create_task(
-            self._writer.run(),
-            name="observe_writer",
-        )
-        self._retention_task = asyncio.create_task(
-            run_retention_if_needed(workspace / "observe" / "observe.db"),
-            name="observe_retention",
-        )
-        self._collector = GlobalErrorCollector(self._writer)
-        self._collector.install()
-        self.context.event_bus.on(TurnCommitted, self._observe_turn_committed)
-        self.context.event_bus.on(RetrievalCompleted, self._observe_retrieval)
-        self.context.event_bus.on(MemoryWritten, self._observe_memory_written)
-
-    async def terminate(self) -> None:
-        collector = getattr(self, "_collector", None)
-        if collector is not None:
-            await collector.uninstall()
-        for task in (
-            getattr(self, "_retention_task", None),
-            getattr(self, "_writer_task", None),
-        ):
-            if task is None:
-                continue
-            _ = task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
-
-    def _observe_turn_committed(self, event: TurnCommitted) -> None:
-        writer = getattr(self, "_writer", None)
-        if not isinstance(writer, _ObserveWriter):
-            return
-        _emit_turn_trace(writer, event)
-
-    def _observe_retrieval(self, event: RetrievalCompleted) -> None:
-        writer = getattr(self, "_writer", None)
-        if not isinstance(writer, _ObserveWriter):
-            return
-        writer.emit(_to_rag_query_log(event))
-
-    def _observe_memory_written(self, event: MemoryWritten) -> None:
-        writer = getattr(self, "_writer", None)
-        if not isinstance(writer, _ObserveWriter):
-            return
-        writer.emit(_to_memory_write_trace(event))
+def _observe_turn_committed(writer: TraceWriter, event: TurnCommitted) -> None:
+    _emit_turn_trace(writer, event)
 
 
-def _emit_turn_trace(writer: _ObserveWriter, event: TurnCommitted) -> None:
+def _observe_retrieval(writer: TraceWriter, event: RetrievalCompleted) -> None:
+    writer.emit(_to_rag_query_log(event))
+
+
+def _observe_memory_written(writer: TraceWriter, event: MemoryWritten) -> None:
+    writer.emit(_to_memory_write_trace(event))
+
+
+def _emit_turn_trace(writer: TraceWriter, event: TurnCommitted) -> None:
     from .events import TurnTrace as TurnTraceEvent
 
     post_reply_budget = event.post_reply_budget

--- a/plugins/observe/manifest.yaml
+++ b/plugins/observe/manifest.yaml
@@ -1,0 +1,7 @@
+api: 2
+id: observe
+desc: 零埋点全链路遥测采集（turn trace / RAG 检索 / 记忆写入 / 全局错误）
+capabilities:
+  - workspace
+  - events
+  - background

--- a/plugins/observe/tests/test_plugin.py
+++ b/plugins/observe/tests/test_plugin.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import shutil
 import sqlite3
 from contextlib import closing
@@ -11,6 +12,7 @@ import pytest
 from agent.plugin_host import HostServices, PluginKernel
 from bus.event_bus import EventBus
 from bus.events_lifecycle import TurnCommitted
+from core.memory.events import MemoryWritten, RetrievalCompleted, RetrievalHitSummary
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
@@ -40,14 +42,58 @@ def _turn_committed(**overrides: object) -> TurnCommitted:
     return TurnCommitted(**defaults)
 
 
+def _retrieval_completed(**overrides: object) -> RetrievalCompleted:
+    defaults: dict[str, object] = dict(
+        session_key="cli:1",
+        channel="cli",
+        chat_id="1",
+        query="改写问题",
+        orig_query="原始问题",
+        hits=[
+            RetrievalHitSummary(
+                item_id="mem_1",
+                memory_type="event",
+                # summary 故意超过 120 字符，证明 _to_rag_query_log 的截断逻辑真的跑了，
+                # 而不只是原样透传。
+                score=0.9,
+                summary="命中的记忆" * 30,
+                injected=True,
+            )
+        ],
+        injected_count=1,
+        route_decision="RETRIEVE",
+        aux_queries=["假想问题"],
+    )
+    defaults.update(overrides)
+    return RetrievalCompleted(**defaults)
+
+
+def _memory_written(**overrides: object) -> MemoryWritten:
+    defaults: dict[str, object] = dict(
+        session_key="cli:1",
+        channel="cli",
+        chat_id="1",
+        action="supersede",
+        source_ref="cli:1@post_response",
+        superseded_ids=["mem_1"],
+    )
+    defaults.update(overrides)
+    return MemoryWritten(**defaults)
+
+
 async def _wait_for_turn_row(db_path: Path, *, timeout: float = 5.0) -> int:
     """Polls observe.db until the async writer task has committed a row."""
+    return await _wait_for_table_count(db_path, "turns", timeout=timeout)
+
+
+async def _wait_for_table_count(db_path: Path, table: str, *, timeout: float = 5.0) -> int:
+    """Polls observe.db until the async writer task has committed a row into ``table``."""
     loop = asyncio.get_running_loop()
     deadline = loop.time() + timeout
     while loop.time() < deadline:
         if db_path.exists():
             with closing(sqlite3.connect(str(db_path))) as conn:
-                count = conn.execute("SELECT COUNT(*) FROM turns").fetchone()[0]
+                count = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
                 if count:
                     return int(count)
         await asyncio.sleep(0.02)
@@ -80,6 +126,85 @@ async def test_turn_committed_event_reaches_writer_and_is_persisted(tmp_path: Pa
     db_path = workspace / "observe" / "observe.db"
     row_count = await _wait_for_turn_row(db_path)
     assert row_count == 1
+
+
+@pytest.mark.asyncio
+async def test_retrieval_completed_event_translated_and_persisted(tmp_path: Path) -> None:
+    """RetrievalCompleted 订阅必须真正落库，且经 _to_rag_query_log 翻译
+    （截断 summary 到 120 字符、映射 hits_json）——不是只订阅了事件却没接对
+    翻译函数。"""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kernel, bus = _load_observe_kernel(tmp_path, workspace=workspace)
+    await kernel.load_all()
+
+    db_path = workspace / "observe" / "observe.db"
+    _ = await bus.emit(_retrieval_completed())
+    row_count = await _wait_for_table_count(db_path, "rag_queries")
+    assert row_count == 1
+
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        row = conn.execute(
+            """SELECT caller, session_key, query, orig_query, aux_queries,
+                      hits_json, injected_count, route_decision, error
+               FROM rag_queries"""
+        ).fetchone()
+
+    (
+        caller, session_key, query, orig_query, aux_queries_json,
+        hits_json, injected_count, route_decision, error,
+    ) = row
+    assert caller == "passive"
+    assert session_key == "cli:1"
+    assert query == "改写问题"
+    assert orig_query == "原始问题"
+    assert json.loads(aux_queries_json) == ["假想问题"]
+    assert injected_count == 1
+    assert route_decision == "RETRIEVE"
+    assert error is None
+
+    hits = json.loads(hits_json)
+    assert len(hits) == 1
+    # 翻译函数把 summary 截到 120 字符（RagHitLog 构造时做的），源 summary 是
+    # "命中的记忆" * 30 = 150 字符；证明截断逻辑真的跑了，而不是原样透传。
+    assert hits[0]["id"] == "mem_1"
+    assert hits[0]["type"] == "event"
+    assert hits[0]["score"] == 0.9
+    assert hits[0]["injected"] is True
+    assert len(hits[0]["summary"]) == 120
+    assert hits[0]["summary"] == ("命中的记忆" * 30)[:120]
+
+
+@pytest.mark.asyncio
+async def test_memory_written_event_translated_and_persisted(tmp_path: Path) -> None:
+    """MemoryWritten 订阅必须真正落库，且经 _to_memory_write_trace 翻译
+    （action/source_ref/superseded_ids 映射到对应列）。"""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kernel, bus = _load_observe_kernel(tmp_path, workspace=workspace)
+    await kernel.load_all()
+
+    db_path = workspace / "observe" / "observe.db"
+    _ = await bus.emit(_memory_written())
+    row_count = await _wait_for_table_count(db_path, "memory_writes")
+    assert row_count == 1
+
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        row = conn.execute(
+            """SELECT session_key, source_ref, action, memory_type, item_id,
+                      summary, superseded_ids, error
+               FROM memory_writes"""
+        ).fetchone()
+
+    session_key, source_ref, action, memory_type, item_id, summary, superseded_ids_json, error = row
+    assert session_key == "cli:1"
+    assert source_ref == "cli:1@post_response"
+    assert action == "supersede"
+    assert memory_type is None
+    assert item_id is None
+    assert summary is None
+    assert json.loads(superseded_ids_json) == ["mem_1"]
+    assert error is None
 
 
 @pytest.mark.asyncio

--- a/plugins/observe/tests/test_plugin.py
+++ b/plugins/observe/tests/test_plugin.py
@@ -1,0 +1,107 @@
+from __future__ import annotations
+
+import asyncio
+import shutil
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+from agent.plugin_host import HostServices, PluginKernel
+from bus.event_bus import EventBus
+from bus.events_lifecycle import TurnCommitted
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_observe_kernel(
+    tmp_path: Path, *, workspace: Path | None
+) -> tuple[PluginKernel, EventBus]:
+    root = tmp_path / "plugins"
+    root.mkdir()
+    shutil.copytree(_REPO_ROOT / "plugins" / "observe", root / "observe")
+    bus = EventBus()
+    kernel = PluginKernel([root], services=HostServices(event_bus=bus, workspace=workspace))
+    return kernel, bus
+
+
+def _turn_committed(**overrides: object) -> TurnCommitted:
+    defaults: dict[str, object] = dict(
+        session_key="cli:1",
+        channel="cli",
+        chat_id="1",
+        input_message="hi",
+        persisted_user_message="hi",
+        assistant_response="hello",
+        tools_used=[],
+    )
+    defaults.update(overrides)
+    return TurnCommitted(**defaults)
+
+
+async def _wait_for_turn_row(db_path: Path, *, timeout: float = 5.0) -> int:
+    """Polls observe.db until the async writer task has committed a row."""
+    loop = asyncio.get_running_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if db_path.exists():
+            with closing(sqlite3.connect(str(db_path))) as conn:
+                count = conn.execute("SELECT COUNT(*) FROM turns").fetchone()[0]
+                if count:
+                    return int(count)
+        await asyncio.sleep(0.02)
+    return 0
+
+
+@pytest.mark.asyncio
+async def test_setup_skips_without_workspace(tmp_path: Path) -> None:
+    """workspace 缺失时插件仍加载成功但不贡献任何行为，对齐旧 initialize() 的早退。"""
+    kernel, _bus = _load_observe_kernel(tmp_path, workspace=None)
+
+    await kernel.load_all()
+
+    assert kernel.loaded_count == 1
+    _ = await kernel.terminate_all()
+
+
+@pytest.mark.asyncio
+async def test_turn_committed_event_reaches_writer_and_is_persisted(tmp_path: Path) -> None:
+    """setup() 必须与旧 ObservePlugin.initialize() 等价：TurnCommitted 经事件订阅
+    真正写入 observe.db（而不仅仅是"没抛异常"）。"""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kernel, bus = _load_observe_kernel(tmp_path, workspace=workspace)
+    await kernel.load_all()
+    assert kernel.loaded_count == 1
+
+    _ = await bus.emit(_turn_committed())
+
+    db_path = workspace / "observe" / "observe.db"
+    row_count = await _wait_for_turn_row(db_path)
+    assert row_count == 1
+
+
+@pytest.mark.asyncio
+async def test_unload_cancels_background_tasks_and_uninstalls_collector_cleanly(
+    tmp_path: Path,
+) -> None:
+    """卸载必须干净收尾：不抛异常，且卸载后事件不再落库（effect 真正生效）。"""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    kernel, bus = _load_observe_kernel(tmp_path, workspace=workspace)
+    await kernel.load_all()
+    _ = await bus.emit(_turn_committed(session_key="cli:1"))
+    db_path = workspace / "observe" / "observe.db"
+    _ = await _wait_for_turn_row(db_path)
+
+    errors = await kernel.unload("observe")
+    assert errors == []
+
+    # 卸载后订阅应已随 effect 撤销；再 emit 不应再增加行数
+    row_count_before = await _wait_for_turn_row(db_path, timeout=0.2)
+    _ = await bus.emit(_turn_committed(session_key="cli:2"))
+    await asyncio.sleep(0.1)
+    with closing(sqlite3.connect(str(db_path))) as conn:
+        row_count_after = conn.execute("SELECT COUNT(*) FROM turns").fetchone()[0]
+    assert row_count_after == row_count_before

--- a/plugins/qqbot/backend/plugin.py
+++ b/plugins/qqbot/backend/plugin.py
@@ -1,16 +1,14 @@
 from __future__ import annotations
 
 import re
-from typing import TYPE_CHECKING, cast
+from typing import TYPE_CHECKING
 
 from pydantic import AliasChoices, BaseModel, Field, field_validator
-
-from agent.plugins import Plugin
 
 from .channel import QQBotChannel
 
 if TYPE_CHECKING:
-    from infra.channels.contract import Channel
+    from agent.plugin_host.runtime_context import PluginRuntimeContext
 
 _UNRESOLVED_ENV_RE = re.compile(r"^\$\{\w+\}$")
 
@@ -57,22 +55,21 @@ class QQBotConfigModel(BaseModel):
         return "" if _UNRESOLVED_ENV_RE.fullmatch(text) else text
 
 
-class QQBotPlugin(Plugin):
-    """Exposes the official QQBot channel through the plugin runtime."""
+async def setup(ctx: "PluginRuntimeContext") -> None:
+    """装配 qqbot：校验插件配置，凭据齐备时贡献官方 QQBot 渠道。
 
-    name = "qqbot"
-    desc = "官方 QQBot 渠道"
-    ConfigModel = QQBotConfigModel
-
-    def channels(self) -> list["Channel"]:
-        config = cast(QQBotConfigModel | None, self.context.config)
-        if config is None or not config.app_id or not config.client_secret:
-            return []
-        return [
-            QQBotChannel(
-                app_id=config.app_id,
-                client_secret=config.client_secret,
-                allow_from=config.allow_from,
-                groups=config.groups,
-            )
-        ]
+    行为对齐 legacy：QQBotConfigModel 校验失败时 setup() 直接抛出，交由内核的
+    通用失败回滚处理，与旧 ``_load_plugin_config`` 在校验失败时跳过插件加载
+    的语义一致；凭据缺失（非校验失败）则不贡献渠道，同样与旧 channels() 一致。
+    """
+    config = QQBotConfigModel.model_validate(ctx.config.as_dict())
+    if not config.app_id or not config.client_secret:
+        return
+    ctx.channels.add(
+        QQBotChannel(
+            app_id=config.app_id,
+            client_secret=config.client_secret,
+            allow_from=config.allow_from,
+            groups=config.groups,
+        )
+    )

--- a/plugins/qqbot/manifest.yaml
+++ b/plugins/qqbot/manifest.yaml
@@ -1,3 +1,8 @@
-name: qqbot
-version: 0.1.0
+api: 2
+id: qqbot
+version: '0.1.0'
 desc: 官方 QQBot 渠道
+capabilities:
+  - config
+  - channels
+config_model: QQBotConfigModel

--- a/plugins/qqbot/tests/test_plugin.py
+++ b/plugins/qqbot/tests/test_plugin.py
@@ -1,37 +1,83 @@
 from __future__ import annotations
 
-from types import SimpleNamespace
-from typing import cast
+import asyncio
+import shutil
+import tempfile
+from pathlib import Path
+from typing import Any
 
-from plugins.qqbot.backend.plugin import QQBotConfigModel, QQBotPlugin
+import pytest
+
+from agent.plugin_host import HostServices, PluginKernel
+from bus.event_bus import EventBus
+from plugins.qqbot.backend.plugin import QQBotConfigModel
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_qqbot_channels(plugin_configs: dict[str, dict[str, Any]] | None = None) -> list[Any]:
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "qqbot"
+        shutil.copytree(_REPO_ROOT / "plugins" / "qqbot", plugin_dir)
+        kernel = PluginKernel(
+            [Path(tmp)],
+            services=HostServices(
+                event_bus=EventBus(), plugin_configs=plugin_configs or {}
+            ),
+        )
+        asyncio.run(kernel.load_all())
+        assert kernel.loaded_count == 1
+        return kernel.channels
 
 
 def test_qqbot_plugin_skips_channel_without_credentials() -> None:
-    plugin = QQBotPlugin()
-    plugin.context = cast(object, SimpleNamespace(config=QQBotConfigModel()))
-
-    assert plugin.channels() == []
+    assert _load_qqbot_channels() == []
 
 
 def test_qqbot_plugin_accepts_legacy_config_aliases() -> None:
-    plugin = QQBotPlugin()
-    plugin.context = cast(
-        object,
-        SimpleNamespace(
-            config=QQBotConfigModel.model_validate(
-                {
-                    "appId": "app",
-                    "clientSecret": "secret",
-                    "allow_from": ["user-openid"],
-                }
-            )
-        ),
+    channels = _load_qqbot_channels(
+        {
+            "qqbot": {
+                "appId": "app",
+                "clientSecret": "secret",
+                "allow_from": ["user-openid"],
+            }
+        }
     )
-
-    channels = plugin.channels()
 
     assert len(channels) == 1
     assert channels[0].name == "qqbot"
     assert channels[0]._app_id == "app"
     assert channels[0]._client_secret == "secret"
     assert channels[0]._allow_from == {"user-openid"}
+
+
+def test_qqbot_plugin_skips_channel_when_only_app_id_present() -> None:
+    assert _load_qqbot_channels({"qqbot": {"app_id": "app"}}) == []
+
+
+def test_qqbot_config_model_validates_directly() -> None:
+    """QQBotConfigModel 的校验/别名规则单独测试，不依赖内核装配。"""
+    config = QQBotConfigModel.model_validate({"app_id": "${APP_ID}", "client_secret": "s"})
+
+    assert config.app_id == ""
+    assert config.client_secret == "s"
+
+
+@pytest.mark.asyncio
+async def test_qqbot_setup_raises_on_invalid_config_and_kernel_rolls_back() -> None:
+    """配置校验失败时插件加载失败并回滚，行为对齐旧 _load_plugin_config。"""
+    with tempfile.TemporaryDirectory() as tmp:
+        plugin_dir = Path(tmp) / "qqbot"
+        shutil.copytree(_REPO_ROOT / "plugins" / "qqbot", plugin_dir)
+        kernel = PluginKernel(
+            [Path(tmp)],
+            services=HostServices(
+                event_bus=EventBus(),
+                # allow_from 必须是 list[str]；传入非法类型触发 pydantic 校验错误
+                plugin_configs={"qqbot": {"allow_from": {"not": "a list"}}},
+            ),
+        )
+        await kernel.load_all()
+
+        assert kernel.loaded_count == 0

--- a/plugins/qqbot/ui/index.tsx
+++ b/plugins/qqbot/ui/index.tsx
@@ -1,0 +1,18 @@
+import type { PluginUiModule } from "../../../apps/desktop/renderer/src/plugins/pluginUiModuleContract";
+
+/**
+ * qqbot's own settings.section contribution (#183): its App ID/Client
+ * Secret used to live hardcoded in the core Channels settings tab and were
+ * threaded through the shared settings draft. Now that the plugin declares
+ * `config_model` (see backend/plugin.py, backend/manifest.yaml), the
+ * generic schema-driven form (`PluginSchemaSettingsSection`, wired in by
+ * `kind: "schema"` below) reads/writes `[plugins.qqbot]` directly through
+ * `plugin.config.get/set`, independent of the core settings save
+ * transaction.
+ */
+const qqbotUiModule: PluginUiModule = {
+  pluginId: "qqbot",
+  settingsSection: { kind: "schema", label: "QQBot" },
+};
+
+export default qqbotUiModule;

--- a/plugins/relationship_proactive/backend/plugin.py
+++ b/plugins/relationship_proactive/backend/plugin.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
 from agent.core.proactive_turn.gates import (
     ProactiveGateAdapter,
     ProactiveGateCompletion,
@@ -9,9 +11,11 @@ from agent.core.proactive_turn.gates import (
     ProactiveGateDecision,
     ProactiveMode,
 )
-from agent.plugins import Plugin
 from bus.events_lifecycle import SceneObservationCommitted
 from core.roles.relationship_runtime import RoleRelationshipRuntimeService
+
+if TYPE_CHECKING:
+    from agent.plugin_host.runtime_context import PluginRuntimeContext
 
 
 class _SceneFollowupGate(ProactiveGateAdapter):
@@ -70,32 +74,25 @@ class RelationshipLonelinessGate(ProactiveGateAdapter):
         )
 
 
-class RelationshipProactivePlugin(Plugin):
-    """Adapts the relationship runtime to the proactive gate seam."""
+async def setup(ctx: "PluginRuntimeContext") -> None:
+    """装配 relationship_proactive：贡献主动 tick 准入 gate 并订阅场景决策事件。
 
-    name = "relationship_proactive"
+    ``ctx.relationship_runtime`` 在同一次 kernel generation 内固定不变（由
+    bootstrap 构造 ``HostServices`` 时一次性注入），因此是否贡献 gate 只需在
+    装配时判定一次，与旧 ``proactive_gates()`` 每次调用时动态判定 None 的效果
+    等价。
+    """
+    runtime = ctx.relationship_runtime
+    if runtime is None:
+        return
 
-    async def initialize(self) -> None:
-        self._scene_handler = self._handle_scene_observation
-        self.context.event_bus.on(SceneObservationCommitted, self._scene_handler)
-
-    def _handle_scene_observation(self, event: SceneObservationCommitted) -> None:
-        runtime = self.context.relationship_runtime
-        if runtime is None:
-            return
+    def _handle_scene_observation(event: SceneObservationCommitted) -> None:
         runtime.apply_scene_decision(
             event.session_key,
             event.transition,
             event.scene_key,
         )
 
-    def proactive_gates(self):
-        runtime = self.context.relationship_runtime
-        if runtime is None:
-            return []
-        return [_SceneFollowupGate(runtime), RelationshipLonelinessGate(runtime)]
-
-    async def terminate(self) -> None:
-        handler = getattr(self, "_scene_handler", None)
-        if handler is not None:
-            self.context.event_bus.off(SceneObservationCommitted, handler)
+    ctx.events.on(SceneObservationCommitted, _handle_scene_observation)
+    ctx.proactive_gates.add(_SceneFollowupGate(runtime))
+    ctx.proactive_gates.add(RelationshipLonelinessGate(runtime))

--- a/plugins/relationship_proactive/manifest.yaml
+++ b/plugins/relationship_proactive/manifest.yaml
@@ -1,0 +1,7 @@
+api: 2
+id: relationship_proactive
+desc: 关系驱动的主动 tick 准入策略（孤独度回退、场景后续跟进）
+capabilities:
+  - relationship_runtime
+  - events
+  - proactive_gates

--- a/plugins/relationship_proactive/tests/test_plugin.py
+++ b/plugins/relationship_proactive/tests/test_plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from datetime import datetime, timezone
 from pathlib import Path
 from unittest.mock import MagicMock
@@ -12,10 +13,11 @@ from agent.core.proactive_turn.gates import (
     ProactiveGateContext,
     ProactiveMode,
 )
-from agent.plugins.context import PluginContext, PluginKVStore
+from agent.plugin_host import HostServices, PluginKernel
 from bus.event_bus import EventBus
 from bus.events_lifecycle import SceneObservationCommitted
-from plugins.relationship_proactive.backend.plugin import RelationshipProactivePlugin
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _context() -> ProactiveGateContext:
@@ -27,22 +29,34 @@ def _context() -> ProactiveGateContext:
     )
 
 
-def test_scene_gate_claims_tick_and_advances_only_after_delivery(tmp_path: Path):
+def _load_relationship_proactive_kernel(
+    tmp_path: Path, *, relationship_runtime: object
+) -> tuple[PluginKernel, EventBus]:
+    root = tmp_path / "plugins"
+    root.mkdir()
+    shutil.copytree(
+        _REPO_ROOT / "plugins" / "relationship_proactive",
+        root / "relationship_proactive",
+    )
+    bus = EventBus()
+    kernel = PluginKernel(
+        [root],
+        services=HostServices(event_bus=bus, relationship_runtime=relationship_runtime),
+    )
+    return kernel, bus
+
+
+@pytest.mark.asyncio
+async def test_scene_gate_claims_tick_and_advances_only_after_delivery(tmp_path: Path):
     runtime = MagicMock()
     runtime.should_trigger_scene_followup.return_value = (
         True,
         {"attempt_index": 1},
     )
-    plugin = RelationshipProactivePlugin()
-    plugin.context = PluginContext(
-        event_bus=EventBus(),
-        tool_registry=None,
-        plugin_id="relationship_proactive",
-        plugin_dir=tmp_path,
-        kv_store=PluginKVStore(tmp_path / ".kv.json"),
-        relationship_runtime=runtime,
-    )
-    chain = ProactiveGateChain(plugin.proactive_gates())
+    kernel, _bus = _load_relationship_proactive_kernel(tmp_path, relationship_runtime=runtime)
+    await kernel.load_all()
+    assert kernel.loaded_count == 1
+    chain = ProactiveGateChain(kernel.proactive_gates)
 
     result = chain.evaluate(_context())
 
@@ -61,7 +75,8 @@ def test_scene_gate_claims_tick_and_advances_only_after_delivery(tmp_path: Path)
     runtime.close_scene_followup.assert_not_called()
 
 
-def test_loneliness_gate_blocks_when_relationship_runtime_rejects(tmp_path: Path):
+@pytest.mark.asyncio
+async def test_loneliness_gate_blocks_when_relationship_runtime_rejects(tmp_path: Path):
     runtime = MagicMock()
     runtime.should_trigger_scene_followup.return_value = (False, {})
     runtime.should_trigger_proactive.return_value = (
@@ -72,17 +87,10 @@ def test_loneliness_gate_blocks_when_relationship_runtime_rejects(tmp_path: Path
             "trigger_threshold": 60,
         },
     )
-    plugin = RelationshipProactivePlugin()
-    plugin.context = PluginContext(
-        event_bus=EventBus(),
-        tool_registry=None,
-        plugin_id="relationship_proactive",
-        plugin_dir=tmp_path,
-        kv_store=PluginKVStore(tmp_path / ".kv.json"),
-        relationship_runtime=runtime,
-    )
+    kernel, _bus = _load_relationship_proactive_kernel(tmp_path, relationship_runtime=runtime)
+    await kernel.load_all()
 
-    result = ProactiveGateChain(plugin.proactive_gates()).evaluate(_context())
+    result = ProactiveGateChain(kernel.proactive_gates).evaluate(_context())
 
     assert result.blocked is True
     assert result.reason == "cooldown"
@@ -97,17 +105,8 @@ def test_loneliness_gate_blocks_when_relationship_runtime_rejects(tmp_path: Path
 @pytest.mark.asyncio
 async def test_plugin_applies_shared_scene_observation(tmp_path: Path):
     runtime = MagicMock()
-    bus = EventBus()
-    plugin = RelationshipProactivePlugin()
-    plugin.context = PluginContext(
-        event_bus=bus,
-        tool_registry=None,
-        plugin_id="relationship_proactive",
-        plugin_dir=tmp_path,
-        kv_store=PluginKVStore(tmp_path / ".kv.json"),
-        relationship_runtime=runtime,
-    )
-    await plugin.initialize()
+    kernel, bus = _load_relationship_proactive_kernel(tmp_path, relationship_runtime=runtime)
+    await kernel.load_all()
 
     await bus.fanout(
         SceneObservationCommitted(
@@ -128,4 +127,31 @@ async def test_plugin_applies_shared_scene_observation(tmp_path: Path):
         "started",
         "rain",
     )
-    await plugin.terminate()
+
+    # 卸载后场景事件不应再触发 relationship_runtime，证明订阅挂在插件作用域上
+    _ = await kernel.unload("relationship_proactive")
+    await bus.fanout(
+        SceneObservationCommitted(
+            session_key="role:mira",
+            channel="desktop",
+            chat_id="role:mira",
+            role_id="mira",
+            source="passive",
+            transition="closed",
+            scene_key="",
+            should_generate=False,
+            prompt="",
+        )
+    )
+    runtime.apply_scene_decision.assert_called_once()
+
+
+@pytest.mark.asyncio
+async def test_setup_contributes_nothing_when_relationship_runtime_absent(tmp_path: Path):
+    """relationship_runtime 未接线时插件仍加载成功但不贡献任何 gate/订阅。"""
+    kernel, _bus = _load_relationship_proactive_kernel(tmp_path, relationship_runtime=None)
+
+    await kernel.load_all()
+
+    assert kernel.loaded_count == 1
+    assert kernel.proactive_gates == []

--- a/plugins/relationship_proactive/tests/test_plugin.py
+++ b/plugins/relationship_proactive/tests/test_plugin.py
@@ -147,6 +147,25 @@ async def test_plugin_applies_shared_scene_observation(tmp_path: Path):
 
 
 @pytest.mark.asyncio
+async def test_collects_and_clears_official_proactive_gates(tmp_path: Path):
+    """setup() 必须与旧 proactive_gates() 等价：两个 gate 按声明顺序聚合进
+    kernel.proactive_gates，卸载后整体清空——不只是"能驱动 gate 链"，而是
+    "聚合面本身真的收纳了这两个 gate 且卸载会清掉"。"""
+    runtime = MagicMock()
+    kernel, _bus = _load_relationship_proactive_kernel(tmp_path, relationship_runtime=runtime)
+
+    await kernel.load_all()
+
+    assert [gate.name for gate in kernel.proactive_gates] == [
+        "relationship.scene_followup",
+        "relationship.loneliness",
+    ]
+
+    _ = await kernel.unload("relationship_proactive")
+    assert kernel.proactive_gates == []
+
+
+@pytest.mark.asyncio
 async def test_setup_contributes_nothing_when_relationship_runtime_absent(tmp_path: Path):
     """relationship_runtime 未接线时插件仍加载成功但不贡献任何 gate/订阅。"""
     kernel, _bus = _load_relationship_proactive_kernel(tmp_path, relationship_runtime=None)

--- a/plugins/scene_awareness/backend/plugin.py
+++ b/plugins/scene_awareness/backend/plugin.py
@@ -17,8 +17,18 @@ logger = logging.getLogger(__name__)
 async def setup(ctx: "PluginRuntimeContext") -> None:
     """装配 scene_awareness：观察完成的角色回合并发布共享场景决策。
 
-    ``ctx.effect`` 登记 ``controller.terminate()`` 作为自定义副作用，卸载时
-    取消并等待所有进行中的场景观察后台任务，对齐旧 ``terminate()`` 的收尾。
+    ``ctx.effect("controller_terminate", ...)`` 必须先于三个 ``ctx.events.on``
+    登记：``EffectScope.dispose_all`` 按 LIFO 逆序处置，先登记的后处置。若顺序
+    颠倒（先 events.on 再 effect），卸载时会先跑 controller.terminate() 再撤销
+    事件订阅——``SceneAwarenessController.terminate()`` 对 in-flight 任务是
+    "snapshot tasks -> cancel -> await gather -> clear()"，await 期间订阅仍然
+    生效，此时若有 ProactiveMessageCommitted 落地，
+    ``schedule_proactive_turn`` 会把一个新任务塞进 ``_tasks``（不在 snapshot
+    里，因此不会被 cancel），terminate() 末尾的 ``clear()`` 随即丢弃对它的
+    唯一引用——任务泄漏，再也无法取消或等待。先登记 effect（=最后处置，
+    最先执行）能保证 controller.terminate() 在三个订阅撤销之前跑，与旧
+    ``terminate()`` 手写的 "先 event_bus.off，再 await controller.terminate()"
+    顺序等价（#183 复审）。
     """
     workspace = ctx.workspace
     if workspace is None:
@@ -46,7 +56,8 @@ async def setup(ctx: "PluginRuntimeContext") -> None:
     def _handle_proactive_message(event: ProactiveMessageCommitted) -> None:
         controller.schedule_proactive_turn(event)
 
+    # 登记顺序刻意在三个事件订阅之前：见上方文档。
+    ctx.effect("controller_terminate", controller.terminate)
     ctx.events.on(BeforeTurnCtx, _capture_passive_turn)
     ctx.events.on(AfterTurnCtx, _schedule_passive_turn)
     ctx.events.on(ProactiveMessageCommitted, _handle_proactive_message)
-    ctx.effect("controller_terminate", controller.terminate)

--- a/plugins/scene_awareness/backend/plugin.py
+++ b/plugins/scene_awareness/backend/plugin.py
@@ -1,67 +1,52 @@
 from __future__ import annotations
 
 import logging
+from typing import TYPE_CHECKING
 
 from agent.lifecycle.types import AfterTurnCtx, BeforeTurnCtx
-from agent.plugins import Plugin, on_after_turn, on_before_turn
 from bus.events_lifecycle import ProactiveMessageCommitted
 from core.roles.store import RoleStore
 from plugins.scene_awareness.backend.controller import SceneAwarenessController
 
+if TYPE_CHECKING:
+    from agent.plugin_host.runtime_context import PluginRuntimeContext
+
 logger = logging.getLogger(__name__)
 
 
-class SceneAwarenessPlugin(Plugin):
-    """Observe completed role turns and publish shared scene decisions."""
+async def setup(ctx: "PluginRuntimeContext") -> None:
+    """装配 scene_awareness：观察完成的角色回合并发布共享场景决策。
 
-    name = "scene_awareness"
+    ``ctx.effect`` 登记 ``controller.terminate()`` 作为自定义副作用，卸载时
+    取消并等待所有进行中的场景观察后台任务，对齐旧 ``terminate()`` 的收尾。
+    """
+    workspace = ctx.workspace
+    if workspace is None:
+        raise RuntimeError("场景观察插件需要 workspace")
+    controller = SceneAwarenessController(
+        role_store=RoleStore(workspace),
+        session_manager=ctx.session_manager,
+        event_bus=ctx.events,
+        kv_store=ctx.kv,
+        light_provider=ctx.light_provider,
+        light_model=ctx.light_model,
+    )
+    if ctx.light_provider is None or not ctx.light_model.strip():
+        logger.warning("场景观察缺少 light_model provider，后台判定已禁用")
 
-    async def initialize(self) -> None:
-        workspace = self.context.workspace
-        if workspace is None:
-            raise RuntimeError("场景观察插件需要 workspace")
-        self._controller = SceneAwarenessController(
-            role_store=RoleStore(workspace),
-            session_manager=self.context.session_manager,
-            event_bus=self.context.event_bus,
-            kv_store=self.context.kv_store,
-            light_provider=self.context.light_provider,
-            light_model=self.context.light_model,
-        )
-        self._proactive_handler = self._handle_proactive_message
-        self.context.event_bus.on(
-            ProactiveMessageCommitted,
-            self._proactive_handler,
-        )
-        if self.context.light_provider is None or not self.context.light_model.strip():
-            logger.warning("场景观察缺少 light_model provider，后台判定已禁用")
-
-    @property
-    def scene_tasks(self):
-        """Return a snapshot of in-flight scene observation tasks."""
-
-        return self._controller.tasks
-
-    @on_before_turn()
-    async def capture_passive_turn(self, ctx: BeforeTurnCtx) -> BeforeTurnCtx:
+    async def _capture_passive_turn(event: BeforeTurnCtx) -> BeforeTurnCtx:
         """Capture the passive turn before reasoning mutates its context."""
+        controller.capture_passive_turn(event)
+        return event
 
-        self._controller.capture_passive_turn(ctx)
-        return ctx
-
-    @on_after_turn()
-    async def schedule_passive_turn(self, ctx: AfterTurnCtx) -> None:
+    async def _schedule_passive_turn(event: AfterTurnCtx) -> None:
         """Schedule observation after a passive text turn completes."""
+        controller.schedule_passive_turn(event)
 
-        self._controller.schedule_passive_turn(ctx)
+    def _handle_proactive_message(event: ProactiveMessageCommitted) -> None:
+        controller.schedule_proactive_turn(event)
 
-    def _handle_proactive_message(self, event: ProactiveMessageCommitted) -> None:
-        self._controller.schedule_proactive_turn(event)
-
-    async def terminate(self) -> None:
-        handler = getattr(self, "_proactive_handler", None)
-        if handler is not None:
-            self.context.event_bus.off(ProactiveMessageCommitted, handler)
-        controller = getattr(self, "_controller", None)
-        if controller is not None:
-            await controller.terminate()
+    ctx.events.on(BeforeTurnCtx, _capture_passive_turn)
+    ctx.events.on(AfterTurnCtx, _schedule_passive_turn)
+    ctx.events.on(ProactiveMessageCommitted, _handle_proactive_message)
+    ctx.effect("controller_terminate", controller.terminate)

--- a/plugins/scene_awareness/manifest.yaml
+++ b/plugins/scene_awareness/manifest.yaml
@@ -1,0 +1,10 @@
+api: 2
+id: scene_awareness
+desc: 观察完成的角色回合并发布共享场景决策
+capabilities:
+  - workspace
+  - session_manager
+  - events
+  - kv
+  - light_provider
+  - light_model

--- a/plugins/scene_awareness/tests/test_plugin.py
+++ b/plugins/scene_awareness/tests/test_plugin.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -11,12 +12,19 @@ from agent.lifecycle.types import AfterTurnCtx, BeforeTurnCtx
 from agent.plugin_host import HostServices, PluginKernel, PluginState
 from bus.event_bus import EventBus
 from bus.events_lifecycle import ProactiveMessageCommitted
+from core.roles.store import RoleStore
+from session.manager import SessionManager
 
 _REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 def _load_scene_awareness_kernel(
-    tmp_path: Path, *, workspace: Path | None, session_manager: object = None
+    tmp_path: Path,
+    *,
+    workspace: Path | None,
+    session_manager: object = None,
+    light_provider: object = None,
+    light_model: str = "",
 ) -> tuple[PluginKernel, EventBus]:
     root = tmp_path / "plugins"
     root.mkdir()
@@ -27,7 +35,11 @@ def _load_scene_awareness_kernel(
     kernel = PluginKernel(
         [root],
         services=HostServices(
-            event_bus=bus, workspace=workspace, session_manager=session_manager
+            event_bus=bus,
+            workspace=workspace,
+            session_manager=session_manager,
+            light_provider=light_provider,
+            light_model=light_model,
         ),
     )
     return kernel, bus
@@ -120,3 +132,115 @@ async def test_setup_wires_before_after_turn_and_proactive_events(
     after_before_ctx = _before_turn_ctx(session_key="cli:2")
     result_after_unload = await bus.emit(after_before_ctx)
     assert result_after_unload is after_before_ctx
+
+
+class _BlockingLightProvider:
+    """假 light_provider：chat() 挂起在 release 上，可控地制造一个仍在
+    进行中的场景观察任务，供并发卸载测试制造竞争窗口。"""
+
+    def __init__(self) -> None:
+        self.entered = asyncio.Event()
+        self.release = asyncio.Event()
+        self.chat_call_count = 0
+
+    async def chat(self, **kwargs: object) -> SimpleNamespace:
+        self.chat_call_count += 1
+        self.entered.set()
+        await self.release.wait()
+        return SimpleNamespace(
+            content="",
+            tool_calls=[
+                SimpleNamespace(
+                    name="submit_scene_observation",
+                    arguments={
+                        "transition": "none",
+                        "should_generate": False,
+                        "scene_key": "",
+                        "visual_key": "",
+                        "prompt": "",
+                        "negative_prompt": "",
+                        "size_preset": "",
+                    },
+                )
+            ],
+        )
+
+
+@pytest.mark.asyncio
+async def test_unload_unsubscribes_proactive_handler_before_terminating_controller(
+    tmp_path: Path,
+) -> None:
+    """回归 #183 复审发现的收尾顺序缺陷：``ctx.effect`` 必须先于三个
+    ``ctx.events.on`` 登记，使 LIFO 卸载先撤销订阅、再 terminate controller。
+
+    颠倒时会出现真实的任务泄漏：controller.terminate() 对 in-flight 任务做
+    "snapshot -> cancel -> await gather -> clear()"；若在这个 await 窗口内
+    ProactiveMessageCommitted 订阅仍然生效，一条新消息会通过
+    schedule_proactive_turn 塞入一个不在 snapshot 里、因此不会被 cancel 的新
+    任务，随后又被 clear() 丢弃引用——泄漏且永远不会完成。
+
+    用真实并发验证：先让一个场景观察任务卡在 light_provider.chat() 里（确保
+    controller.terminate() 的 gather 真的会挂起），卸载开始后、gather 仍在
+    等待时再 fanout 第二条 ProactiveMessageCommitted。断言 chat() 只被调用
+    过一次——如果收尾顺序颠倒，这条断言会失败（第二条消息会真的触发第二次
+    chat() 调用，对应一个永远不会完成的孤儿任务）。
+    """
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    role_store = RoleStore(workspace)
+    _ = role_store.create_role(
+        role_id="mira",
+        name="Mira",
+        system_prompt="粉发少女",
+        runtime_config={"auto_scene_cg_enabled": True},
+    )
+    sessions = SessionManager(workspace)
+    sessions.open_role_session("mira", role_name="Mira")
+    provider = _BlockingLightProvider()
+    kernel, bus = _load_scene_awareness_kernel(
+        tmp_path,
+        workspace=workspace,
+        session_manager=sessions,
+        light_provider=provider,
+        light_model="light-model",
+    )
+    await kernel.load_all()
+
+    def _proactive_message(**overrides: object) -> ProactiveMessageCommitted:
+        defaults: dict[str, object] = dict(
+            session_key="role:mira",
+            channel="desktop",
+            chat_id="role:mira",
+            role_id="mira",
+            assistant_response="她忽然走近抱住了你。",
+            tools_used=(),
+        )
+        defaults.update(overrides)
+        return ProactiveMessageCommitted(**defaults)
+
+    # 1. 触发第一个场景观察任务，等它真正卡进 chat() 的挂起点（此时它已经被
+    #    收纳进 controller._tasks，之后 terminate() 的 snapshot 会包含它）。
+    await bus.fanout(_proactive_message())
+    await asyncio.wait_for(provider.entered.wait(), timeout=2)
+    provider.entered.clear()
+
+    # 2. 并发发起卸载。unload_task 创建后立即调度，其自身的第一段全同步执行
+    #    （无论收尾顺序对错，都是：处置最先被 pop 到的 effect……直到轮到
+    #    controller.terminate()，其内部 snapshot + cancel(task1) 均为同步代码，
+    #    唯一的挂起点是随后的 gather）；单次 sleep(0) 足以让它跑到这个挂起点，
+    #    且刚好还没来得及让 task1 的 CancelledError 真正投递（那需要额外的调度
+    #    轮次）。多等一轮反而有把窗口错过的风险，因此这里刻意只 sleep(0) 一次。
+    unload_task = asyncio.create_task(kernel.unload("scene_awareness"))
+    await asyncio.sleep(0)
+
+    # 3. 在这个挂起窗口内再 fanout 一条 ProactiveMessageCommitted。收尾顺序
+    #    正确时，事件订阅已经撤销，这条消息不会被任何人处理。
+    await bus.fanout(_proactive_message(session_key="role:mira-2", chat_id="role:mira-2"))
+
+    provider.release.set()
+    errors = await asyncio.wait_for(unload_task, timeout=5)
+    assert errors == []
+
+    # 给可能被错误创建的孤儿任务一点调度机会，让它也有机会调用 chat()。
+    await asyncio.sleep(0.05)
+    assert provider.chat_call_count == 1

--- a/plugins/scene_awareness/tests/test_plugin.py
+++ b/plugins/scene_awareness/tests/test_plugin.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent.lifecycle.types import AfterTurnCtx, BeforeTurnCtx
+from agent.plugin_host import HostServices, PluginKernel, PluginState
+from bus.event_bus import EventBus
+from bus.events_lifecycle import ProactiveMessageCommitted
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_scene_awareness_kernel(
+    tmp_path: Path, *, workspace: Path | None, session_manager: object = None
+) -> tuple[PluginKernel, EventBus]:
+    root = tmp_path / "plugins"
+    root.mkdir()
+    shutil.copytree(
+        _REPO_ROOT / "plugins" / "scene_awareness", root / "scene_awareness"
+    )
+    bus = EventBus()
+    kernel = PluginKernel(
+        [root],
+        services=HostServices(
+            event_bus=bus, workspace=workspace, session_manager=session_manager
+        ),
+    )
+    return kernel, bus
+
+
+def _before_turn_ctx(**overrides: object) -> BeforeTurnCtx:
+    defaults: dict[str, object] = dict(
+        session_key="cli:1",
+        channel="cli",
+        chat_id="1",
+        content="hello",
+        timestamp=datetime.now(timezone.utc),
+        retrieved_memory_block="",
+        retrieval_trace_raw=None,
+        history_messages=(),
+    )
+    defaults.update(overrides)
+    return BeforeTurnCtx(**defaults)
+
+
+def _after_turn_ctx(**overrides: object) -> AfterTurnCtx:
+    defaults: dict[str, object] = dict(
+        session_key="cli:1",
+        channel="cli",
+        chat_id="1",
+        reply="hi there",
+        tools_used=(),
+        thinking=None,
+        will_dispatch=True,
+    )
+    defaults.update(overrides)
+    return AfterTurnCtx(**defaults)
+
+
+@pytest.mark.asyncio
+async def test_setup_fails_without_workspace(tmp_path: Path) -> None:
+    """workspace 缺失时插件加载失败并回滚，对齐旧 initialize() 的 raise。"""
+    kernel, _bus = _load_scene_awareness_kernel(tmp_path, workspace=None)
+
+    await kernel.load_all()
+
+    assert kernel.loaded_count == 0
+    states = {item["id"]: item for item in kernel.states()}
+    assert states["scene_awareness"]["state"] == PluginState.FAILED.name
+    assert "workspace" in states["scene_awareness"]["error"]
+
+
+@pytest.mark.asyncio
+async def test_setup_wires_before_after_turn_and_proactive_events(
+    tmp_path: Path,
+) -> None:
+    """setup() 必须贡献与旧 SceneAwarenessPlugin 等价的三个事件订阅，且卸载后
+    干净收尾（controller.terminate() 不抛异常，effect 真正撤销订阅）。"""
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    session_manager = SimpleNamespace(get_or_create=lambda key: SimpleNamespace(
+        metadata={}, messages=()
+    ))
+    kernel, bus = _load_scene_awareness_kernel(
+        tmp_path, workspace=workspace, session_manager=session_manager
+    )
+
+    await kernel.load_all()
+    assert kernel.loaded_count == 1
+
+    # before_turn 是 GATE：handler 必须把（未被改写的）ctx 原样传回
+    before_ctx = _before_turn_ctx()
+    result = await bus.emit(before_ctx)
+    assert result is before_ctx
+
+    # after_turn / proactive 只需确认订阅生效且不抛异常（controller 内部因缺少
+    # light_provider 静默跳过调度，这部分业务逻辑由 test_controller.py 覆盖）
+    _ = await bus.emit(_after_turn_ctx())
+    await bus.fanout(
+        ProactiveMessageCommitted(
+            session_key="cli:1",
+            channel="cli",
+            chat_id="1",
+            role_id="",
+            assistant_response="hi",
+            tools_used=(),
+        )
+    )
+
+    errors = await kernel.unload("scene_awareness")
+    assert errors == []
+
+    # 卸载后事件订阅应已撤销：再次 emit 必须不再命中任何 handler，
+    # bus.emit 在没有 handler 时原样返回同一个对象。
+    after_before_ctx = _before_turn_ctx(session_key="cli:2")
+    result_after_unload = await bus.emit(after_before_ctx)
+    assert result_after_unload is after_before_ctx

--- a/tests/backend/agent/plugin_host/conftest.py
+++ b/tests/backend/agent/plugin_host/conftest.py
@@ -50,6 +50,11 @@ def make_kernel(
     strict: bool = False,
     plugin_configs: dict[str, dict] | None = None,
     workspace: Path | None = None,
+    session_manager: object = None,
+    memory_engine: object = None,
+    light_provider: object = None,
+    light_model: str = "",
+    relationship_runtime: object = None,
 ) -> PluginKernel:
     # 插件数据落在 workspace 而非插件目录（issue #209），而 legacy 适配器会为每个
     # 插件装配 kv，因此夹具默认提供一个可写 workspace。这里刻意不复用
@@ -68,6 +73,11 @@ def make_kernel(
             tool_registry=tools,
             plugin_configs=plugin_configs or {},
             workspace=resolved_workspace,
+            session_manager=session_manager,
+            memory_engine=memory_engine,
+            light_provider=light_provider,
+            light_model=light_model,
+            relationship_runtime=relationship_runtime,
         ),
         namespace=namespace,
         strict=strict,

--- a/tests/backend/agent/plugin_host/test_kernel.py
+++ b/tests/backend/agent/plugin_host/test_kernel.py
@@ -364,6 +364,105 @@ async def test_v2_plugin_rpc_method_callable_then_gone_after_unload(tmp_path: Pa
     assert kernel.rpc.resolve("plugin.rpcdemo.ping") is None
 
 
+_HOST_SERVICES_PLUGIN = """
+captured: dict = {}
+
+
+async def setup(ctx):
+    captured["workspace"] = ctx.workspace
+    captured["memory_engine"] = ctx.memory_engine
+    captured["session_manager"] = ctx.session_manager
+    captured["light_provider"] = ctx.light_provider
+    captured["light_model"] = ctx.light_model
+    captured["relationship_runtime"] = ctx.relationship_runtime
+""".strip()
+
+_HOST_SERVICES_MANIFEST = (
+    "api: 2\nid: hostrefs\ncapabilities:\n"
+    "  - workspace\n  - memory_engine\n  - session_manager\n"
+    "  - light_provider\n  - light_model\n  - relationship_runtime\n"
+)
+
+
+@pytest.mark.asyncio
+async def test_v2_plugin_reads_host_service_references(tmp_path: Path):
+    """新增 6 个直传型 capability（#183）必须原样透出 HostServices 的同名字段。"""
+    plugin_dir = tmp_path / "hostrefs"
+    (plugin_dir / "backend").mkdir(parents=True)
+    (plugin_dir / "backend" / "plugin.py").write_text(
+        _HOST_SERVICES_PLUGIN, encoding="utf-8"
+    )
+    (plugin_dir / "manifest.yaml").write_text(
+        _HOST_SERVICES_MANIFEST, encoding="utf-8"
+    )
+    workspace = tmp_path / "workspace-for-hostrefs"
+    workspace.mkdir()
+    memory_engine = object()
+    session_manager = object()
+    light_provider = object()
+    relationship_runtime = object()
+    kernel = make_kernel(
+        [tmp_path],
+        event_bus=EventBus(),
+        workspace=workspace,
+        memory_engine=memory_engine,
+        session_manager=session_manager,
+        light_provider=light_provider,
+        light_model="light-model-x",
+        relationship_runtime=relationship_runtime,
+    )
+    await kernel.load_all()
+
+    import sys
+
+    module = next(
+        m for k, m in sys.modules.items()
+        if k.startswith("akasic_plugin_") and k.endswith("_hostrefs")
+    )
+    assert module.captured == {
+        "workspace": workspace,
+        "memory_engine": memory_engine,
+        "session_manager": session_manager,
+        "light_provider": light_provider,
+        "light_model": "light-model-x",
+        "relationship_runtime": relationship_runtime,
+    }
+
+
+@pytest.mark.asyncio
+async def test_v2_plugin_host_service_capabilities_are_gated(tmp_path: Path):
+    """未在 manifest 声明的直传型 capability 访问时必须抛 CapabilityNotGranted。"""
+    plugin_dir = tmp_path / "hostrefs_gated"
+    (plugin_dir / "backend").mkdir(parents=True)
+    (plugin_dir / "backend" / "plugin.py").write_text(
+        """
+captured: dict = {}
+
+
+async def setup(ctx):
+    try:
+        _ = ctx.memory_engine
+    except AttributeError as e:
+        captured["denied"] = str(e)
+""".strip(),
+        encoding="utf-8",
+    )
+    (plugin_dir / "manifest.yaml").write_text(
+        "api: 2\nid: hostrefs_gated\ncapabilities:\n  - workspace\n",
+        encoding="utf-8",
+    )
+    kernel = make_kernel([tmp_path], event_bus=EventBus())
+    await kernel.load_all()
+
+    import sys
+
+    module = next(
+        m for k, m in sys.modules.items()
+        if k.startswith("akasic_plugin_") and k.endswith("_hostrefs_gated")
+    )
+    assert "未声明 capability" in module.captured["denied"]
+
+
 @pytest.mark.asyncio
 async def test_weather_tool_via_facade(tmp_path: Path):
     stage_plugin_fixture("weather", tmp_path)

--- a/tests/backend/agent/plugins/test_manager.py
+++ b/tests/backend/agent/plugins/test_manager.py
@@ -1,16 +1,13 @@
 from __future__ import annotations
 
-import importlib
 import json
 import shlex
 import shutil
 import tempfile
-import sqlite3
-from collections.abc import Callable
 from datetime import datetime
 from pathlib import Path
 from types import SimpleNamespace
-from typing import Any, cast
+from typing import Any
 
 import pytest
 
@@ -22,11 +19,6 @@ from agent.plugins.registry import plugin_registry
 from agent.tool_hooks import ToolHook
 from agent.tools.registry import ToolRegistry
 from bus.event_bus import EventBus
-from bus.events_lifecycle import TurnCommitted
-from core.memory.events import MemoryWritten, RetrievalCompleted, RetrievalHitSummary
-
-_observe_db = importlib.import_module("plugins.observe.backend.db")
-open_db = cast(Callable[[Path], sqlite3.Connection], getattr(_observe_db, "open_db"))
 
 
 # ── fixtures ──────────────────────────────────────────────────────────────────
@@ -132,143 +124,6 @@ async def test_strict_candidate_rejects_plugin_initialization_failure(tmp_path):
         await manager.load_all()
     assert manager.loaded_count == 0
     assert plugin_registry.get_instance(manager.discover()[0]["import_path"]) is None
-
-
-@pytest.mark.asyncio
-async def test_collects_and_clears_official_proactive_gates(tmp_path: Path):
-    source = REPOSITORY_ROOT / "plugins" / "relationship_proactive" / "backend"
-    plugin_root = tmp_path / "plugins"
-    shutil.copytree(source, plugin_root / "relationship_proactive")
-    bus = EventBus()
-    mgr = PluginManager(
-        plugin_dirs=[plugin_root],
-        event_bus=bus,
-        relationship_runtime=object(),
-    )
-
-    await mgr.load_all()
-
-    assert [gate.name for gate in mgr.proactive_gates] == [
-        "relationship.scene_followup",
-        "relationship.loneliness",
-    ]
-    await mgr.terminate_all()
-    assert mgr.proactive_gates == []
-    await bus.aclose()
-
-
-@pytest.mark.asyncio
-async def test_observe_plugin_writes_turn_trace(tmp_path: Path):
-    source = REPOSITORY_ROOT / "plugins" / "observe" / "backend"
-    plugin_root = tmp_path / "plugins"
-    shutil.copytree(source, plugin_root / "observe")
-    bus = EventBus()
-    mgr = PluginManager(
-        plugin_dirs=[plugin_root],
-        event_bus=bus,
-        workspace=tmp_path,
-    )
-
-    await mgr.load_all()
-    await bus.emit(
-        TurnCommitted(
-            session_key="telegram:observe",
-            channel="telegram",
-            chat_id="observe",
-            input_message="你好",
-            persisted_user_message="你好",
-            assistant_response="收到",
-            tools_used=[],
-            thinking=None,
-            raw_reply="收到",
-            meme_tag=None,
-            meme_media_count=0,
-            tool_chain_raw=[],
-            tool_call_groups=[],
-            post_reply_budget={"prompt_tokens": 8},
-            react_stats={"cache_prompt_tokens": 8, "cache_hit_tokens": 6},
-        )
-    )
-    await mgr.terminate_all()
-    await bus.aclose()
-
-    conn = open_db(tmp_path / "observe" / "observe.db")
-    try:
-        row = conn.execute(
-            """SELECT session_key, user_msg, llm_output, react_cache_hit_tokens
-               FROM turns WHERE source='agent'"""
-        ).fetchone()
-    finally:
-        conn.close()
-    assert row == ("telegram:observe", "你好", "收到", 6)
-
-
-@pytest.mark.asyncio
-async def test_observe_plugin_writes_memory_domain_events(tmp_path: Path):
-    source = REPOSITORY_ROOT / "plugins" / "observe" / "backend"
-    plugin_root = tmp_path / "plugins"
-    shutil.copytree(source, plugin_root / "observe")
-    bus = EventBus()
-    mgr = PluginManager(
-        plugin_dirs=[plugin_root],
-        event_bus=bus,
-        workspace=tmp_path,
-    )
-
-    await mgr.load_all()
-    await bus.fanout(
-        RetrievalCompleted(
-            session_key="telegram:memory",
-            channel="telegram",
-            chat_id="memory",
-            query="改写问题",
-            orig_query="原始问题",
-            hits=[
-                RetrievalHitSummary(
-                    item_id="mem_1",
-                    memory_type="event",
-                    score=0.9,
-                    summary="命中的记忆",
-                    injected=True,
-                )
-            ],
-            injected_count=1,
-            route_decision="RETRIEVE",
-            aux_queries=["假想问题"],
-        )
-    )
-    await bus.fanout(
-        MemoryWritten(
-            session_key="telegram:memory",
-            channel="telegram",
-            chat_id="memory",
-            action="supersede",
-            source_ref="telegram:memory@post_response",
-            superseded_ids=["mem_1"],
-        )
-    )
-    await mgr.terminate_all()
-    await bus.aclose()
-
-    conn = open_db(tmp_path / "observe" / "observe.db")
-    try:
-        rag = conn.execute(
-            """SELECT session_key, query, orig_query, injected_count
-               FROM rag_queries"""
-        ).fetchone()
-        memory_write = conn.execute(
-            """SELECT session_key, action, source_ref, superseded_ids
-               FROM memory_writes"""
-        ).fetchone()
-    finally:
-        conn.close()
-    assert rag == ("telegram:memory", "改写问题", "原始问题", 1)
-    assert memory_write == (
-        "telegram:memory",
-        "supersede",
-        "telegram:memory@post_response",
-        '["mem_1"]',
-    )
 
 
 @pytest.mark.asyncio

--- a/tests/backend/desktop_bridge/runtime/test_plugin_config.py
+++ b/tests/backend/desktop_bridge/runtime/test_plugin_config.py
@@ -1,8 +1,9 @@
 """plugin.config.get/set：schema 通道读写，覆盖验收标准 3 与 4。
 
-用真实的 legacy 插件（仓库自带的 qqbot，经 ``Plugin.ConfigModel`` 声明配置
-模型）和一个完全没有配置模型的旧插件（hello 夹具）做被测对象，而不是只能
-造假插件；证明 ``plugin.config`` 通道对存量插件立刻可用。
+用真实插件（仓库自带的 qqbot，经 v2 manifest 的 ``config_model`` 声明配置
+模型——#183 之前经 legacy ``Plugin.ConfigModel`` 声明，迁移后 schema 解析路径
+换了但通道行为不变）和一个完全没有配置模型的旧插件（hello 夹具）做被测对象，
+而不是只能造假插件；证明 ``plugin.config`` 通道对存量插件立刻可用。
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Closes #183. Part of #174。

qqbot、scene_awareness、observe、relationship_proactive、akasha、default_memory 六个插件
全部脱离旧 `Plugin` ABC，改写为 v2 `setup(ctx)`；qqbot 配置迁入它自己的 settings.section。
Memory contract 与引擎内部未动。

已 rebase 到 `4bb79bdf`（#181-B 合并后的 main）。

---

## 先补框架：六个 host service capability

批 B 的插件需要批 A（#182）完全没碰过的宿主引用——`workspace`、`memory_engine`、
`session_manager`、`light_provider`、`light_model`、`relationship_runtime`。这些早就穿在
`HostServices` 里给旧适配器用，但从没暴露给 v2 插件。补成六个直通 capability
（不需要包装类：它们是纯引用，没有 effect 或生命周期要管），按 manifest 逐个 gate，
与既有 capability 一致。新增两条 kernel 测试覆盖读取与 gate。

## 逐个插件

| 插件 | 迁移要点 |
| --- | --- |
| **qqbot** | `channels()` → `setup(ctx)`，走 `ctx.config` / `ctx.channels`。配置用 `QQBotConfigModel.model_validate(ctx.config.as_dict())` 显式校验，非法配置仍让整个插件加载失败，与旧 `_load_plugin_config` 一致 |
| **akasha**（仅壳） | `AkashaPlugin` → `setup(ctx)` + 模块级 `render_last_query()`。记忆引擎身份改成 setup 时查一次而非每次调用查——等价，因为它在一个 kernel generation 内固定 |
| **default_memory**（仅壳） | `@on_tool_result()` → `ctx.events.on(AfterToolResultCtx, ...)`，同一条 EventBus 分发路径，无能力缺口 |
| **observe** | `initialize`/`terminate` → `setup(ctx)`，用 `ctx.workspace`、`ctx.background.spawn`（writer + retention）、`ctx.effect`（卸载 collector）、三个 `ctx.events.on` |
| **relationship_proactive** | `ctx.relationship_runtime` + `ctx.events.on` + `ctx.proactive_gates.add` |
| **scene_awareness** | `@on_before_turn`/`@on_after_turn` → `ctx.events.on` ×3，外加 `ctx.workspace`、`ctx.session_manager`、`ctx.kv`、`ctx.light_provider`/`ctx.light_model`、`ctx.effect` 收 controller。顺手删掉无调用方的 `scene_tasks` property |

每个插件新增 `manifest.yaml`（`api: 2`），只声明它 `setup()` 真正用到的 capability。

**observe 与 scene_awareness 的 effect 注册顺序是刻意排的**：LIFO 释放才能保住旧代码
「collector flush 先于 writer 任务取消」那条不变量。docstring 里写明了，别顺手重排。

## 一个会静默删配置的坑

**主设置页每次保存是整份 `config.toml` 重写，不是 merge。** `settings.ts` 里那个
`pluginsRawToml` 兜底原本把 `"qqbot"` 排除在外（因为它有一条 `channels.qqBot*` 的专用往返）。
只删专用字段而不同时去掉这个排除，会导致**此后任何一次无关的设置保存都静默删掉
`[plugins.qqbot]`**——用户的 app_id 和 client_secret 就这么没了。

已去掉排除，让 qqbot 和其它没有专属 UI 的插件一样走兜底。`feishu` 仍然排除：那个渠道
已从 runtime 退役，后端直接拒收 `[plugins.feishu]`。

核心侧同时删掉 `ChannelsSettingsSection.tsx` / `registerBuiltinSettingsSections.tsx` 里
硬编码的 qqbot 分节，以及 `bridge/shared.ts` 的 `ChannelsConfig` 与 `settings.ts` 里的
`qqBotAppId`/`qqBotClientSecret`。`plugins/qqbot/ui/index.tsx` 注册 `kind: "schema"` 的
settings.section，复用 #179/#177 已有的 `plugin.config.get/set` + schema 表单，后端不需要新管线。

## 删掉 3 条过时测试——不是为了让门禁变绿

`tests/backend/agent/plugins/test_manager.py` 里
`test_collects_and_clears_official_proactive_gates`、
`test_observe_plugin_writes_turn_trace`、
`test_observe_plugin_writes_memory_domain_events` 三条，直接 `PluginManager(...)` 拿真实
插件目录当夹具。

`PluginManager` 是 #174 之前的旧类，**生产里已无任何实例化**：`manager.py` 自己就带着
`TODO(#184): 旧 PluginManager 无活跃调用方`，`plugin_host/legacy.py` 只从该模块 import 了
几个辅助函数（`_EVENT_TYPE_MAP`、`_load_plugin_config` 等）而没用这个类。而且它根本加载不了
`api: 2` 的插件——插件一声明 v2，旧管理器就静默跳过，断言随之失败。

它们证明的行为现在由各插件自己的 `plugins/<id>/tests/test_plugin.py` 针对**真正在跑的**
`PluginKernel` 证明，而且更细：

- observe → `test_turn_committed_event_reaches_writer_and_is_persisted`（断言真的落库一行）
  ＋ `test_unload_cancels_background_tasks_and_uninstalls_collector_cleanly`
- proactive gates → `test_scene_gate_claims_tick_and_advances_only_after_delivery`、
  `test_loneliness_gate_blocks_when_relationship_runtime_rejects`、
  `test_setup_contributes_nothing_when_relationship_runtime_absent`（断言 `proactive_gates == []`）

`test_manager.py` 里其余旧管理器覆盖保持不动。

---

## 验证（rebase 之后重跑的实际结果）

| 门禁 | 结果 |
| --- | --- |
| `pytest -q` | **2394 passed**（基线 2380） |
| `pyright --project pyrightconfig.json --level error` | **0 errors** |
| `pyright --project pyrightconfig.tests.json --level error` | **0 errors** |
| `ruff check .` | All checks passed |
| `pnpm run typecheck` | exit 0 |
| `pnpm run lint` | 1 problem, **0 errors**（`RoleAssetCategoryGroups.tsx` 既有 warning） |
| `pnpm test` | **835 passed / 0 failed / 1 skipped** |
| `pnpm run build` | ✓ built |
| `pnpm run desktop:test:plugin-ui` | passed |

`black` 未跑（#204 全仓库既有不合规，不在范围内）。
`test_server_eof_cancels_and_awaits_in_flight_request`（既有 flaky）本次通过。

pyright 过程中修掉三个实现引入的真错误：observe 的 `_ObserveWriter` Protocol 在 `writer`
变成局部具体变量后与 `TraceWriter` 结构不兼容（v2 没有旧代码那个
`getattr(self, "_writer", None)` 空窗期，Protocol 已无存在理由，删掉直接标 `TraceWriter`）；
一个测试 helper 的 `dict[str, object]` 返回类型挡住了链式下标。

### rebase 说明

本分支原先也各自改过 `renderer/tsconfig.json`、`test-unit.mjs`、eslint 配置与 lint 脚本
（为了让 `plugins/*/ui` 进门禁）。#181-B 已在 main 上以通用形式做掉同一件事，所以 rebase
时这四个文件取 main 的版本，本 PR 只保留 qqbot 自身的改动。有意思的是两条线独立撞上并
独立解决了同一个 ESLint 问题（flat config 不 lint cwd 以上的目录），最后落到同一个方案：
仓库根放一个 config、lint 在根上跑而不带 `--config`。

rebase 后 `plugins/qqbot/ui/index.tsx` 是**由 main 的通用管线**接进 typecheck / lint /
单测的，上面那批结果就是这个组合的实际验证。

## 没有验证到的部分

- **qqbot 渠道没有真连过**。测试证明的是插件在真 kernel 下注册出同样的 channel 贡献、
  配置校验行为一致，不是「真的连上 QQ 开放平台收发消息」。
- **qqbot 设置区块没有人工点过**。schema 表单渲染与 `plugin.config.get/set` 往返由既有
  单测与 `test_plugin_config.py` 覆盖，但没有真的开着应用改一次 app_id 再看 config.toml。
- 上面那条静默删配置的修复由 `settingsPersistence.test.ts` 覆盖往返，但同样没有人工
  走一遍「装了 qqbot 的用户改一次无关设置」的升级路径。

## 顺带记录

发现一个**既有的**循环 import 地雷（`agent.plugins.manager` ↔ `agent.plugin_host`），
只在单独收集 `test_manager.py` 时浮现；在未改动的 main 上确认同样存在，不影响全量跑，
超出范围未动。
