### PR TITLE
fix: keep role runtime data out of repository tests

### DIFF
--- a/apps/backend/skills/README.md
+++ b/apps/backend/skills/README.md
@@ -19,7 +19,7 @@
   - 文件：`apps/backend/skills/meme-manage/SKILL.md`
 
 - `create-drift-skill`
-  - 在工作区 drift/skills 下创建或更新 drift skill。
+  - 在当前角色的 `roles/<role-id>/drift/skills` 下创建或更新 drift skill。
   - 文件：`apps/backend/skills/create-drift-skill/SKILL.md`
 
 - `codex-delegate`

--- a/apps/backend/skills/create-drift-skill/SKILL.md
+++ b/apps/backend/skills/create-drift-skill/SKILL.md
@@ -1,13 +1,13 @@
 ---
 name: create-drift-skill
-description: 在工作区 drift/skills 下创建或更新一个 drift skill，用于把新的长期小任务沉淀成可复用技能。
+description: 在当前角色的 roles/<role-id>/drift/skills 下创建或更新一个 drift skill，用于把新的长期小任务沉淀成可复用技能。
 ---
 
 # 创建 Drift Skill
 
 ## 目标
 
-把适合反复执行的小任务沉淀到工作区 `drift/skills/<skill_name>/SKILL.md`。
+把适合反复执行的小任务沉淀到当前角色的 `roles/<role-id>/drift/skills/<skill_name>/SKILL.md`。
 
 ## 何时使用
 
@@ -16,7 +16,7 @@ description: 在工作区 drift/skills 下创建或更新一个 drift skill，�
 
 ## 工作流
 
-1. 先确认目标 skill 名是否明确，并检查 `drift/skills/<skill_name>/` 是否已存在。
+1. 先确认目标 skill 名是否明确，并检查当前角色的 `roles/<role-id>/drift/skills/<skill_name>/` 是否已存在。
 2. 读取已有 `SKILL.md`，如果已存在就在原基础上更新；不存在再创建。
 3. `SKILL.md` 顶部 frontmatter 至少包含：
 
@@ -31,7 +31,7 @@ description: <一句话描述>
 
 ## 约束
 
-- skill 文件必须写到工作区 `drift/skills/` 下，不要写到仓库内建目录
+- skill 文件必须写到当前角色的 `roles/<role-id>/drift/skills/` 下，不要写到仓库内建目录，也不要写到其他角色的目录
 - 不要为了一个一次性动作创建 skill
 - 如果只是当前 skill 的进展变化，优先更新它的 working files 或 state，而不是新建 skill
 - 结束流程必须写清 `finish_drift.message_result`：已成功推送写 `sent`，静默结束写 `silent`

--- a/docs/_handbook/drift-guide.md
+++ b/docs/_handbook/drift-guide.md
@@ -5,7 +5,7 @@
 Drift 是一个**你写模型可以做什么、模型照着执行**的后台任务系统。
 
 - **什么时候跑**：proactive 拉了一圈啥也没有（无 alert、无 content、无 context fallback）
-- **做什么**：你写在 `drift/skills/<skill-name>/SKILL.md` 里的事
+- **做什么**：你写在当前角色 `roles/<role-id>/drift/skills/<skill-name>/SKILL.md` 里的事
 - **怎么做**：SKILL.md 是一份分步操作指南——先读哪个文件、跑什么脚本、怎么判断、什么时候发消息——模型一步步按着走
 - **跟 proactive 的本质区别**：proactive 的行为是代码里写死的 system prompt，drift 的行为是你写的 SKILL.md
 
@@ -19,7 +19,7 @@ Drift 是一个**你写模型可以做什么、模型照着执行**的后台任�
 tick
   └── DataGateway.run() → 无 alert / 无 content / 无 context
        └── DriftTurnPipeline.run()
-            ├── scan_skills()      读取 drift/skills/*/SKILL.md
+            ├── scan_skills()      读取当前角色 roles/<role-id>/drift/skills/*/SKILL.md
             ├── filter_skills()   跳过 requires_mcp 未满足的 skill
             ├── build_context()   注入记忆、近期上下文、skill 列表
             └── tool_loop(max_steps)
