### PR TITLE
fix: 同步 uv.lock 中的项目名称为 shiori-agent

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -3,21 +3,6 @@ revision = 3
 requires-python = ">=3.12"
 
 [[package]]
-name = "akashic-agent"
-version = "0.1.0"
-source = { virtual = "." }
-
-[package.dev-dependencies]
-dev = [
-    { name = "rich" },
-]
-
-[package.metadata]
-
-[package.metadata.requires-dev]
-dev = [{ name = "rich", specifier = ">=15.0.0" }]
-
-[[package]]
 name = "markdown-it-py"
 version = "4.0.0"
 source = { registry = "https://pypi.org/simple" }
@@ -59,3 +44,18 @@ sdist = { url = "https://files.pythonhosted.org/packages/c0/8f/0722ca900cc807c13
 wheels = [
     { url = "https://files.pythonhosted.org/packages/82/3b/64d4899d73f91ba49a8c18a8ff3f0ea8f1c1d75481760df8c68ef5235bf5/rich-15.0.0-py3-none-any.whl", hash = "sha256:33bd4ef74232fb73fe9279a257718407f169c09b78a87ad3d296f548e27de0bb", size = 310654, upload-time = "2026-04-12T08:24:02.83Z" },
 ]
+
+[[package]]
+name = "shiori-agent"
+version = "0.1.0"
+source = { virtual = "." }
+
+[package.dev-dependencies]
+dev = [
+    { name = "rich" },
+]
+
+[package.metadata]
+
+[package.metadata.requires-dev]
+dev = [{ name = "rich", specifier = ">=15.0.0" }]


### PR DESCRIPTION
项目更名后，uv.lock 仍以 akashic-agent 记录本项目，导致 uv lock --check 失败。通过 uv lock 重新生成锁文件，将根项目名称同步为 shiori-agent；第三方依赖版本与哈希均未变化。

验证：修复前 uv lock --check 提示锁文件需要更新；修复后 uv lock --check 和 git diff --check 均通过。仅修改锁文件元数据，未运行应用测试或构建。

已知阻塞项：无。

Closes #233