@@ -46,18 +46,18 @@ tick
 
 ## Drift Skill 格式
 
-每个 skill 是一个目录，放在 `~/.shiori/workspace/drift/skills/<skill-name>/` 下，核心文件是 `SKILL.md`。
+每个 skill 是一个目录，放在当前角色的 `~/.shiori/workspace/roles/<role-id>/drift/skills/<skill-name>/` 下，核心文件是 `SKILL.md`。不同角色各自维护自己的 Drift skill 和运行状态。
 
 ### 哪些文件你写、哪些 agent 写
 
 | 文件 | 维护方式 | 说明 |
 |------|---------|------|
-| `drift/skills/<name>/SKILL.md` | **你写** | drift 任务定义，agent 每轮当 system prompt 读。也可以让主 agent 用内置 skill `create-drift-skill` 帮你生成 |
-| `drift/skills/<name>/state.json` | **agent 写** | skill 执行时自动更新状态，不用管 |
-| `drift/skills/<name>/*.md` | **agent 写** | 工作文件（audited.md、queue.md、backlog.md 等），skill 执行时自动读写 |
-| `drift/skills/<name>/scripts/*.py` | **你写** | 固定脚本，skill 通过 `shell` 工具调用 |
-| `drift/drift.json` | **agent 写** | DriftTurnPipeline 自动写运行记录（recent_runs），不用管 |
-| `drift/drift_note.md` | **agent 写** | 跨轮次的自由笔记，agent 可读可写 |
+| `roles/<role-id>/drift/skills/<name>/SKILL.md` | **你写** | 当前角色的 drift 任务定义，agent 每轮当 system prompt 读。也可以让主 agent 用内置 skill `create-drift-skill` 帮你生成 |
+| `roles/<role-id>/drift/skills/<name>/state.json` | **agent 写** | 当前角色的 skill 执行时自动更新状态，不用管 |
+| `roles/<role-id>/drift/skills/<name>/*.md` | **agent 写** | 当前角色的工作文件（audited.md、queue.md、backlog.md 等），skill 执行时自动读写 |
+| `roles/<role-id>/drift/skills/<name>/scripts/*.py` | **你写** | 当前角色固定脚本，skill 通过 `shell` 工具调用 |
+| `roles/<role-id>/drift/drift.json` | **agent 写** | 当前角色的 DriftTurnPipeline 自动写运行记录（recent_runs），不用管 |
+| `roles/<role-id>/drift/drift_note.md` | **agent 写** | 当前角色跨轮次的自由笔记，agent 可读可写 |
 
 内置了一个 skill 放仓库里（`apps/backend/skills/`），用来创建新的 drift skill。
 
@@ -183,7 +183,7 @@ description: 每天备份一次 conversation 精华到 notion
 4. 没有新内容 → 静默结束
 
 ## 工作文件
-- `skills/my-skill/last_sync.md`：上次同步时间
+- `roles/<role-id>/drift/skills/my-skill/last_sync.md`：当前角色上次同步时间
 
 ## 要求
 - 不调用 message_push（此 skill 纯后台）

--- a/docs/_handbook/proactive-guide.md
+++ b/docs/_handbook/proactive-guide.md
@@ -37,7 +37,7 @@ Drift 跟 proactive 的**根本区别在于控制方式**：
 
 | | Proactive | Drift |
 |---|---|---|
-| **行为由谁定义** | 固定 system prompt（代码里写死的） | `SKILL.md` 文件（你写的，放在 `drift/skills/` 下） |
+| **行为由谁定义** | 固定 system prompt（代码里写死的） | `SKILL.md` 文件（你写的，放在当前角色的 `roles/<role-id>/drift/skills/` 下） |
 | **做什么** | 分类、筛选、决定推不推 | 你定义什么就做什么（审记忆、问问题、自我诊断...） |
 | **工具** | 推送决策专用工具（mark_*, message_push, finish_turn） | 通用工具（read_file, write_file, fetch_messages, shell...）+ 可 message_push 一次 |
 | **收尾** | finish_turn(decision=reply/skip) | finish_drift(message_result=sent/silent) |
@@ -76,9 +76,9 @@ proactive tick
 | `proactive_sources.json` | **你写** | 声明哪个 MCP server 提供哪类数据（alert/content/context） |
 | `PROACTIVE_CONTEXT.md` | **agent 维护** | 主 agent（被动回复时）通过对话帮你写和改。proactive agent 只读不写 |
 | `schedules.json` | **都行** | 你可以手动写，也可以让主 agent 调内置的 `schedule` 工具增删改 |
-| `drift/skills/*/SKILL.md` | **你写** | Drift 的任务定义。也可以用内置 skill `create-drift-skill` 让 agent 帮你生成 |
+| `roles/<role-id>/drift/skills/*/SKILL.md` | **你写** | 当前角色的 Drift 任务定义。也可以用内置 skill `create-drift-skill` 让 agent 帮你生成 |
 | `memory/*.md` | **agent 维护** | 长期记忆、自我认知、近期上下文——全部由主 agent 通过被动对话自动读写 |
-| `drift/drift.json` | **agent 维护** | Drift runner 自动写运行记录，不用管 |
+| `roles/<role-id>/drift/drift.json` | **agent 维护** | 当前角色的 Drift runner 自动写运行记录，不用管 |
 | `proactive_quota.json` | **agent 维护** | AnyAction gate 自动写配额计数，不用管 |
 
 ### 1. 开启 proactive（config.toml）

--- a/tests/backend/desktop_bridge/test_service.py
+++ b/tests/backend/desktop_bridge/test_service.py
@@ -40,7 +40,7 @@ async def test_registered_committed_push_requires_its_original_message(tmp_path,
     )
     assert "发送失败" in result
     assert "uncommitted delivery" in result
-    assert SessionManager(tmp_path).get_or_create("role:mira").messages == []
+    assert sessions._store.fetch_session_messages("role:mira") == []
     assert emitted == []
     await service.aclose()
 
@@ -68,7 +68,7 @@ async def test_push_tool_blank_media_cannot_create_empty_desktop_messages(
             channel="desktop", chat_id="mira", message=message, **{field: "   "},
         )
 
-        persisted = SessionManager(tmp_path).get_or_create("role:mira").messages
+        persisted = manager._store.fetch_session_messages("role:mira")
         assert [item["content"] for item in persisted] == ([message] if message else [])
         if message:
             assert result == "文本已发送"

--- a/tests/backend/proactive_v2/test_drift.py
+++ b/tests/backend/proactive_v2/test_drift.py
@@ -145,15 +145,15 @@ def _make_drift_pipeline(
     )
 
 
-def test_drift_tool_schemas_include_reused_tools():
+def test_drift_tool_schemas_include_reused_tools(tmp_path: Path):
     ctx = AgentTickContext(now_utc=datetime.now(timezone.utc))
     names = {
         schema["function"]["name"]
         for schema in build_drift_tool_registry(
             ctx=ctx,
             deps=DriftToolDeps(
-                drift_dir=Path("."),
-                store=DriftStateStore(Path(".")),
+                drift_dir=tmp_path,
+                store=DriftStateStore(tmp_path),
                 shared_tools=_build_shared_tools(),
             ),
         ).get_schemas()


### PR DESCRIPTION
## Summary
- keep Drift skills scoped to the active role workspace
- prevent push-related tests from creating empty session rows while inspecting persistence

## Verification
- `.venv\Scripts\pytest.exe -q tests/backend/desktop_bridge/test_service.py -k "registered_committed_push_requires_its_original_message or push_tool_blank_media_cannot_create_empty_desktop_messages"` (6 passed)
- `git diff --check`

Review exemption: skipped automatic code review; this is a small, bounded documentation/test-isolation fix with no production behavior change.